### PR TITLE
feat(api): add GraphExpansionPolicy fallback pipeline

### DIFF
--- a/apps/api/app/schemas/__init__.py
+++ b/apps/api/app/schemas/__init__.py
@@ -14,6 +14,10 @@ from .query import (
     QueryResponse,
     VerifierStatus,
 )
+from .graph import (
+    ExpandedCandidate,
+    GraphExpansionResult,
+)
 from .retrieval import (
     RawRetrievalRequest,
     RawRetrievalResponse,
@@ -25,7 +29,9 @@ __all__ = [
     "Citation",
     "ClaimResult",
     "EvidenceUnit",
+    "ExpandedCandidate",
     "ExactCitation",
+    "GraphExpansionResult",
     "GraphEdge",
     "GraphNode",
     "GraphPayload",

--- a/apps/api/app/schemas/graph.py
+++ b/apps/api/app/schemas/graph.py
@@ -1,0 +1,26 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from .query import GraphEdge, GraphNode
+from .retrieval import RetrievalCandidate
+
+
+class ExpandedCandidate(BaseModel):
+    unit_id: str
+    source: Literal["seed", "graph_expansion"] = "seed"
+    graph_distance: int = Field(default=0, ge=0)
+    graph_proximity: float = Field(default=1.0, ge=0.0)
+    expansion_edge_type: str | None = None
+    expansion_reason: str | None = None
+    retrieval_candidate: RetrievalCandidate | None = None
+    score_breakdown: dict[str, float] = Field(default_factory=dict)
+
+
+class GraphExpansionResult(BaseModel):
+    seed_candidates: list[ExpandedCandidate] = Field(default_factory=list)
+    expanded_candidates: list[ExpandedCandidate] = Field(default_factory=list)
+    graph_nodes: list[GraphNode] = Field(default_factory=list)
+    graph_edges: list[GraphEdge] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    debug: dict[str, Any] | None = None

--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -157,6 +157,7 @@ class QueryDebugData(BaseModel):
     retrieval_mode: str
     query_understanding: QueryPlan | None = None
     retrieval: dict[str, Any] | None = None
+    graph_expansion: dict[str, Any] | None = None
     evidence_units_count: int = Field(..., ge=0)
     citations_count: int = Field(..., ge=0)
     graph_nodes_count: int = Field(..., ge=0)

--- a/apps/api/app/services/graph_expansion_policy.py
+++ b/apps/api/app/services/graph_expansion_policy.py
@@ -1,0 +1,277 @@
+import math
+import unicodedata
+from typing import Any
+
+from ..schemas import (
+    ExpandedCandidate,
+    GraphExpansionResult,
+    GraphNode,
+    QueryPlan,
+    RawRetrievalResponse,
+    RetrievalCandidate,
+)
+
+GRAPH_EXPANSION_NO_SEED_CANDIDATES = "graph_expansion_no_seed_candidates"
+GRAPH_EXPANSION_NOT_CONFIGURED = "graph_expansion_not_configured"
+GRAPH_EXPANSION_NEIGHBORS_UNAVAILABLE = "graph_expansion_neighbors_unavailable"
+
+DEFAULT_ALLOWED_EDGE_TYPES = [
+    "contains_parent",
+    "contains_child",
+    "references",
+    "defines",
+    "exception_to",
+    "sanctions",
+    "creates_obligation",
+    "creates_right",
+    "creates_prohibition",
+    "procedure_step",
+]
+
+EDGE_TYPE_WEIGHTS = {
+    "contains_parent": 0.90,
+    "contains_child": 0.75,
+    "references": 0.85,
+    "defines": 0.80,
+    "exception_to": 0.95,
+    "sanctions": 0.85,
+    "creates_obligation": 0.90,
+    "creates_right": 0.90,
+    "creates_prohibition": 0.90,
+    "procedure_step": 0.80,
+    "semantically_related": 0.45,
+}
+
+
+class GraphExpansionPolicy:
+    def __init__(
+        self,
+        max_depth: int = 2,
+        max_expanded_nodes: int = 80,
+        lambda_decay: float = 0.7,
+        neighbors_client: Any | None = None,
+    ) -> None:
+        self.max_depth = max_depth
+        self.max_expanded_nodes = max_expanded_nodes
+        self.lambda_decay = lambda_decay
+        self.neighbors_client = neighbors_client
+
+    async def expand(
+        self,
+        *,
+        plan: QueryPlan,
+        retrieval_response: RawRetrievalResponse,
+        debug: bool = False,
+    ) -> GraphExpansionResult:
+        seeds = [
+            self._seed_candidate(candidate)
+            for candidate in retrieval_response.candidates[: self.max_expanded_nodes]
+        ]
+
+        if not seeds:
+            return self._result(
+                plan=plan,
+                seed_candidates=[],
+                expanded_candidates=[],
+                graph_nodes=[],
+                warning=GRAPH_EXPANSION_NO_SEED_CANDIDATES,
+                fallback_used=True,
+                reason="graph expansion has no seed candidates",
+                debug=debug,
+            )
+
+        if not self._neighbors_client_configured():
+            return self._result(
+                plan=plan,
+                seed_candidates=seeds,
+                expanded_candidates=seeds,
+                graph_nodes=self._seed_graph_nodes(retrieval_response.candidates),
+                warning=GRAPH_EXPANSION_NOT_CONFIGURED,
+                fallback_used=True,
+                reason="graph neighbors endpoint is not configured",
+                debug=debug,
+            )
+
+        return self._result(
+            plan=plan,
+            seed_candidates=seeds,
+            expanded_candidates=seeds,
+            graph_nodes=self._seed_graph_nodes(retrieval_response.candidates),
+            warning=GRAPH_EXPANSION_NEIGHBORS_UNAVAILABLE,
+            fallback_used=True,
+            reason="graph neighbors endpoint request failed",
+            debug=debug,
+        )
+
+    def policy_for_plan(self, plan: QueryPlan) -> dict[str, Any]:
+        return {
+            "max_depth": self.max_depth,
+            "max_expanded_nodes": self.max_expanded_nodes,
+            "lambda_decay": self.lambda_decay,
+            "allowed_edge_types": self.allowed_edge_types(plan),
+            "edge_type_weights": EDGE_TYPE_WEIGHTS,
+            "priority_edge_types": self.priority_edge_types(plan),
+        }
+
+    def allowed_edge_types(self, plan: QueryPlan) -> list[str]:
+        allowed = list(DEFAULT_ALLOWED_EDGE_TYPES)
+        if plan.exact_citations:
+            return [
+                edge_type
+                for edge_type in allowed
+                if edge_type != "semantically_related"
+            ]
+        return allowed
+
+    def priority_edge_types(self, plan: QueryPlan) -> list[str]:
+        match_text = self._match_text(plan.normalized_question)
+        consequence_query = any(
+            term in match_text
+            for term in (
+                "poate",
+                "are voie",
+                "ce se intampla daca",
+                "fara",
+                "amenda",
+            )
+        )
+
+        priorities: list[str] = []
+        if consequence_query or any(
+            query_type in plan.query_types
+            for query_type in ("exception", "sanction", "prohibition", "obligation")
+        ):
+            priorities.extend(
+                [
+                    "exception_to",
+                    "sanctions",
+                    "creates_obligation",
+                    "creates_prohibition",
+                ]
+            )
+        if "right" in plan.query_types:
+            priorities.append("creates_right")
+        if "definition" in plan.query_types or plan.ambiguity_flags:
+            priorities.append("defines")
+        if "procedure" in plan.query_types:
+            priorities.append("procedure_step")
+
+        return self._dedupe_allowed(priorities, self.allowed_edge_types(plan))
+
+    def graph_proximity(self, edge_type: str, distance: int) -> float:
+        edge_weight = EDGE_TYPE_WEIGHTS.get(edge_type, 0.0)
+        return edge_weight * math.exp(-self.lambda_decay * distance)
+
+    def _seed_candidate(self, candidate: RetrievalCandidate) -> ExpandedCandidate:
+        return ExpandedCandidate(
+            unit_id=candidate.unit_id,
+            source="seed",
+            graph_distance=0,
+            graph_proximity=1.0,
+            retrieval_candidate=candidate,
+            score_breakdown=candidate.score_breakdown,
+        )
+
+    def _seed_graph_nodes(
+        self,
+        candidates: list[RetrievalCandidate],
+    ) -> list[GraphNode]:
+        nodes: list[GraphNode] = []
+        seen: set[str] = set()
+        for candidate in candidates:
+            if not candidate.unit or candidate.unit_id in seen:
+                continue
+            seen.add(candidate.unit_id)
+            label = self._node_label(candidate)
+            nodes.append(
+                GraphNode(
+                    node_id=f"legal_unit:{candidate.unit_id}",
+                    node_type="legal_unit",
+                    label=label,
+                    metadata={
+                        **self._scalar_metadata(candidate.unit),
+                        "legal_unit_id": candidate.unit_id,
+                        "seed": True,
+                    },
+                )
+            )
+        return nodes
+
+    def _node_label(self, candidate: RetrievalCandidate) -> str:
+        if not candidate.unit:
+            return candidate.unit_id
+        for key in ("label", "title", "legal_unit_id", "id"):
+            value = candidate.unit.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        return candidate.unit_id
+
+    def _scalar_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in metadata.items()
+            if isinstance(value, str | int | float | bool) or value is None
+        }
+
+    def _neighbors_client_configured(self) -> bool:
+        if self.neighbors_client is None:
+            return False
+        return bool(
+            getattr(self.neighbors_client, "is_configured", False)
+            or getattr(self.neighbors_client, "configured", False)
+        )
+
+    def _result(
+        self,
+        *,
+        plan: QueryPlan,
+        seed_candidates: list[ExpandedCandidate],
+        expanded_candidates: list[ExpandedCandidate],
+        graph_nodes: list[GraphNode],
+        warning: str,
+        fallback_used: bool,
+        reason: str,
+        debug: bool,
+    ) -> GraphExpansionResult:
+        result = GraphExpansionResult(
+            seed_candidates=seed_candidates,
+            expanded_candidates=expanded_candidates,
+            graph_nodes=graph_nodes,
+            graph_edges=[],
+            warnings=[warning],
+            debug=None,
+        )
+        if debug:
+            result.debug = {
+                "fallback_used": fallback_used,
+                "reason": reason,
+                "policy": self.policy_for_plan(plan),
+                "seed_candidate_count": len(seed_candidates),
+                "expanded_candidate_count": len(expanded_candidates),
+                "expanded_candidates": [
+                    candidate.model_dump(mode="json")
+                    for candidate in expanded_candidates
+                ],
+                "graph_node_count": len(graph_nodes),
+                "graph_edge_count": 0,
+                "warnings": result.warnings,
+            }
+        return result
+
+    def _dedupe_allowed(
+        self,
+        edge_types: list[str],
+        allowed_edge_types: list[str],
+    ) -> list[str]:
+        priorities: list[str] = []
+        for edge_type in edge_types:
+            if edge_type in allowed_edge_types and edge_type not in priorities:
+                priorities.append(edge_type)
+        return priorities
+
+    def _match_text(self, text: str) -> str:
+        normalized = unicodedata.normalize("NFD", text)
+        stripped = "".join(
+            char for char in normalized if unicodedata.category(char) != "Mn"
+        )
+        return stripped.casefold()

--- a/apps/api/app/services/query_orchestrator.py
+++ b/apps/api/app/services/query_orchestrator.py
@@ -1,6 +1,7 @@
 from uuid import NAMESPACE_URL, uuid5
 
 from ..schemas import QueryDebugData, QueryRequest, QueryResponse
+from .graph_expansion_policy import GraphExpansionPolicy
 from .mock_evidence import MockEvidenceService
 from .query_understanding import QueryUnderstanding
 from .raw_retriever_client import RawRetrieverClient
@@ -12,10 +13,14 @@ class QueryOrchestrator:
         evidence_service: MockEvidenceService | None = None,
         query_understanding: QueryUnderstanding | None = None,
         raw_retriever_client: RawRetrieverClient | None = None,
+        graph_expansion_policy: GraphExpansionPolicy | None = None,
     ) -> None:
         self.evidence_service = evidence_service or MockEvidenceService()
         self.query_understanding = query_understanding or QueryUnderstanding()
         self.raw_retriever_client = raw_retriever_client or RawRetrieverClient()
