### PR TITLE
feat(api): integrate RawRetrieverClient fallback for query pipeline

### DIFF
--- a/apps/api/app/schemas/__init__.py
+++ b/apps/api/app/schemas/__init__.py
@@ -14,6 +14,11 @@ from .query import (
     QueryResponse,
     VerifierStatus,
 )
+from .retrieval import (
+    RawRetrievalRequest,
+    RawRetrievalResponse,
+    RetrievalCandidate,
+)
 
 __all__ = [
     "AnswerPayload",
@@ -30,4 +35,7 @@ __all__ = [
     "QueryRequest",
     "QueryResponse",
     "VerifierStatus",
+    "RawRetrievalRequest",
+    "RawRetrievalResponse",
+    "RetrievalCandidate",
 ]

--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -156,6 +156,7 @@ class QueryDebugData(BaseModel):
     evidence_service: str
     retrieval_mode: str
     query_understanding: QueryPlan | None = None
+    retrieval: dict[str, Any] | None = None
     evidence_units_count: int = Field(..., ge=0)
     citations_count: int = Field(..., ge=0)
     graph_nodes_count: int = Field(..., ge=0)

--- a/apps/api/app/schemas/retrieval.py
+++ b/apps/api/app/schemas/retrieval.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .query import ExactCitation
+
+
+class RawRetrievalRequest(BaseModel):
+    question: str
+    retrieval_filters: dict[str, Any] = Field(default_factory=dict)
+    exact_citations: list[ExactCitation] = Field(default_factory=list)
+    top_k: int = Field(default=50, ge=1)
+    debug: bool = False
+
+
+class RetrievalCandidate(BaseModel):
+    unit_id: str
+    rank: int
+    retrieval_score: float = 0.0
+    score_breakdown: dict[str, float] = Field(default_factory=dict)
+    matched_terms: list[str] = Field(default_factory=list)
+    why_retrieved: str | None = None
+    unit: dict[str, Any] | None = None
+
+
+class RawRetrievalResponse(BaseModel):
+    candidates: list[RetrievalCandidate] = Field(default_factory=list)
+    retrieval_methods: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    debug: dict[str, Any] | None = None

--- a/apps/api/app/services/query_orchestrator.py
+++ b/apps/api/app/services/query_orchestrator.py
@@ -3,6 +3,7 @@ from uuid import NAMESPACE_URL, uuid5
 from ..schemas import QueryDebugData, QueryRequest, QueryResponse
 from .mock_evidence import MockEvidenceService
 from .query_understanding import QueryUnderstanding
+from .raw_retriever_client import RawRetrieverClient
 
 
 class QueryOrchestrator:
@@ -10,13 +11,20 @@ class QueryOrchestrator:
         self,
         evidence_service: MockEvidenceService | None = None,
         query_understanding: QueryUnderstanding | None = None,
+        raw_retriever_client: RawRetrieverClient | None = None,
     ) -> None:
         self.evidence_service = evidence_service or MockEvidenceService()
         self.query_understanding = query_understanding or QueryUnderstanding()
+        self.raw_retriever_client = raw_retriever_client or RawRetrieverClient()
 
     async def run(self, request: QueryRequest) -> QueryResponse:
         query_id = self._query_id(request)
         query_plan = self.query_understanding.build_plan(request)
+        raw_retrieval = await self.raw_retriever_client.retrieve(
+            query_plan,
+            top_k=50,
+            debug=request.debug,
+        )
         evidence_pack = await self.evidence_service.build_pack(request, query_id)
         debug = None
         if request.debug:
@@ -25,6 +33,7 @@ class QueryOrchestrator:
                 evidence_service=self.evidence_service.__class__.__name__,
                 retrieval_mode="mock_static_fixture",
                 query_understanding=query_plan,
+                retrieval=raw_retrieval.debug,
                 evidence_units_count=len(evidence_pack.evidence_units),
                 citations_count=len(evidence_pack.citations),
                 graph_nodes_count=len(evidence_pack.graph.nodes),
@@ -41,7 +50,7 @@ class QueryOrchestrator:
             verifier=evidence_pack.verifier,
             graph=evidence_pack.graph,
             debug=debug,
-            warnings=evidence_pack.warnings,
+            warnings=evidence_pack.warnings + raw_retrieval.warnings,
         )
 
     def _query_id(self, request: QueryRequest) -> str:

