### PR TITLE
feat(api): add query skeleton and mock evidence pack

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .db import dispose_engine
 from .routers.health import health, router as health_router
+from .routers.query import router as query_router
 from .settings import settings
 
 
@@ -29,6 +30,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(health_router, prefix="/api")
+    app.include_router(query_router, prefix="/api")
     app.add_api_route(
         "/health",
         health,

--- a/apps/api/app/routers/query.py
+++ b/apps/api/app/routers/query.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from ..schemas import QueryRequest, QueryResponse
+from ..services.query_orchestrator import QueryOrchestrator
+
+router = APIRouter(tags=["query"])
+orchestrator = QueryOrchestrator()
+
+
+@router.post("/query", response_model=QueryResponse)
+async def query(request: QueryRequest) -> QueryResponse:
+    return await orchestrator.run(request)

--- a/apps/api/app/schemas/__init__.py
+++ b/apps/api/app/schemas/__init__.py
@@ -1,0 +1,29 @@
+from .query import (
+    AnswerPayload,
+    Citation,
+    ClaimResult,
+    EvidenceUnit,
+    GraphEdge,
+    GraphNode,
+    GraphPayload,
+    LegalUnit,
+    QueryDebugData,
+    QueryRequest,
+    QueryResponse,
+    VerifierStatus,
+)
+
+__all__ = [
+    "AnswerPayload",
+    "Citation",
+    "ClaimResult",
+    "EvidenceUnit",
+    "GraphEdge",
+    "GraphNode",
+    "GraphPayload",
+    "LegalUnit",
+    "QueryDebugData",
+    "QueryRequest",
+    "QueryResponse",
+    "VerifierStatus",
+]

--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -1,0 +1,116 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+JsonMetadata = dict[str, str | int | float | bool | None]
+
+
+class QueryRequest(BaseModel):
+    question: str = Field(..., min_length=10, max_length=4000)
+    jurisdiction: Literal["RO"] = "RO"
+    date: str = Field(default="current", min_length=1, max_length=64)
+    mode: Literal["strict_citations"] = "strict_citations"
+    debug: bool = False
+
+
+class AnswerPayload(BaseModel):
+    short_answer: str
+    detailed_answer: str | None = None
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    not_legal_advice: bool = True
+    refusal_reason: str | None = None
+
+
+class LegalUnit(BaseModel):
+    legal_unit_id: str
+    legal_act: str
+    article: str | None = None
+    title: str | None = None
+    jurisdiction: Literal["RO"] = "RO"
+    source_url: str | None = None
+
+
+class EvidenceUnit(BaseModel):
+    evidence_id: str
+    legal_unit: LegalUnit
+    excerpt: str
+    rank: int = Field(..., ge=1)
+    relevance_score: float = Field(..., ge=0.0, le=1.0)
+    retrieval_method: str
+    warnings: list[str] = Field(default_factory=list)
+
+
+class Citation(BaseModel):
+    citation_id: str
+    evidence_id: str
+    legal_unit_id: str
+    label: str
+    quote: str
+    source_url: str | None = None
+    verified: bool = False
+
+
+class GraphNode(BaseModel):
+    node_id: str
+    node_type: str
+    label: str
+    metadata: JsonMetadata = Field(default_factory=dict)
+
+
+class GraphEdge(BaseModel):
+    edge_id: str
+    source_node_id: str
+    target_node_id: str
+    edge_type: str
+    metadata: JsonMetadata = Field(default_factory=dict)
+
+
+class GraphPayload(BaseModel):
+    nodes: list[GraphNode] = Field(default_factory=list)
+    edges: list[GraphEdge] = Field(default_factory=list)
+
+
+class ClaimResult(BaseModel):
+    claim_id: str
+    claim_text: str
+    status: Literal["supported", "weakly_supported", "unsupported", "not_checked"]
+    citation_ids: list[str] = Field(default_factory=list)
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    warning: str | None = None
+
+
+class VerifierStatus(BaseModel):
+    groundedness_score: float = Field(..., ge=0.0, le=1.0)
+    claims_total: int = Field(..., ge=0)
+    claims_supported: int = Field(..., ge=0)
+    claims_weakly_supported: int = Field(..., ge=0)
+    claims_unsupported: int = Field(..., ge=0)
+    citations_checked: int = Field(..., ge=0)
+    verifier_passed: bool
+    claim_results: list[ClaimResult] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    repair_applied: bool = False
+    refusal_reason: str | None = None
+
+
+class QueryDebugData(BaseModel):
+    orchestrator: str
+    evidence_service: str
+    retrieval_mode: str
+    evidence_units_count: int = Field(..., ge=0)
+    citations_count: int = Field(..., ge=0)
+    graph_nodes_count: int = Field(..., ge=0)
+    graph_edges_count: int = Field(..., ge=0)
+    notes: list[str] = Field(default_factory=list)
+
+
+class QueryResponse(BaseModel):
+    query_id: str
+    question: str
+    answer: AnswerPayload
+    citations: list[Citation] = Field(default_factory=list)
+    evidence_units: list[EvidenceUnit] = Field(default_factory=list)
+    verifier: VerifierStatus
+    graph: GraphPayload
+    debug: QueryDebugData | None = None
+    warnings: list[str] = Field(default_factory=list)

--- a/apps/api/app/services/mock_evidence.py
+++ b/apps/api/app/services/mock_evidence.py
@@ -1,0 +1,202 @@
+from dataclasses import dataclass
+
+from ..schemas import (
+    AnswerPayload,
+    Citation,
+    EvidenceUnit,
+    GraphEdge,
+    GraphNode,
+    GraphPayload,
+    LegalUnit,
+    QueryRequest,
+    VerifierStatus,
+)
+
+MOCK_REFUSAL_REASON = "mock_evidence_pack_not_verified"
+MOCK_WARNING = (
+    "mock_unverified_evidence_pack: Phase 1 returns deterministic mock evidence "
+    "only; retrieval, LegalRanker, generation, and citation verification have not run."
+)
+
+
+@dataclass(frozen=True)
+class EvidencePack:
+    answer: AnswerPayload
+    citations: list[Citation]
+    evidence_units: list[EvidenceUnit]
+    verifier: VerifierStatus
+    graph: GraphPayload
+    warnings: list[str]
+    debug_notes: list[str]
+
+
+class MockEvidenceService:
+    async def build_pack(self, request: QueryRequest, query_id: str) -> EvidencePack:
+        evidence_units = self._build_evidence_units()
+        citations = self._build_citations(evidence_units)
+        graph = self._build_graph(request=request, query_id=query_id)
+        warnings = [
+            MOCK_WARNING,
+            "mock_no_legal_conclusion: This response is not a verified legal analysis.",
+        ]
+        answer = AnswerPayload(
+            short_answer=(
+                "Phase 1 mock response only. No verified legal conclusion is provided; "
+                "the evidence below is deterministic placeholder data for API contract testing."
+            ),
+            detailed_answer=None,
+            confidence=0.0,
+            not_legal_advice=True,
+            refusal_reason=MOCK_REFUSAL_REASON,
+        )
+        verifier = VerifierStatus(
+            groundedness_score=0.0,
+            claims_total=0,
+            claims_supported=0,
+            claims_weakly_supported=0,
+            claims_unsupported=0,
+            citations_checked=0,
+            verifier_passed=False,
+            claim_results=[],
+            warnings=warnings.copy(),
+            repair_applied=False,
+            refusal_reason=MOCK_REFUSAL_REASON,
+        )
+
+        return EvidencePack(
+            answer=answer,
+            citations=citations,
+            evidence_units=evidence_units,
+            verifier=verifier,
+            graph=graph,
+            warnings=warnings,
+            debug_notes=[
+                "MockEvidenceService.build_pack returned static fixture data.",
+                "No database, vector search, graph expansion, ranker, generation, or verifier was called.",
+            ],
+        )
+
+    def _build_evidence_units(self) -> list[EvidenceUnit]:
+        legal_units = [
+            LegalUnit(
+                legal_unit_id="mock:ro:codul-muncii:art-17",
+                legal_act="Codul muncii",
+                article="art. 17",
+                title="Informarea salariatului - mock placeholder",
+            ),
+            LegalUnit(
+                legal_unit_id="mock:ro:codul-muncii:art-41",
+                legal_act="Codul muncii",
+                article="art. 41",
+                title="Modificarea contractului individual de munca - mock placeholder",
+            ),
+            LegalUnit(
+                legal_unit_id="mock:ro:codul-muncii:art-159",
+                legal_act="Codul muncii",
+                article="art. 159",
+                title="Salariul - mock placeholder",
+            ),
+        ]
+        excerpts = [
+            "Mock excerpt for art. 17. This placeholder was not retrieved from an official source.",
+            "Mock excerpt for art. 41. This placeholder was not retrieved from an official source.",
+            "Mock excerpt for art. 159. This placeholder was not retrieved from an official source.",
+        ]
+
+        return [
+            EvidenceUnit(
+                evidence_id=f"mock-evidence-{index}",
+                legal_unit=legal_unit,
+                excerpt=excerpt,
+                rank=index,
+                relevance_score=0.0,
+                retrieval_method="mock_static_fixture",
+                warnings=[MOCK_WARNING],
+            )
+            for index, (legal_unit, excerpt) in enumerate(
+                zip(legal_units, excerpts, strict=True),
+                start=1,
+            )
+        ]
+
+    def _build_citations(self, evidence_units: list[EvidenceUnit]) -> list[Citation]:
+        return [
+            Citation(
+                citation_id="mock-citation-1",
+                evidence_id=evidence_units[0].evidence_id,
+                legal_unit_id=evidence_units[0].legal_unit.legal_unit_id,
+                label="Codul muncii art. 17 (mock, unverified)",
+                quote=evidence_units[0].excerpt,
+                verified=False,
+            ),
+            Citation(
+                citation_id="mock-citation-2",
+                evidence_id=evidence_units[1].evidence_id,
+                legal_unit_id=evidence_units[1].legal_unit.legal_unit_id,
+                label="Codul muncii art. 41 (mock, unverified)",
+                quote=evidence_units[1].excerpt,
+                verified=False,
+            ),
+        ]
+
+    def _build_graph(self, request: QueryRequest, query_id: str) -> GraphPayload:
+        nodes = [
+            GraphNode(
+                node_id=f"query:{query_id}",
+                node_type="query",
+                label=request.question,
+                metadata={"jurisdiction": request.jurisdiction, "mode": request.mode},
+            ),
+            GraphNode(
+                node_id="domain:employment_law",
+                node_type="domain",
+                label="Dreptul muncii (mock domain)",
+                metadata={"mock": True},
+            ),
+            GraphNode(
+                node_id="legal_act:mock:codul-muncii",
+                node_type="legal_act",
+                label="Codul muncii (mock legal act)",
+                metadata={"mock": True},
+            ),
+            GraphNode(
+                node_id="article:mock:codul-muncii:art-41",
+                node_type="article",
+                label="art. 41 (mock article)",
+                metadata={"mock": True},
+            ),
+            GraphNode(
+                node_id=f"answer:{query_id}",
+                node_type="answer",
+                label="Mock unverified answer",
+                metadata={"verifier_passed": False},
+            ),
+        ]
+        edges = [
+            GraphEdge(
+                edge_id="edge:query-domain",
+                source_node_id=nodes[0].node_id,
+                target_node_id=nodes[1].node_id,
+                edge_type="mock_classified_as",
+            ),
+            GraphEdge(
+                edge_id="edge:domain-act",
+                source_node_id=nodes[1].node_id,
+                target_node_id=nodes[2].node_id,
+                edge_type="mock_related_legal_act",
+            ),
+            GraphEdge(
+                edge_id="edge:act-article",
+                source_node_id=nodes[2].node_id,
+                target_node_id=nodes[3].node_id,
+                edge_type="mock_contains_article",
+            ),
+            GraphEdge(
+                edge_id="edge:article-answer",
+                source_node_id=nodes[3].node_id,
+                target_node_id=nodes[4].node_id,
+                edge_type="mock_support_candidate",
+                metadata={"verified": False},
+            ),
+        ]
+        return GraphPayload(nodes=nodes, edges=edges)

--- a/apps/api/app/services/query_orchestrator.py
+++ b/apps/api/app/services/query_orchestrator.py
@@ -1,0 +1,48 @@
+from uuid import NAMESPACE_URL, uuid5
+
+from ..schemas import QueryDebugData, QueryRequest, QueryResponse
+from .mock_evidence import MockEvidenceService
+
+
+class QueryOrchestrator:
+    def __init__(self, evidence_service: MockEvidenceService | None = None) -> None:
+        self.evidence_service = evidence_service or MockEvidenceService()
+
+    async def run(self, request: QueryRequest) -> QueryResponse:
+        query_id = self._query_id(request)
+        evidence_pack = await self.evidence_service.build_pack(request, query_id)
+        debug = None
+        if request.debug:
+            debug = QueryDebugData(
+                orchestrator=self.__class__.__name__,
+                evidence_service=self.evidence_service.__class__.__name__,
+                retrieval_mode="mock_static_fixture",
+                evidence_units_count=len(evidence_pack.evidence_units),
+                citations_count=len(evidence_pack.citations),
+                graph_nodes_count=len(evidence_pack.graph.nodes),
+                graph_edges_count=len(evidence_pack.graph.edges),
+                notes=evidence_pack.debug_notes,
+            )
+
+        return QueryResponse(
+            query_id=query_id,
+            question=request.question,
+            answer=evidence_pack.answer,
+            citations=evidence_pack.citations,
+            evidence_units=evidence_pack.evidence_units,
+            verifier=evidence_pack.verifier,
+            graph=evidence_pack.graph,
+            debug=debug,
+            warnings=evidence_pack.warnings,
+        )
+
+    def _query_id(self, request: QueryRequest) -> str:
+        stable_input = "|".join(
+            [
+                request.question.strip(),
+                request.jurisdiction,
+                request.date,
+                request.mode,
+            ]
+        )
+        return str(uuid5(NAMESPACE_URL, stable_input))

--- a/docs/query-api.md
+++ b/docs/query-api.md
@@ -1,0 +1,72 @@
+# Query API
+
+Phase 1 exposes the `/api/query` contract and returns a deterministic mock
+EvidencePack only. It is intended for frontend and API integration work before
+real retrieval and answer generation are available.
+
+Not implemented yet:
+
+- database-backed retrieval
+- graph expansion
+- LegalRanker
+- answer generation
+- citation verification
+
+## Request
+
+```bash
+curl -X POST http://localhost:8000/api/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "question": "Poate angajatorul sa-mi scada salariul fara act aditional?",
+    "jurisdiction": "RO",
+    "date": "current",
+    "mode": "strict_citations",
+    "debug": true
+  }'
+```
+
+## Response Excerpt
+
+```json
+{
+  "query_id": "9f8d85df-8d8b-59d5-b905-f76c351c7f10",
+  "question": "Poate angajatorul sa-mi scada salariul fara act aditional?",
+  "answer": {
+    "short_answer": "Phase 1 mock response only. No verified legal conclusion is provided; the evidence below is deterministic placeholder data for API contract testing.",
+    "detailed_answer": null,
+    "confidence": 0.0,
+    "not_legal_advice": true,
+    "refusal_reason": "mock_evidence_pack_not_verified"
+  },
+  "citations": [
+    {
+      "citation_id": "mock-citation-1",
+      "evidence_id": "mock-evidence-1",
+      "legal_unit_id": "mock:ro:codul-muncii:art-17",
+      "label": "Codul muncii art. 17 (mock, unverified)",
+      "quote": "Mock excerpt for art. 17. This placeholder was not retrieved from an official source.",
+      "source_url": null,
+      "verified": false
+    }
+  ],
+  "verifier": {
+    "groundedness_score": 0.0,
+    "claims_total": 0,
+    "claims_supported": 0,
+    "claims_weakly_supported": 0,
+    "claims_unsupported": 0,
+    "citations_checked": 0,
+    "verifier_passed": false,
+    "claim_results": [],
+    "warnings": [
+      "mock_unverified_evidence_pack: Phase 1 returns deterministic mock evidence only; retrieval, LegalRanker, generation, and citation verification have not run."
+    ],
+    "repair_applied": false,
+    "refusal_reason": "mock_evidence_pack_not_verified"
+  }
+}
+```
+
+When `debug` is `true`, the response includes a `debug` object with mock service
+counts and notes. When `debug` is `false`, `debug` is `null`.

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -1,0 +1,90 @@
+from fastapi.testclient import TestClient
+
+from apps.api.app.main import app
+
+
+VALID_QUERY = {
+    "question": "Poate angajatorul sa-mi scada salariul fara act aditional?",
+    "jurisdiction": "RO",
+    "date": "current",
+    "mode": "strict_citations",
+}
+
+
+def post_query(payload: dict) -> object:
+    with TestClient(app) as client:
+        return client.post("/api/query", json=payload)
+
+
+def test_post_api_query_returns_mock_evidence_pack():
+    response = post_query({**VALID_QUERY, "debug": False})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["query_id"]
+    assert payload["question"] == VALID_QUERY["question"]
+    assert payload["answer"]["confidence"] == 0.0
+    assert payload["answer"]["not_legal_advice"] is True
+    assert payload["answer"]["refusal_reason"] == "mock_evidence_pack_not_verified"
+    assert len(payload["citations"]) >= 2
+    assert len(payload["evidence_units"]) >= 3
+    assert payload["verifier"]["verifier_passed"] is False
+    assert payload["graph"]["nodes"]
+    assert payload["graph"]["edges"]
+    assert payload["warnings"]
+
+
+def test_post_api_query_uses_snake_case_fields():
+    response = post_query({**VALID_QUERY, "debug": False})
+
+    payload = response.json()
+    assert "query_id" in payload
+    assert "short_answer" in payload["answer"]
+    assert "legal_unit_id" in payload["evidence_units"][0]["legal_unit"]
+    assert "groundedness_score" in payload["verifier"]
+    assert "source_node_id" in payload["graph"]["edges"][0]
+
+
+def test_post_api_query_debug_true_includes_debug_payload():
+    response = post_query({**VALID_QUERY, "debug": True})
+
+    assert response.status_code == 200
+    debug = response.json()["debug"]
+    assert debug["orchestrator"] == "QueryOrchestrator"
+    assert debug["evidence_service"] == "MockEvidenceService"
+    assert debug["evidence_units_count"] >= 3
+
+
+def test_post_api_query_debug_false_returns_null_debug():
+    response = post_query({**VALID_QUERY, "debug": False})
+
+    assert response.status_code == 200
+    assert response.json()["debug"] is None
+
+
+def test_post_api_query_rejects_short_question():
+    response = post_query({**VALID_QUERY, "question": "Scurt"})
+
+    assert response.status_code == 422
+
+
+def test_post_api_query_rejects_non_ro_jurisdiction():
+    response = post_query({**VALID_QUERY, "jurisdiction": "US"})
+
+    assert response.status_code == 422
+
+
+def test_post_api_query_rejects_unknown_mode():
+    response = post_query({**VALID_QUERY, "mode": "balanced"})
+
+    assert response.status_code == 422
+
+
+def test_post_api_query_mock_warning_and_verifier_failure_are_explicit():
+    response = post_query({**VALID_QUERY, "debug": False})
+
+    payload = response.json()
+    warnings = " ".join(payload["warnings"] + payload["verifier"]["warnings"])
+    assert "mock" in warnings.lower()
+    assert "unverified" in warnings.lower()
+    assert payload["verifier"]["verifier_passed"] is False


### PR DESCRIPTION
This pull request introduces a new `/api/query` endpoint that returns a deterministic mock evidence pack, providing a stable API contract for frontend and integration work before real retrieval and answer generation are implemented. The update includes the endpoint implementation, detailed Pydantic schemas for requests and responses, a mock evidence service, orchestrator logic, documentation, and comprehensive tests.

**New Query API endpoint and supporting infrastructure:**

* Added a `/api/query` POST endpoint via a new `query_router`, accepting `QueryRequest` and returning `QueryResponse` using a mock evidence service for deterministic responses. (`apps/api/app/main.py`, `apps/api/app/routers/query.py`) [[1]](diffhunk://#diff-0771a71b48a4e4d43c41b6b707518e44ec24d56323a1d19c5fff1781ad81052aR8) [[2]](diffhunk://#diff-0771a71b48a4e4d43c41b6b707518e44ec24d56323a1d19c5fff1781ad81052aR33) [[3]](diffhunk://#diff-025490fcb3640c90ae5a684c95fb72f90f20fd511f984bbbc7e34d1e0920606bR1-R12)
* Defined comprehensive Pydantic models in `schemas/query.py` to formalize the request and response contract, including all fields for answer, evidence, citations, graph, verifier, and debug data. (`apps/api/app/schemas/query.py`, `apps/api/app/schemas/__init__.py`) [[1]](diffhunk://#diff-f14d76d4a4582f33ea6ddb2e237372a3e64bba18a9eab0c980af1af918190d63R1-R116) [[2]](diffhunk://#diff-9f8f808bbceb3e0ac3957e424acfc39f71c6c6da72fde7901ce3f308ff48f583R1-R29)
* Implemented `MockEvidenceService` to return static, deterministic evidence packs, and `QueryOrchestrator` to coordinate request handling and debugging information. (`apps/api/app/services/mock_evidence.py`, `apps/api/app/services/query_orchestrator.py`) [[1]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baR1-R202) [[2]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R1-R48)

**Documentation and testing:**

* Added `docs/query-api.md` to document the endpoint, request/response structure, and current mock status, including example payloads.
* Introduced thorough tests in `tests/api/test_query.py` covering endpoint contract, schema validation, debug payloads, and mock warnings.