+        self.graph_expansion_policy = (
+            graph_expansion_policy or GraphExpansionPolicy()
+        )
 
     async def run(self, request: QueryRequest) -> QueryResponse:
         query_id = self._query_id(request)
@@ -23,6 +28,11 @@ class QueryOrchestrator:
         raw_retrieval = await self.raw_retriever_client.retrieve(
             query_plan,
             top_k=50,
+            debug=request.debug,
+        )
+        graph_expansion = await self.graph_expansion_policy.expand(
+            plan=query_plan,
+            retrieval_response=raw_retrieval,
             debug=request.debug,
         )
         evidence_pack = await self.evidence_service.build_pack(request, query_id)
@@ -34,6 +44,7 @@ class QueryOrchestrator:
                 retrieval_mode="mock_static_fixture",
                 query_understanding=query_plan,
                 retrieval=raw_retrieval.debug,
+                graph_expansion=graph_expansion.debug,
                 evidence_units_count=len(evidence_pack.evidence_units),
                 citations_count=len(evidence_pack.citations),
                 graph_nodes_count=len(evidence_pack.graph.nodes),
@@ -50,7 +61,11 @@ class QueryOrchestrator:
             verifier=evidence_pack.verifier,
             graph=evidence_pack.graph,
             debug=debug,