--- a/apps/api/app/services/raw_retriever_client.py
+++ b/apps/api/app/services/raw_retriever_client.py
@@ -1,0 +1,132 @@
+from typing import Any
+
+import httpx
+
+from ..schemas import QueryPlan, RawRetrievalRequest, RawRetrievalResponse
+from ..settings import settings
+
+RAW_RETRIEVAL_NOT_CONFIGURED = "raw_retrieval_not_configured"
+RAW_RETRIEVAL_UNAVAILABLE = "raw_retrieval_unavailable"
+
+
+class RawRetrieverClient:
+    def __init__(
+        self,
+        base_url: str | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        configured_url = base_url
+        if configured_url is None:
+            configured_url = settings.raw_retrieval_base_url
+        self.base_url = configured_url.strip().rstrip("/") if configured_url else None
+        self.timeout_seconds = timeout_seconds
+
+    async def retrieve(
+        self,
+        plan: QueryPlan,
+        *,
+        top_k: int = 50,
+        debug: bool = False,
+    ) -> RawRetrievalResponse:
+        request = self.build_request(plan=plan, top_k=top_k, debug=debug)
+        request_payload = request.model_dump(mode="json")
+
+        if not self.base_url:
+            return self._fallback_response(
+                warning=RAW_RETRIEVAL_NOT_CONFIGURED,
+                reason="raw retrieval endpoint is not configured",
+                request_payload=request_payload,
+                debug=debug,
+            )
+
+        try:
+            response_payload = await self._send_payload(request_payload)
+            response = RawRetrievalResponse.model_validate(response_payload)
+        except Exception:
+            return self._fallback_response(
+                warning=RAW_RETRIEVAL_UNAVAILABLE,
+                reason="raw retrieval endpoint request failed",
+                request_payload=request_payload,
+                debug=debug,
+            )
+
+        if debug:
+            response.debug = self._debug_payload(
+                request_payload=request_payload,
+                response=response,
+                fallback_used=False,
+                reason=None,
+            )
+        return response
+
+    def build_request(
+        self,
+        plan: QueryPlan,
+        *,
+        top_k: int = 50,
+        debug: bool = False,
+    ) -> RawRetrievalRequest:
+        return RawRetrievalRequest(
+            question=plan.question,
+            retrieval_filters=plan.retrieval_filters,
+            exact_citations=plan.exact_citations,
+            top_k=top_k,
+            debug=debug,
+        )
+
+    async def _send_payload(self, request_payload: dict[str, Any]) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.post(self._endpoint_url(), json=request_payload)
+            response.raise_for_status()
+            return response.json()
+
+    def _endpoint_url(self) -> str:
+        if not self.base_url:
+            raise RuntimeError("raw retrieval endpoint is not configured")
+        if self.base_url.endswith("/api/retrieve/raw"):
+            return self.base_url
+        return f"{self.base_url}/api/retrieve/raw"
+
+    def _fallback_response(
+        self,
+        *,
+        warning: str,
+        reason: str,
+        request_payload: dict[str, Any],
+        debug: bool,
+    ) -> RawRetrievalResponse:
+        response = RawRetrievalResponse(
+            candidates=[],
+            retrieval_methods=[],
+            warnings=[warning],
+            debug=None,
+        )
+        if debug:
+            response.debug = self._debug_payload(
+                request_payload=request_payload,
+                response=response,
+                fallback_used=True,
+                reason=reason,
+            )
+        return response
+
+    def _debug_payload(
+        self,
+        *,
+        request_payload: dict[str, Any],
+        response: RawRetrievalResponse,
+        fallback_used: bool,
+        reason: str | None,
+    ) -> dict[str, Any]:
+        debug_payload: dict[str, Any] = {
+            "request_payload": request_payload,
+            "response_summary": {
+                "candidate_count": len(response.candidates),
+                "retrieval_methods": response.retrieval_methods,
+                "warnings": response.warnings,
+            },
+            "fallback_used": fallback_used,
+        }
+        if reason:
+            debug_payload["reason"] = reason
+        return debug_payload

--- a/apps/api/app/settings.py
+++ b/apps/api/app/settings.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     app_env: str = "development"
     database_url: str | None = None
     api_cors_origins: str = "http://localhost:3000,http://127.0.0.1:3000"
+    raw_retrieval_base_url: str | None = None
 
     @property
     def cors_origins(self) -> list[str]:

--- a/docs/query-api.md
+++ b/docs/query-api.md
@@ -1,13 +1,15 @@
 # Query API
 
-Phase 3 exposes the `/api/query` contract, deterministic QueryUnderstanding,
-DomainRouter debug data, ExactCitationDetector output, and a deterministic mock
-EvidencePack only. It is intended for frontend and API integration work before
-real retrieval and answer generation are available.
+Phase 4 exposes the `/api/query` contract, deterministic QueryUnderstanding,
+DomainRouter debug data, ExactCitationDetector output, RawRetrieverClient
+request construction, and a deterministic mock EvidencePack only. It is intended
+for frontend and API integration work before real retrieval and answer generation
+are available.
 
 Not implemented yet:
 
 - database-backed retrieval
+- `/api/retrieve/raw`, which is owned by Handoff 04
 - graph expansion
 - LegalRanker
 - answer generation
@@ -16,6 +18,9 @@ Not implemented yet:
 The query understanding layer is rule-based and inspectable. It does not call an
 LLM and it does not retrieve legal text. Exact citations are parsed only into
 future lookup hints; they are not resolved against `legal_units` yet.
+RawRetrieverClient prepares the future raw retrieval payload. If the raw
+retrieval endpoint is not configured or unavailable, `/api/query` returns a safe
+fallback with `confidence: 0.0`, `verifier_passed: false`, and retrieval warnings.
 
 ## Request
 
@@ -129,6 +134,46 @@ Exact citation example:
           }
         }
       ]