-            warnings=evidence_pack.warnings + raw_retrieval.warnings,
+            warnings=(
+                evidence_pack.warnings
+                + raw_retrieval.warnings
+                + graph_expansion.warnings
+            ),
         )
 
     def _query_id(self, request: QueryRequest) -> str:

--- a/docs/query-api.md
+++ b/docs/query-api.md
@@ -1,16 +1,17 @@
 # Query API
 
-Phase 4 exposes the `/api/query` contract, deterministic QueryUnderstanding,
+Phase 5 exposes the `/api/query` contract, deterministic QueryUnderstanding,
 DomainRouter debug data, ExactCitationDetector output, RawRetrieverClient
-request construction, and a deterministic mock EvidencePack only. It is intended
-for frontend and API integration work before real retrieval and answer generation
-are available.
+request construction, GraphExpansionPolicy debug data, and a deterministic mock
+EvidencePack only. It is intended for frontend and API integration work before
+real retrieval, graph traversal, and answer generation are available.
 
 Not implemented yet:
 
 - database-backed retrieval
 - `/api/retrieve/raw`, which is owned by Handoff 04
-- graph expansion
+- graph/neighbors endpoints, which are owned by Handoff 04
+- database-backed graph expansion
 - LegalRanker
 - answer generation
 - citation verification