+    }
+  }
+}
+```
+
+Raw retrieval debug excerpt when `/api/retrieve/raw` is not configured:
+
+```json
+{
+  "debug": {
+    "retrieval": {
+      "request_payload": {
+        "question": "Ce spune art. 41 alin. (1) din Codul muncii?",
+        "retrieval_filters": {
+          "legal_domain": "muncă",
+          "exact_citation_filters": [
+            {
+              "law_id": "ro.codul_muncii",
+              "article_number": "41",
+              "paragraph_number": "1",
+              "status": "active"
+            }
+          ]
+        },
+        "exact_citations": [
+          {
+            "article": "41",
+            "paragraph": "1",
+            "act_hint": "Codul muncii"
+          }
+        ],
+        "top_k": 50,
+        "debug": true
+      },
+      "response_summary": {
+        "candidate_count": 0,
+        "retrieval_methods": [],
+        "warnings": ["raw_retrieval_not_configured"]
+      },
+      "fallback_used": true
     }
   }
 }

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -59,6 +59,11 @@ def test_post_api_query_debug_true_includes_debug_payload():
     assert "obligation" in debug["query_understanding"]["query_types"]
     assert debug["query_understanding"]["exact_citations"] == []
     assert debug["query_understanding"]["retrieval_filters"]["status"] == "active"
+    retrieval = debug["retrieval"]
+    assert retrieval["fallback_used"] is True
+    assert retrieval["request_payload"]["retrieval_filters"]["legal_domain"] == "muncă"
+    assert retrieval["response_summary"]["candidate_count"] == 0
+    assert "raw_retrieval_not_configured" in retrieval["response_summary"]["warnings"]
 
 
 def test_post_api_query_debug_false_returns_null_debug():
@@ -80,11 +85,18 @@ def test_post_api_query_debug_true_includes_exact_citations():
     assert response.status_code == 200
     payload = response.json()
     citation = payload["debug"]["query_understanding"]["exact_citations"][0]
+    retrieval = payload["debug"]["retrieval"]
     assert payload["debug"]["query_understanding"]["legal_domain"] == "muncă"
     assert citation["article"] == "41"
     assert citation["law_id_hint"] == "ro.codul_muncii"
+    request_payload = retrieval["request_payload"]
+    assert request_payload["exact_citations"][0]["article"] == "41"
+    filters = request_payload["retrieval_filters"]["exact_citation_filters"][0]
+    assert filters["article_number"] == "41"
+    assert filters["law_id"] == "ro.codul_muncii"
     assert payload["answer"]["confidence"] == 0.0
     assert payload["verifier"]["verifier_passed"] is False
+    assert "raw_retrieval_not_configured" in payload["warnings"]
 
 
 def test_post_api_query_rejects_short_question():