@@ -18,9 +19,10 @@ Not implemented yet:
 The query understanding layer is rule-based and inspectable. It does not call an
 LLM and it does not retrieve legal text. Exact citations are parsed only into
 future lookup hints; they are not resolved against `legal_units` yet.
-RawRetrieverClient prepares the future raw retrieval payload. If the raw
-retrieval endpoint is not configured or unavailable, `/api/query` returns a safe
-fallback with `confidence: 0.0`, `verifier_passed: false`, and retrieval warnings.
+RawRetrieverClient prepares the future raw retrieval payload. GraphExpansionPolicy
+turns raw retrieval candidates into graph expansion seeds and policy metadata. If
+raw retrieval or graph neighbors are not configured, `/api/query` returns a safe
+fallback with `confidence: 0.0`, `verifier_passed: false`, and explicit warnings.
 
 ## Request
 
@@ -79,8 +81,8 @@ curl -X POST http://localhost:8000/api/query \
 ```
 
 When `debug` is `true`, the response includes a `debug` object with mock service
-counts, notes, and `query_understanding`. When `debug` is `false`, `debug` is
-`null`.
+counts, notes, `query_understanding`, `retrieval`, and `graph_expansion`. When
+`debug` is `false`, `debug` is `null`.
 
 Example debug excerpt:
 
@@ -174,6 +176,49 @@ Raw retrieval debug excerpt when `/api/retrieve/raw` is not configured:
         "warnings": ["raw_retrieval_not_configured"]
       },
       "fallback_used": true
+    }
+  }
+}
+```
+
+Graph expansion debug excerpt when raw retrieval has no seed candidates:
+
+```json
+{
+  "debug": {
+    "graph_expansion": {
+      "fallback_used": true,
+      "reason": "graph expansion has no seed candidates",
+      "policy": {
+        "max_depth": 2,
+        "max_expanded_nodes": 80,
+        "lambda_decay": 0.7,
+        "allowed_edge_types": [
+          "contains_parent",
+          "contains_child",
+          "references",
+          "defines",
+          "exception_to",
+          "sanctions",
+          "creates_obligation",
+          "creates_right",
+          "creates_prohibition",
+          "procedure_step"
+        ],
+        "priority_edge_types": [
+          "exception_to",
+          "sanctions",
+          "creates_obligation",
+          "creates_prohibition",
+          "creates_right"
+        ]
+      },
+      "seed_candidate_count": 0,
+      "expanded_candidate_count": 0,
+      "expanded_candidates": [],
+      "graph_node_count": 0,
+      "graph_edge_count": 0,
+      "warnings": ["graph_expansion_no_seed_candidates"]
     }
   }
 }

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -65,13 +65,26 @@ def test_post_api_query_debug_true_includes_debug_payload():
     assert retrieval["request_payload"]["exact_citations"] == []
     assert retrieval["response_summary"]["candidate_count"] == 0
     assert "raw_retrieval_not_configured" in retrieval["response_summary"]["warnings"]
+    graph_expansion = debug["graph_expansion"]
+    assert graph_expansion["fallback_used"] is True
+    assert graph_expansion["seed_candidate_count"] == 0
+    assert graph_expansion["expanded_candidate_count"] == 0
+    assert "graph_expansion_no_seed_candidates" in graph_expansion["warnings"]
+    priorities = graph_expansion["policy"]["priority_edge_types"]
+    assert "exception_to" in priorities
+    assert "sanctions" in priorities
+    assert "creates_obligation" in priorities
+    assert "creates_prohibition" in priorities
 
 
 def test_post_api_query_debug_false_returns_null_debug():
     response = post_query({**VALID_QUERY, "debug": False})
 
     assert response.status_code == 200
-    assert response.json()["debug"] is None
+    payload = response.json()
+    assert payload["debug"] is None
+    assert "raw_retrieval_not_configured" in payload["warnings"]
+    assert "graph_expansion_no_seed_candidates" in payload["warnings"]
 
 
 def test_post_api_query_debug_true_includes_exact_citations():
@@ -103,6 +116,17 @@ def test_post_api_query_debug_true_includes_exact_citations():
     assert payload["answer"]["refusal_reason"] == "mock_evidence_pack_not_verified"
     assert payload["verifier"]["verifier_passed"] is False
     assert "raw_retrieval_not_configured" in payload["warnings"]
+    assert "graph_expansion_no_seed_candidates" in payload["warnings"]
+    assert payload["debug"]["graph_expansion"]["fallback_used"] is True
+
+
+def test_handoff04_graph_endpoints_are_not_registered():
+    paths = {route.path for route in app.routes}
+
+    assert "/api/legal-units/{id}/neighbors" not in paths
+    assert "/api/explore/root" not in paths
+    assert "/api/explore/node/{id}/children" not in paths
+    assert "/api/query/{id}/graph" not in paths
 
 
 def test_post_api_query_rejects_short_question():

--- a/tests/test_graph_expansion_policy.py
+++ b/tests/test_graph_expansion_policy.py
@@ -1,0 +1,115 @@
+import pytest
+
+from apps.api.app.schemas import QueryRequest, RawRetrievalResponse, RetrievalCandidate
+from apps.api.app.services.graph_expansion_policy import (
+    EDGE_TYPE_WEIGHTS,
+    GRAPH_EXPANSION_NO_SEED_CANDIDATES,
+    GRAPH_EXPANSION_NOT_CONFIGURED,
+    GraphExpansionPolicy,
+)
+from apps.api.app.services.query_understanding import QueryUnderstanding
+
+
+def build_plan(question: str):
+    request = QueryRequest(
+        question=question,
+        jurisdiction="RO",
+        date="current",
+        mode="strict_citations",
+        debug=True,
+    )
+    return QueryUnderstanding().build_plan(request)
+
+
+@pytest.mark.anyio
+async def test_no_seed_candidates_returns_safe_noop_fallback():
+    plan = build_plan("Ce spune art. 41 alin. (1) din Codul muncii?")
+
+    result = await GraphExpansionPolicy().expand(
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[]),
+        debug=True,
+    )
+
+    assert result.seed_candidates == []
+    assert result.expanded_candidates == []
+    assert result.graph_nodes == []
+    assert result.graph_edges == []
+    assert result.warnings == [GRAPH_EXPANSION_NO_SEED_CANDIDATES]
+    assert result.debug["fallback_used"] is True
+    assert result.debug["reason"] == "graph expansion has no seed candidates"
+    assert result.debug["seed_candidate_count"] == 0
+    assert result.debug["expanded_candidate_count"] == 0
+
+
+@pytest.mark.anyio
+async def test_seed_candidate_without_neighbors_client_returns_seed_only_fallback():
+    plan = build_plan("Ce spune art. 41 alin. (1) din Codul muncii?")
+    candidate = RetrievalCandidate(
+        unit_id="ro.codul_muncii.art_41.alin_1",
+        rank=1,
+        retrieval_score=0.91,
+        score_breakdown={"bm25": 0.7},
+        unit={
+            "title": "Codul muncii art. 41 alin. 1",
+            "legal_domain": "muncă",
+            "status": "active",
+            "importance": 0.9,
+        },
+    )
+
+    result = await GraphExpansionPolicy(neighbors_client=None).expand(
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[candidate]),
+        debug=True,
+    )
+
+    assert result.warnings == [GRAPH_EXPANSION_NOT_CONFIGURED]
+    assert len(result.seed_candidates) == 1
+    assert len(result.expanded_candidates) == 1
+    expanded = result.expanded_candidates[0]
+    assert expanded.unit_id == "ro.codul_muncii.art_41.alin_1"
+    assert expanded.source == "seed"
+    assert expanded.graph_distance == 0
+    assert expanded.graph_proximity == 1.0
+    assert expanded.retrieval_candidate == candidate
+    assert result.graph_nodes[0].node_type == "legal_unit"
+    assert result.graph_edges == []
+    assert result.debug["fallback_used"] is True
+    assert result.debug["reason"] == "graph neighbors endpoint is not configured"
+    assert result.debug["expanded_candidate_count"] == 1
+
+
+def test_policy_config_defaults_and_edge_weights_are_exposed():
+    plan = build_plan("Poate angajatorul să-mi scadă salariul fără act adițional?")
+    policy = GraphExpansionPolicy()
+
+    config = policy.policy_for_plan(plan)
+
+    assert config["max_depth"] == 2
+    assert config["max_expanded_nodes"] == 80
+    assert config["lambda_decay"] == 0.7
+    assert config["edge_type_weights"] == EDGE_TYPE_WEIGHTS
+    assert config["edge_type_weights"]["exception_to"] == 0.95
+    assert "references" in config["allowed_edge_types"]
+    assert "creates_obligation" in config["allowed_edge_types"]
+
+
+def test_exact_citation_policy_excludes_semantically_related_edges():
+    plan = build_plan("Ce spune art. 41 alin. (1) din Codul muncii?")
+
+    allowed_edge_types = GraphExpansionPolicy().allowed_edge_types(plan)
+
+    assert plan.exact_citations
+    assert "semantically_related" not in allowed_edge_types
+
+
+def test_labor_permission_question_prioritizes_expected_edge_types():
+    plan = build_plan("Poate angajatorul să-mi scadă salariul fără act adițional?")
+
+    priority_edge_types = GraphExpansionPolicy().priority_edge_types(plan)
+
+    assert "exception_to" in priority_edge_types
+    assert "sanctions" in priority_edge_types
+    assert "creates_obligation" in priority_edge_types
+    assert "creates_prohibition" in priority_edge_types


### PR DESCRIPTION
This pull request introduces a new graph expansion policy layer to the API, enabling the system to expand on retrieval candidates using a configurable policy. It adds new schema types, a service class for graph expansion, integrates this logic into the query orchestrator, and updates documentation and tests to reflect the new functionality. The changes are primarily focused on preparing for future graph-based features, providing debug output, and handling fallback scenarios when graph expansion is not fully configured.

**Graph Expansion Policy Integration:**

- Added a new `GraphExpansionPolicy` service (`graph_expansion_policy.py`) that defines how to expand retrieval candidates into graph seeds, prioritizes edge types, calculates proximity, and handles fallback scenarios when graph neighbors are unavailable.
- Integrated `GraphExpansionPolicy` into the `QueryOrchestrator`, so every query now runs graph expansion after retrieval, and its debug output and warnings are included in the API response. [[1]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R4) [[2]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R16-R23) [[3]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R33-R37) [[4]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R47) [[5]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3L53-R68)

**Schema and Debug Enhancements:**

- Introduced new schema types `ExpandedCandidate` and `GraphExpansionResult` in `schemas/graph.py`, and exposed them in the API schema index for use in responses and debug payloads. [[1]](diffhunk://#diff-95ed699393867dc107dbb157bf1d24df93f0d6224d31f8cd14f0e16add24b40aR1-R26) [[2]](diffhunk://#diff-9f8f808bbceb3e0ac3957e424acfc39f71c6c6da72fde7901ce3f308ff48f583R17-R20) [[3]](diffhunk://#diff-9f8f808bbceb3e0ac3957e424acfc39f71c6c6da72fde7901ce3f308ff48f583R32-R34)
- Updated the `QueryDebugData` schema to include a `graph_expansion` field for detailed debug output.

**Documentation Updates:**

- Revised `docs/query-api.md` to document the new graph expansion phase, its debug output, fallback behaviors, and the current unavailability of real graph endpoints. Added example debug payloads for graph expansion. [[1]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL3-R25) [[2]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL82-R85) [[3]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aR183-R225)

**Test Coverage:**

- Extended API tests to assert the presence and correctness of the new `graph_expansion` debug payload, warnings, and fallback logic. Also added a test to ensure that graph endpoints from Handoff 04 are not yet registered. [[1]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R68-R87) [[2]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R119-R129)