--- a/tests/test_raw_retriever_client.py
+++ b/tests/test_raw_retriever_client.py
@@ -1,0 +1,96 @@
+import pytest
+
+from apps.api.app.schemas import QueryRequest
+from apps.api.app.services.raw_retriever_client import (
+    RAW_RETRIEVAL_NOT_CONFIGURED,
+    RAW_RETRIEVAL_UNAVAILABLE,
+    RawRetrieverClient,
+)
+from apps.api.app.services.query_understanding import QueryUnderstanding
+
+
+def build_plan(question: str):
+    request = QueryRequest(
+        question=question,
+        jurisdiction="RO",
+        date="current",
+        mode="strict_citations",
+        debug=True,
+    )
+    return QueryUnderstanding().build_plan(request)
+
+
+@pytest.mark.anyio
+async def test_no_url_returns_safe_fallback_without_exception():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    response = await RawRetrieverClient(base_url=None).retrieve(
+        plan,
+        top_k=50,
+        debug=True,
+    )
+
+    assert response.candidates == []
+    assert response.retrieval_methods == []
+    assert response.warnings == [RAW_RETRIEVAL_NOT_CONFIGURED]
+    assert response.debug["fallback_used"] is True
+    assert response.debug["reason"] == "raw retrieval endpoint is not configured"
+
+
+@pytest.mark.anyio
+async def test_request_payload_includes_required_fields():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    response = await RawRetrieverClient(base_url=None).retrieve(
+        plan,
+        top_k=25,
+        debug=True,
+    )
+
+    payload = response.debug["request_payload"]
+    assert payload["question"] == plan.question
+    assert payload["retrieval_filters"]["legal_domain"] == "muncă"
+    assert payload["exact_citations"] == []
+    assert payload["top_k"] == 25
+    assert payload["debug"] is True
+
+
+@pytest.mark.anyio
+async def test_exact_citation_payload_includes_phase3_filters():
+    plan = build_plan("Ce spune art. 41 alin. (1) din Codul muncii?")
+    response = await RawRetrieverClient(base_url=None).retrieve(plan, debug=True)
+
+    payload = response.debug["request_payload"]
+    citation = payload["exact_citations"][0]
+    filters = payload["retrieval_filters"]["exact_citation_filters"][0]
+    assert citation["article"] == "41"
+    assert citation["paragraph"] == "1"
+    assert citation["act_hint"] == "Codul muncii"
+    assert filters["law_id"] == "ro.codul_muncii"
+    assert filters["article_number"] == "41"
+    assert filters["paragraph_number"] == "1"
+
+
+@pytest.mark.anyio
+async def test_debug_false_omits_internal_debug_payload():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    response = await RawRetrieverClient(base_url=None).retrieve(plan, debug=False)
+
+    assert response.debug is None
+    assert response.warnings == [RAW_RETRIEVAL_NOT_CONFIGURED]
+
+
+@pytest.mark.anyio
+async def test_configured_endpoint_failure_returns_unavailable_fallback(monkeypatch):
+    async def fail_send_payload(_request_payload):
+        raise RuntimeError("endpoint down")
+
+    plan = build_plan("Ce spune art. 41 din Codul muncii?")
+    client = RawRetrieverClient(base_url="http://retrieval.local")
+    monkeypatch.setattr(client, "_send_payload", fail_send_payload)
+
+    response = await client.retrieve(plan, debug=True)
+
+    assert response.candidates == []
+    assert response.retrieval_methods == []
+    assert response.warnings == [RAW_RETRIEVAL_UNAVAILABLE]
+    assert response.debug["fallback_used"] is True
+    assert response.debug["reason"] == "raw retrieval endpoint request failed"


### PR DESCRIPTION
This pull request introduces the initial implementation of the `/api/query` endpoint and supporting data models, along with developer setup documentation and a new domain routing service. The main changes include adding a FastAPI route for handling legal queries, defining comprehensive Pydantic schemas for query requests and responses, and implementing a domain router for classifying legal questions. Additionally, developer onboarding instructions and environment configuration are provided.

**API endpoint and routing:**
- Added a new `/api/query` POST endpoint in `query.py`, which uses a `QueryOrchestrator` to process incoming `QueryRequest` objects and return structured `QueryResponse` results. [[1]](diffhunk://#diff-025490fcb3640c90ae5a684c95fb72f90f20fd511f984bbbc7e34d1e0920606bR1-R12) [[2]](diffhunk://#diff-0771a71b48a4e4d43c41b6b707518e44ec24d56323a1d19c5fff1781ad81052aR8) [[3]](diffhunk://#diff-0771a71b48a4e4d43c41b6b707518e44ec24d56323a1d19c5fff1781ad81052aR33)

**Schema and data model definitions:**
- Introduced extensive Pydantic models for query handling in `schemas/query.py` and `schemas/retrieval.py`, covering requests, responses, evidence, citations, graph payloads, and retrieval candidates. These are re-exported in `schemas/__init__.py` for easy access. [[1]](diffhunk://#diff-f14d76d4a4582f33ea6ddb2e237372a3e64bba18a9eab0c980af1af918190d63R1-R176) [[2]](diffhunk://#diff-3dafeac10ea9b78dbd2dea7ada66ecd3470124a9080f68dd8ab81794b1a7b26bR1-R30) [[3]](diffhunk://#diff-9f8f808bbceb3e0ac3957e424acfc39f71c6c6da72fde7901ce3f308ff48f583R1-R41)

**Domain routing service:**
- Implemented a `DomainRouter` service in `services/domain_router.py` that uses a lexicon-based approach to classify legal questions into domains, with confidence scoring and ambiguity detection.

**Developer onboarding and documentation:**
- Added detailed setup and per-module instructions to `CONTRIBUTING.md`, including environment setup, test running, and file/module responsibilities for different teammates.
- Provided a sample `.env` file with a `DATABASE_URL` for local development.