### PR TITLE
feat(h03): implement phase 6 LegalRanker v1

### DIFF
--- a/apps/api/app/schemas/__init__.py
+++ b/apps/api/app/schemas/__init__.py
@@ -18,6 +18,11 @@ from .graph import (
     ExpandedCandidate,
     GraphExpansionResult,
 )
+from .ranking import (
+    LegalRankerResult,
+    RankedCandidate,
+    RankerFeatureBreakdown,
+)
 from .retrieval import (
     RawRetrievalRequest,
     RawRetrievalResponse,
@@ -36,10 +41,13 @@ __all__ = [
     "GraphNode",
     "GraphPayload",
     "LegalUnit",
+    "LegalRankerResult",
     "QueryDebugData",
     "QueryPlan",
     "QueryRequest",
     "QueryResponse",
+    "RankedCandidate",
+    "RankerFeatureBreakdown",
     "VerifierStatus",
     "RawRetrievalRequest",
     "RawRetrievalResponse",

--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -158,6 +158,7 @@ class QueryDebugData(BaseModel):
     query_understanding: QueryPlan | None = None
     retrieval: dict[str, Any] | None = None
     graph_expansion: dict[str, Any] | None = None
+    legal_ranker: dict[str, Any] | None = None
     evidence_units_count: int = Field(..., ge=0)
     citations_count: int = Field(..., ge=0)
     graph_nodes_count: int = Field(..., ge=0)

--- a/apps/api/app/schemas/ranking.py
+++ b/apps/api/app/schemas/ranking.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RankerFeatureBreakdown(BaseModel):
+    bm25_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    dense_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    exact_citation_match: float = Field(default=0.0, ge=0.0, le=1.0)
+    domain_match: float = Field(default=0.0, ge=0.0, le=1.0)
+    graph_proximity: float = Field(default=0.0, ge=0.0, le=1.0)
+    concept_overlap: float = Field(default=0.0, ge=0.0, le=1.0)
+    legal_term_overlap: float = Field(default=0.0, ge=0.0, le=1.0)
+    temporal_validity: float = Field(default=0.0, ge=0.0, le=1.0)
+    source_reliability: float = Field(default=0.0, ge=0.0, le=1.0)
+    parent_relevance: float = Field(default=0.0, ge=0.0, le=1.0)
+    is_exception: float = Field(default=0.0, ge=0.0, le=1.0)
+    is_definition: float = Field(default=0.0, ge=0.0, le=1.0)
+    is_sanction: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class RankedCandidate(BaseModel):
+    unit_id: str
+    rank: int = Field(..., ge=1)
+    rerank_score: float = Field(..., ge=0.0, le=1.0)
+    retrieval_score: float | None = None
+    unit: dict[str, Any] | None = None
+    score_breakdown: RankerFeatureBreakdown
+    why_ranked: list[str] = Field(default_factory=list)
+    source: str | None = None
+
+
+class LegalRankerResult(BaseModel):
+    ranked_candidates: list[RankedCandidate] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    debug: dict[str, Any] | None = None

--- a/apps/api/app/services/legal_ranker.py
+++ b/apps/api/app/services/legal_ranker.py
@@ -1,0 +1,659 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+import unicodedata
+from typing import Any
+
+from ..schemas import (
+    ExpandedCandidate,
+    GraphExpansionResult,
+    LegalRankerResult,
+    QueryPlan,
+    RankedCandidate,
+    RankerFeatureBreakdown,
+    RawRetrievalResponse,
+    RetrievalCandidate,
+)
+
+LEGAL_RANKER_NO_CANDIDATES = "legal_ranker_no_candidates"
+
+RANKER_WEIGHTS: dict[str, float] = {
+    "bm25_score": 0.16,
+    "dense_score": 0.16,
+    "exact_citation_match": 0.10,
+    "domain_match": 0.10,
+    "graph_proximity": 0.10,
+    "concept_overlap": 0.08,
+    "legal_term_overlap": 0.07,
+    "temporal_validity": 0.07,
+    "source_reliability": 0.05,
+    "parent_relevance": 0.05,
+    "is_exception": 0.03,
+    "is_definition": 0.02,
+    "is_sanction": 0.01,
+}
+
+FEATURE_NAMES = tuple(RANKER_WEIGHTS.keys())
+
+RAW_BM25_KEYS = ("bm25_score", "bm25", "lexical", "lexical_score")
+RAW_DENSE_KEYS = ("dense_score", "dense", "vector", "vector_score")
+
+STOPWORDS = {
+    "a",
+    "al",
+    "ale",
+    "alin",
+    "art",
+    "cu",
+    "de",
+    "din",
+    "este",
+    "fara",
+    "in",
+    "la",
+    "mi",
+    "nr",
+    "pe",
+    "sa",
+    "sau",
+    "se",
+    "si",
+}
+
+
+@dataclass
+class _CandidateBundle:
+    unit_id: str
+    retrieval_candidate: RetrievalCandidate | None = None
+    expanded_candidate: ExpandedCandidate | None = None
+    unit: dict[str, Any] | None = None
+    score_breakdown: dict[str, float] = field(default_factory=dict)
+    graph_proximity: float = 0.0
+    retrieval_score: float | None = None
+    retrieval_rank: int | None = None
+    sources: set[str] = field(default_factory=set)
+    reasons: list[str] = field(default_factory=list)
+
+
+class LegalRanker:
+    def rank(
+        self,
+        *,
+        question: str,
+        plan: QueryPlan,
+        retrieval_response: RawRetrievalResponse,
+        graph_expansion: GraphExpansionResult,
+        debug: bool = False,
+    ) -> LegalRankerResult:
+        bundles = self._merge_candidates(
+            retrieval_response=retrieval_response,
+            graph_expansion=graph_expansion,
+        )
+        input_candidate_count = len(bundles)
+        if not bundles:
+            return self._fallback_result(debug=debug)
+
+        raw_feature_rows = [
+            self._extract_features(
+                question=question,
+                plan=plan,
+                bundle=bundle,
+            )
+            for bundle in bundles
+        ]
+        normalized_feature_rows = self._normalize_rows(raw_feature_rows)
+        scored_rows = [
+            (
+                bundle,
+                RankerFeatureBreakdown(**normalized_features),
+                self._weighted_score(normalized_features),
+            )
+            for bundle, normalized_features in zip(
+                bundles,
+                normalized_feature_rows,
+                strict=True,
+            )
+        ]
+        scored_rows.sort(key=self._sort_key)
+
+        ranked_candidates = [
+            self._ranked_candidate(
+                rank=index,
+                bundle=bundle,
+                score_breakdown=score_breakdown,
+                rerank_score=rerank_score,
+                plan=plan,
+            )
+            for index, (bundle, score_breakdown, rerank_score) in enumerate(
+                scored_rows,
+                start=1,
+            )
+        ]
+
+        result = LegalRankerResult(ranked_candidates=ranked_candidates)
+        if debug:
+            result.debug = self._debug_payload(
+                fallback_used=False,
+                input_candidate_count=input_candidate_count,
+                ranked_candidates=ranked_candidates,
+                warnings=[],
+            )
+        return result
+
+    def _fallback_result(self, *, debug: bool) -> LegalRankerResult:
+        result = LegalRankerResult(
+            ranked_candidates=[],
+            warnings=[LEGAL_RANKER_NO_CANDIDATES],
+            debug=None,
+        )
+        if debug:
+            result.debug = self._debug_payload(
+                fallback_used=True,
+                input_candidate_count=0,
+                ranked_candidates=[],
+                warnings=result.warnings,
+            )
+        return result
+
+    def _merge_candidates(
+        self,
+        *,
+        retrieval_response: RawRetrievalResponse,
+        graph_expansion: GraphExpansionResult,
+    ) -> list[_CandidateBundle]:
+        merged: dict[str, _CandidateBundle] = {}
+
+        for candidate in retrieval_response.candidates:
+            bundle = merged.setdefault(
+                candidate.unit_id,
+                _CandidateBundle(unit_id=candidate.unit_id),
+            )
+            self._merge_retrieval_candidate(bundle, candidate)
+
+        for expanded in (
+            graph_expansion.seed_candidates + graph_expansion.expanded_candidates
+        ):
+            bundle = merged.setdefault(
+                expanded.unit_id,
+                _CandidateBundle(unit_id=expanded.unit_id),
+            )
+            self._merge_expanded_candidate(bundle, expanded)
+            if expanded.retrieval_candidate:
+                self._merge_retrieval_candidate(
+                    bundle,
+                    expanded.retrieval_candidate,
+                )
+
+        return list(merged.values())
+
+    def _merge_retrieval_candidate(
+        self,
+        bundle: _CandidateBundle,
+        candidate: RetrievalCandidate,
+    ) -> None:
+        if (
+            bundle.retrieval_candidate is None
+            or self._unit_info_score(candidate.unit)
+            > self._unit_info_score(bundle.retrieval_candidate.unit)
+        ):
+            bundle.retrieval_candidate = candidate
+        if self._unit_info_score(candidate.unit) > self._unit_info_score(bundle.unit):
+            bundle.unit = candidate.unit
+        if candidate.retrieval_score is not None:
+            bundle.retrieval_score = max(
+                bundle.retrieval_score or 0.0,
+                candidate.retrieval_score,
+            )
+        bundle.retrieval_rank = (
+            candidate.rank
+            if bundle.retrieval_rank is None
+            else min(bundle.retrieval_rank, candidate.rank)
+        )
+        bundle.score_breakdown.update(candidate.score_breakdown)
+        bundle.sources.add("raw_retrieval")
+        if candidate.why_retrieved:
+            bundle.reasons.append(candidate.why_retrieved)
+
+    def _merge_expanded_candidate(
+        self,
+        bundle: _CandidateBundle,
+        candidate: ExpandedCandidate,
+    ) -> None:
+        bundle.expanded_candidate = candidate
+        bundle.graph_proximity = max(
+            bundle.graph_proximity,
+            self._clamp(candidate.graph_proximity),
+        )
+        bundle.score_breakdown.update(candidate.score_breakdown)
+        bundle.sources.add(candidate.source)
+        if candidate.expansion_reason:
+            bundle.reasons.append(candidate.expansion_reason)
+        if candidate.expansion_edge_type:
+            bundle.reasons.append(candidate.expansion_edge_type)
+
+    def _extract_features(
+        self,
+        *,
+        question: str,
+        plan: QueryPlan,
+        bundle: _CandidateBundle,
+    ) -> dict[str, float]:
+        unit = bundle.unit or {}
+        return {
+            "bm25_score": self._score_from_breakdown(
+                bundle.score_breakdown,
+                RAW_BM25_KEYS,
+            ),
+            "dense_score": self._score_from_breakdown(
+                bundle.score_breakdown,
+                RAW_DENSE_KEYS,
+            ),
+            "exact_citation_match": self._exact_citation_match(plan, bundle),
+            "domain_match": self._domain_match(plan, unit),
+            "graph_proximity": self._graph_proximity(bundle),
+            "concept_overlap": self._concept_overlap(question, plan, unit),
+            "legal_term_overlap": self._legal_term_overlap(question, plan, unit),
+            "temporal_validity": self._temporal_validity(unit),
+            "source_reliability": self._source_reliability(unit),
+            "parent_relevance": self._parent_relevance(unit),
+            "is_exception": self._indicator(
+                unit=unit,
+                bundle=bundle,
+                terms=(
+                    "exception",
+                    "exceptie",
+                    "except",
+                    "cu exceptia",
+                    "exception_to",
+                ),
+            ),
+            "is_definition": self._indicator(
+                unit=unit,
+                bundle=bundle,
+                terms=(
+                    "definition",
+                    "defineste",
+                    "in sensul",
+                    "se intelege",
+                    "defines",
+                ),
+            ),
+            "is_sanction": self._indicator(
+                unit=unit,
+                bundle=bundle,
+                terms=(
+                    "sanction",
+                    "sanctiune",
+                    "amenda",
+                    "contraventie",
+                    "sanctions",
+                ),
+            ),
+        }
+
+    def _normalize_rows(
+        self,
+        raw_feature_rows: list[dict[str, float]],
+    ) -> list[dict[str, float]]:
+        normalized = [{name: 0.0 for name in FEATURE_NAMES} for _ in raw_feature_rows]
+        for feature_name in FEATURE_NAMES:
+            values = [row.get(feature_name, 0.0) for row in raw_feature_rows]
+            if any(value > 1.0 for value in values):
+                normalized_values = self._min_max_normalize(values)
+            else:
+                normalized_values = [self._clamp(value) for value in values]
+            for row, value in zip(normalized, normalized_values, strict=True):
+                row[feature_name] = value
+        return normalized
+
+    def _min_max_normalize(self, values: list[float]) -> list[float]:
+        if all(value == 0.0 for value in values):
+            return [0.0 for _ in values]
+        minimum = min(values)
+        maximum = max(values)
+        if minimum == maximum:
+            return [0.5 if minimum != 0.0 else 0.0 for _ in values]
+        return [self._clamp((value - minimum) / (maximum - minimum)) for value in values]
+
+    def _weighted_score(self, features: dict[str, float]) -> float:
+        score = sum(
+            RANKER_WEIGHTS[feature_name] * features.get(feature_name, 0.0)
+            for feature_name in FEATURE_NAMES
+        )
+        return round(self._clamp(score), 6)
+
+    def _sort_key(
+        self,
+        row: tuple[_CandidateBundle, RankerFeatureBreakdown, float],
+    ) -> tuple[float, float, float, float, int, str]:
+        bundle, score_breakdown, rerank_score = row
+        return (
+            -rerank_score,
+            -score_breakdown.exact_citation_match,
+            -score_breakdown.domain_match,
+            -score_breakdown.graph_proximity,
+            bundle.retrieval_rank or 1_000_000,
+            bundle.unit_id,
+        )
+
+    def _ranked_candidate(
+        self,
+        *,
+        rank: int,
+        bundle: _CandidateBundle,
+        score_breakdown: RankerFeatureBreakdown,
+        rerank_score: float,
+        plan: QueryPlan,
+    ) -> RankedCandidate:
+        return RankedCandidate(
+            unit_id=bundle.unit_id,
+            rank=rank,
+            rerank_score=rerank_score,
+            retrieval_score=bundle.retrieval_score,
+            unit=bundle.unit,
+            score_breakdown=score_breakdown,
+            why_ranked=self._why_ranked(plan, bundle, score_breakdown),
+            source=self._source(bundle),
+        )
+
+    def _why_ranked(
+        self,
+        plan: QueryPlan,
+        bundle: _CandidateBundle,
+        score_breakdown: RankerFeatureBreakdown,
+    ) -> list[str]:
+        reasons: list[str] = []
+        if score_breakdown.bm25_score >= 0.70:
+            reasons.append("high_bm25_score")
+        if score_breakdown.dense_score >= 0.70:
+            reasons.append("high_dense_score")
+        if score_breakdown.exact_citation_match > 0:
+            reasons.append("exact_citation_match")
+        if score_breakdown.domain_match == 1.0 and plan.legal_domain:
+            reasons.append(f"domain_match:{self._normal_label(plan.legal_domain)}")
+        if score_breakdown.graph_proximity > 0 and bundle.expanded_candidate:
+            reasons.append("graph_proximity_from_expansion")
+        if score_breakdown.concept_overlap > 0:
+            reasons.append("concept_overlap")
+        if score_breakdown.legal_term_overlap > 0:
+            reasons.append("legal_term_overlap")
+        if score_breakdown.temporal_validity == 1.0:
+            reasons.append("active_legal_unit")
+        if score_breakdown.source_reliability == 1.0:
+            reasons.append("has_source_url")
+        if score_breakdown.is_exception > 0:
+            reasons.append("exception_candidate")
+        if score_breakdown.is_definition > 0:
+            reasons.append("definition_candidate")
+        if score_breakdown.is_sanction > 0:
+            reasons.append("sanction_candidate")
+        if score_breakdown.parent_relevance > 0:
+            reasons.append("parent_context_candidate")
+        for reason in bundle.reasons:
+            normalized_reason = self._normal_label(reason)
+            if normalized_reason and normalized_reason not in reasons:
+                reasons.append(normalized_reason)
+        return reasons
+
+    def _score_from_breakdown(
+        self,
+        score_breakdown: dict[str, float],
+        keys: tuple[str, ...],
+    ) -> float:
+        for key in keys:
+            if key in score_breakdown:
+                return float(score_breakdown[key])
+        return 0.0
+
+    def _exact_citation_match(
+        self,
+        plan: QueryPlan,
+        bundle: _CandidateBundle,
+    ) -> float:
+        if bundle.score_breakdown.get("exact_citation_boost", 0.0) > 0:
+            return 1.0
+        if bundle.score_breakdown.get("exact_citation_match", 0.0) > 0:
+            return 1.0
+        if not plan.exact_citations:
+            return 0.0
+
+        haystack = self._candidate_haystack(bundle)
+        for citation in plan.exact_citations:
+            article_match = True
+            if citation.article:
+                article = self._normalize_text(citation.article)
+                article_match = any(
+                    marker in haystack
+                    for marker in (
+                        f"art {article}",
+                        f"art_{article}",
+                        f"art-{article}",
+                        f"article {article}",
+                    )
+                )
+
+            paragraph_match = True
+            if citation.paragraph:
+                paragraph = self._normalize_text(citation.paragraph)
+                paragraph_match = any(
+                    marker in haystack
+                    for marker in (
+                        f"alin {paragraph}",
+                        f"alin_{paragraph}",
+                        f"paragraph {paragraph}",
+                    )
+                )
+
+            law_match = True
+            if citation.law_id_hint:
+                law = self._normalize_text(citation.law_id_hint)
+                law_match = law in haystack
+            elif citation.act_hint:
+                law = self._normalize_text(citation.act_hint)
+                law_match = law in haystack
+
+            if article_match and paragraph_match and law_match:
+                return 1.0
+        return 0.0
+
+    def _domain_match(self, plan: QueryPlan, unit: dict[str, Any]) -> float:
+        if not plan.legal_domain:
+            return 0.0
+        unit_domain = self._unit_value(unit, "legal_domain", "domain")
+        if not unit_domain:
+            return 0.3
+        plan_domain = self._normalize_text(plan.legal_domain)
+        normalized_unit_domain = self._normalize_text(str(unit_domain))
+        if (
+            plan_domain == normalized_unit_domain
+            or plan_domain in normalized_unit_domain
+            or normalized_unit_domain in plan_domain
+        ):
+            return 1.0
+        return 0.0
+
+    def _graph_proximity(self, bundle: _CandidateBundle) -> float:
+        if bundle.graph_proximity > 0:
+            return bundle.graph_proximity
+        if bundle.retrieval_candidate:
+            return 1.0
+        return 0.0
+
+    def _concept_overlap(
+        self,
+        question: str,
+        plan: QueryPlan,
+        unit: dict[str, Any],
+    ) -> float:
+        concepts = unit.get("legal_concepts")
+        if not concepts:
+            return 0.0
+        concept_tokens = self._tokens_from_value(concepts)
+        if not concept_tokens:
+            return 0.0
+        query_tokens = self._tokenize(question) | {
+            self._normalize_text(query_type) for query_type in plan.query_types
+        }
+        return len(concept_tokens & query_tokens) / len(concept_tokens)
+
+    def _legal_term_overlap(
+        self,
+        question: str,
+        plan: QueryPlan,
+        unit: dict[str, Any],
+    ) -> float:
+        text = self._unit_value(unit, "normalized_text", "raw_text", "text")
+        if not text:
+            return 0.0
+        question_tokens = self._tokenize(plan.normalized_question or question)
+        unit_tokens = self._tokenize(str(text))
+        if not question_tokens or not unit_tokens:
+            return 0.0
+        return len(question_tokens & unit_tokens) / len(question_tokens)
+
+    def _temporal_validity(self, unit: dict[str, Any]) -> float:
+        status = self._normalize_text(str(unit.get("status") or "unknown"))
+        if status == "active":
+            return 1.0
+        if status in {"unknown", ""}:
+            return 0.6
+        if status == "historical":
+            return 0.2
+        if status == "repealed":
+            return 0.0
+        return 0.6
+
+    def _source_reliability(self, unit: dict[str, Any]) -> float:
+        if unit.get("source_url"):
+            return 1.0
+        if any(unit.get(key) for key in ("law_id", "law_title", "raw_text")):
+            return 0.8
+        return 0.6
+
+    def _parent_relevance(self, unit: dict[str, Any]) -> float:
+        unit_type = self._normalize_text(str(unit.get("type") or unit.get("unit_type") or ""))
+        if unit.get("parent_id") and unit_type in {"paragraf", "paragraph", "alineat", "litera", "letter", "punct", "point"}:
+            return 0.6
+        if unit_type in {"articol", "article"}:
+            return 0.3
+        return 0.0
+
+    def _indicator(
+        self,
+        *,
+        unit: dict[str, Any],
+        bundle: _CandidateBundle,
+        terms: tuple[str, ...],
+    ) -> float:
+        haystack = self._candidate_haystack(bundle)
+        if unit:
+            haystack = f"{haystack} {self._normalize_text(str(unit))}"
+        return 1.0 if any(self._normalize_text(term) in haystack for term in terms) else 0.0
+
+    def _debug_payload(
+        self,
+        *,
+        fallback_used: bool,
+        input_candidate_count: int,
+        ranked_candidates: list[RankedCandidate],
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        rows = [candidate.model_dump(mode="json") for candidate in ranked_candidates]
+        return {
+            "fallback_used": fallback_used,
+            "input_candidate_count": input_candidate_count,
+            "ranked_candidate_count": len(ranked_candidates),
+            "weights": RANKER_WEIGHTS,
+            "ranked_candidates": rows,
+            "rows": rows,
+            "warnings": warnings,
+        }
+
+    def _candidate_haystack(self, bundle: _CandidateBundle) -> str:
+        values: list[str] = [bundle.unit_id]
+        if bundle.unit:
+            values.extend(str(value) for value in bundle.unit.values())
+        values.extend(bundle.reasons)
+        if bundle.expanded_candidate:
+            values.extend(
+                str(value)
+                for value in (
+                    bundle.expanded_candidate.source,
+                    bundle.expanded_candidate.expansion_edge_type,
+                    bundle.expanded_candidate.expansion_reason,
+                )
+                if value
+            )
+        return self._normalize_text(" ".join(values))
+
+    def _unit_value(self, unit: dict[str, Any], *keys: str) -> Any:
+        for key in keys:
+            value = unit.get(key)
+            if value is not None:
+                return value
+        return None
+
+    def _unit_info_score(self, unit: dict[str, Any] | None) -> int:
+        if not unit:
+            return 0
+        return sum(1 for value in unit.values() if value not in (None, "", [], {}))
+
+    def _tokens_from_value(self, value: Any) -> set[str]:
+        if isinstance(value, list | tuple | set):
+            return {
+                token
+                for item in value
+                for token in self._tokenize(str(item))
+            }
+        return self._tokenize(str(value))
+
+    def _tokenize(self, text: str) -> set[str]:
+        normalized = self._normalize_text(text)
+        return {
+            token
+            for token in re.split(r"[^a-z0-9_]+", normalized)
+            if len(token) > 1 and token not in STOPWORDS
+        }
+
+    def _normalize_text(self, text: str) -> str:
+        replacements = {
+            "Äƒ": "ă",
+            "Ä‚": "Ă",
+            "È™": "ș",
+            "È˜": "Ș",
+            "È›": "ț",
+            "Èš": "Ț",
+            "Ã¢": "â",
+            "Ã‚": "Â",
+            "Ã®": "î",
+            "ÃŽ": "Î",
+            "ÅŸ": "ș",
+            "Åž": "Ș",
+            "Å£": "ț",
+            "Å¢": "Ț",
+        }
+        for broken, fixed in replacements.items():
+            text = text.replace(broken, fixed)
+        normalized = unicodedata.normalize("NFD", text.casefold())
+        stripped = "".join(
+            char for char in normalized if unicodedata.category(char) != "Mn"
+        )
+        return " ".join(stripped.replace(".", " ").replace("-", "_").split())
+
+    def _normal_label(self, text: str) -> str:
+        return self._normalize_text(text).replace(" ", "_")
+
+    def _source(self, bundle: _CandidateBundle) -> str | None:
+        if not bundle.sources:
+            return None
+        if "graph_expansion" in bundle.sources:
+            return "graph_expansion"
+        if "seed" in bundle.sources:
+            return "seed"
+        if "raw_retrieval" in bundle.sources:
+            return "raw_retrieval"
+        return sorted(bundle.sources)[0]
+
+    def _clamp(self, value: float) -> float:
+        return max(0.0, min(1.0, float(value)))

--- a/apps/api/app/services/query_orchestrator.py
+++ b/apps/api/app/services/query_orchestrator.py
@@ -2,6 +2,7 @@ from uuid import NAMESPACE_URL, uuid5
 
 from ..schemas import QueryDebugData, QueryRequest, QueryResponse
 from .graph_expansion_policy import GraphExpansionPolicy
+from .legal_ranker import LegalRanker
 from .mock_evidence import MockEvidenceService
 from .query_understanding import QueryUnderstanding
 from .raw_retriever_client import RawRetrieverClient
@@ -14,6 +15,7 @@ class QueryOrchestrator:
         query_understanding: QueryUnderstanding | None = None,
         raw_retriever_client: RawRetrieverClient | None = None,
         graph_expansion_policy: GraphExpansionPolicy | None = None,
+        legal_ranker: LegalRanker | None = None,
     ) -> None:
         self.evidence_service = evidence_service or MockEvidenceService()
         self.query_understanding = query_understanding or QueryUnderstanding()
@@ -21,6 +23,7 @@ class QueryOrchestrator:
         self.graph_expansion_policy = (
             graph_expansion_policy or GraphExpansionPolicy()
         )
+        self.legal_ranker = legal_ranker or LegalRanker()
 
     async def run(self, request: QueryRequest) -> QueryResponse:
         query_id = self._query_id(request)
@@ -35,6 +38,13 @@ class QueryOrchestrator:
             retrieval_response=raw_retrieval,
             debug=request.debug,
         )
+        legal_ranker = self.legal_ranker.rank(
+            question=request.question,
+            plan=query_plan,
+            retrieval_response=raw_retrieval,
+            graph_expansion=graph_expansion,
+            debug=request.debug,
+        )
         evidence_pack = await self.evidence_service.build_pack(request, query_id)
         debug = None
         if request.debug:
@@ -45,6 +55,7 @@ class QueryOrchestrator:
                 query_understanding=query_plan,
                 retrieval=raw_retrieval.debug,
                 graph_expansion=graph_expansion.debug,
+                legal_ranker=legal_ranker.debug,
                 evidence_units_count=len(evidence_pack.evidence_units),
                 citations_count=len(evidence_pack.citations),
                 graph_nodes_count=len(evidence_pack.graph.nodes),
@@ -65,6 +76,7 @@ class QueryOrchestrator:
                 evidence_pack.warnings
                 + raw_retrieval.warnings
                 + graph_expansion.warnings
+                + legal_ranker.warnings
             ),
         )
 

--- a/apps/api/app/services/raw_retriever_client.py
+++ b/apps/api/app/services/raw_retriever_client.py
@@ -3,7 +3,7 @@ from typing import Any
 import httpx
 
 from ..schemas import QueryPlan, RawRetrievalRequest, RawRetrievalResponse
-from ..settings import settings
+from ..config import settings
 
 RAW_RETRIEVAL_NOT_CONFIGURED = "raw_retrieval_not_configured"
 RAW_RETRIEVAL_UNAVAILABLE = "raw_retrieval_unavailable"

--- a/docs/query-api.md
+++ b/docs/query-api.md
@@ -1,10 +1,11 @@
 # Query API
 
-Phase 5 exposes the `/api/query` contract, deterministic QueryUnderstanding,
+Phase 6 exposes the `/api/query` contract, deterministic QueryUnderstanding,
 DomainRouter debug data, ExactCitationDetector output, RawRetrieverClient
-request construction, GraphExpansionPolicy debug data, and a deterministic mock
-EvidencePack only. It is intended for frontend and API integration work before
-real retrieval, graph traversal, and answer generation are available.
+request construction, GraphExpansionPolicy debug data, LegalRanker debug data,
+and a deterministic mock EvidencePack only. It is intended for frontend and API
+integration work before real retrieval, graph traversal, EvidencePack
+compilation, and answer generation are available.
 
 Not implemented yet:
 
@@ -12,7 +13,7 @@ Not implemented yet:
 - `/api/retrieve/raw`, which is owned by Handoff 04
 - graph/neighbors endpoints, which are owned by Handoff 04
 - database-backed graph expansion
-- LegalRanker
+- EvidencePackCompiler, which is planned for Handoff 03 Phase 7
 - answer generation
 - citation verification
 
@@ -20,9 +21,11 @@ The query understanding layer is rule-based and inspectable. It does not call an
 LLM and it does not retrieve legal text. Exact citations are parsed only into
 future lookup hints; they are not resolved against `legal_units` yet.
 RawRetrieverClient prepares the future raw retrieval payload. GraphExpansionPolicy
-turns raw retrieval candidates into graph expansion seeds and policy metadata. If
-raw retrieval or graph neighbors are not configured, `/api/query` returns a safe
-fallback with `confidence: 0.0`, `verifier_passed: false`, and explicit warnings.
+turns raw retrieval candidates into graph expansion seeds and policy metadata.
+LegalRanker reranks raw and expanded candidates deterministically when they
+exist. If raw retrieval or graph neighbors are not configured, `/api/query`
+returns a safe fallback with `confidence: 0.0`, `verifier_passed: false`, and
+explicit warnings.
 
 ## Request
 
@@ -81,8 +84,8 @@ curl -X POST http://localhost:8000/api/query \
 ```
 
 When `debug` is `true`, the response includes a `debug` object with mock service
-counts, notes, `query_understanding`, `retrieval`, and `graph_expansion`. When
-`debug` is `false`, `debug` is `null`.
+counts, notes, `query_understanding`, `retrieval`, `graph_expansion`, and
+`legal_ranker`. When `debug` is `false`, `debug` is `null`.
 
 Example debug excerpt:
 
@@ -104,6 +107,38 @@ Example debug excerpt:
         "max_depth": 2,
         "max_expanded_nodes": 80
       }
+    }
+  }
+}
+```
+
+LegalRanker debug excerpt when no candidates are available:
+
+```json
+{
+  "debug": {
+    "legal_ranker": {
+      "fallback_used": true,
+      "input_candidate_count": 0,
+      "ranked_candidate_count": 0,
+      "weights": {
+        "bm25_score": 0.16,
+        "dense_score": 0.16,
+        "exact_citation_match": 0.1,
+        "domain_match": 0.1,
+        "graph_proximity": 0.1,
+        "concept_overlap": 0.08,
+        "legal_term_overlap": 0.07,
+        "temporal_validity": 0.07,
+        "source_reliability": 0.05,
+        "parent_relevance": 0.05,
+        "is_exception": 0.03,
+        "is_definition": 0.02,
+        "is_sanction": 0.01
+      },
+      "ranked_candidates": [],
+      "rows": [],
+      "warnings": ["legal_ranker_no_candidates"]
     }
   }
 }

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from apps.api.app.main import app
-from apps.api.app.routers import health as health_module
+from apps.api.app.routes import health as health_module
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -79,7 +79,7 @@ def test_legacy_health_does_not_require_database():
 
 
 def test_api_health_db_returns_503_without_database_url(monkeypatch):
-    import apps.api.app.db as db_module
+    import apps.api.app.db.session as db_module
 
     monkeypatch.setattr(db_module.settings, "database_url", None)
     monkeypatch.setattr(db_module, "_engine", None)

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -75,6 +75,12 @@ def test_post_api_query_debug_true_includes_debug_payload():
     assert "sanctions" in priorities
     assert "creates_obligation" in priorities
     assert "creates_prohibition" in priorities
+    legal_ranker = debug["legal_ranker"]
+    assert legal_ranker["fallback_used"] is True
+    assert legal_ranker["input_candidate_count"] == 0
+    assert legal_ranker["ranked_candidate_count"] == 0
+    assert legal_ranker["ranked_candidates"] == []
+    assert "legal_ranker_no_candidates" in legal_ranker["warnings"]
 
 
 def test_post_api_query_debug_false_returns_null_debug():
@@ -85,6 +91,7 @@ def test_post_api_query_debug_false_returns_null_debug():
     assert payload["debug"] is None
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
+    assert "legal_ranker_no_candidates" in payload["warnings"]
 
 
 def test_post_api_query_debug_true_includes_exact_citations():
@@ -117,7 +124,9 @@ def test_post_api_query_debug_true_includes_exact_citations():
     assert payload["verifier"]["verifier_passed"] is False
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
+    assert "legal_ranker_no_candidates" in payload["warnings"]
     assert payload["debug"]["graph_expansion"]["fallback_used"] is True
+    assert payload["debug"]["legal_ranker"]["fallback_used"] is True
 
 
 def test_handoff04_graph_endpoints_are_not_registered():

--- a/tests/test_legal_ranker.py
+++ b/tests/test_legal_ranker.py
@@ -1,0 +1,233 @@
+from apps.api.app.schemas import (
+    ExpandedCandidate,
+    GraphExpansionResult,
+    QueryRequest,
+    RawRetrievalResponse,
+    RetrievalCandidate,
+)
+from apps.api.app.services.legal_ranker import (
+    LEGAL_RANKER_NO_CANDIDATES,
+    LegalRanker,
+)
+from apps.api.app.services.query_understanding import QueryUnderstanding
+
+
+def build_plan(question: str):
+    request = QueryRequest(
+        question=question,
+        jurisdiction="RO",
+        date="current",
+        mode="strict_citations",
+        debug=True,
+    )
+    return QueryUnderstanding().build_plan(request)
+
+
+def candidate(
+    unit_id: str,
+    *,
+    rank: int = 1,
+    score_breakdown: dict[str, float] | None = None,
+    unit: dict | None = None,
+) -> RetrievalCandidate:
+    return RetrievalCandidate(
+        unit_id=unit_id,
+        rank=rank,
+        retrieval_score=score_breakdown.get("bm25", 0.0) if score_breakdown else 0.0,
+        score_breakdown=score_breakdown or {},
+        unit=unit or {
+            "legal_domain": "munca",
+            "status": "active",
+            "law_id": "ro.codul_muncii",
+            "raw_text": "salariu contract act aditional",
+            "type": "articol",
+        },
+    )
+
+
+def empty_graph() -> GraphExpansionResult:
+    return GraphExpansionResult()
+
+
+def test_no_candidates_returns_safe_fallback():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[]),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    assert result.ranked_candidates == []
+    assert result.warnings == [LEGAL_RANKER_NO_CANDIDATES]
+    assert result.debug["fallback_used"] is True
+    assert result.debug["input_candidate_count"] == 0
+    assert result.debug["ranked_candidate_count"] == 0
+
+
+def test_candidates_are_sorted_by_descending_rerank_score():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    low = candidate("ro.codul_muncii.art_10", score_breakdown={"bm25": 0.1})
+    high = candidate(
+        "ro.codul_muncii.art_41",
+        score_breakdown={"bm25": 0.9, "dense": 0.8},
+    )
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[low, high]),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    assert [candidate.unit_id for candidate in result.ranked_candidates] == [
+        "ro.codul_muncii.art_41",
+        "ro.codul_muncii.art_10",
+    ]
+    assert result.ranked_candidates[0].rerank_score > result.ranked_candidates[1].rerank_score
+
+
+def test_exact_citation_candidate_gets_boost_and_ranks_first():
+    plan = build_plan("Ce spune art. 41 alin. (1) din Codul muncii?")
+    exact = candidate(
+        "ro.codul_muncii.art_41.alin_1",
+        rank=2,
+        score_breakdown={"bm25": 0.2},
+    )
+    generic = candidate(
+        "ro.codul_muncii.art_99",
+        rank=1,
+        score_breakdown={"bm25": 0.2},
+    )
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[generic, exact]),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    top = result.ranked_candidates[0]
+    assert top.unit_id == "ro.codul_muncii.art_41.alin_1"
+    assert top.score_breakdown.exact_citation_match == 1.0
+    assert "exact_citation_match" in top.why_ranked
+
+
+def test_domain_match_for_labor_question():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(
+            candidates=[
+                candidate(
+                    "ro.codul_muncii.art_41",
+                    unit={"legal_domain": "munca", "status": "active"},
+                )
+            ]
+        ),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    ranked = result.ranked_candidates[0]
+    assert ranked.score_breakdown.domain_match == 1.0
+    assert "domain_match:munca" in ranked.why_ranked
+
+
+def test_graph_proximity_influences_score():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    graph = GraphExpansionResult(
+        expanded_candidates=[
+            ExpandedCandidate(
+                unit_id="ro.codul_muncii.art_41",
+                source="graph_expansion",
+                graph_distance=1,
+                graph_proximity=0.9,
+            ),
+            ExpandedCandidate(
+                unit_id="ro.codul_muncii.art_42",
+                source="graph_expansion",
+                graph_distance=1,
+                graph_proximity=0.1,
+            ),
+        ]
+    )
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[]),
+        graph_expansion=graph,
+        debug=True,
+    )
+
+    assert result.ranked_candidates[0].unit_id == "ro.codul_muncii.art_41"
+    assert result.ranked_candidates[0].score_breakdown.graph_proximity == 0.9
+
+
+def test_repealed_status_gets_zero_temporal_validity():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(
+            candidates=[
+                candidate(
+                    "ro.codul_muncii.art_41",
+                    unit={"legal_domain": "munca", "status": "repealed"},
+                )
+            ]
+        ),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    assert result.ranked_candidates[0].score_breakdown.temporal_validity == 0.0
+
+
+def test_scores_are_normalized_and_clamped_to_unit_interval():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(
+            candidates=[
+                candidate("ro.codul_muncii.art_1", score_breakdown={"bm25": 10.0}),
+                candidate("ro.codul_muncii.art_2", score_breakdown={"bm25": -2.0}),
+            ]
+        ),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    for ranked in result.ranked_candidates:
+        assert 0.0 <= ranked.rerank_score <= 1.0
+        for value in ranked.score_breakdown.model_dump().values():
+            assert 0.0 <= value <= 1.0
+
+
+def test_tie_break_is_deterministic_by_raw_rank_then_unit_id():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    first = candidate("ro.codul_muncii.art_a", rank=1, score_breakdown={"bm25": 0.5})
+    second = candidate("ro.codul_muncii.art_b", rank=2, score_breakdown={"bm25": 0.5})
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[second, first]),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    assert [candidate.unit_id for candidate in result.ranked_candidates] == [
+        "ro.codul_muncii.art_a",
+        "ro.codul_muncii.art_b",
+    ]


### PR DESCRIPTION
This pull request introduces the initial implementation of a deterministic legal ranker for query responses, integrating it into the query orchestration flow and API. It adds new schemas, service logic, and comprehensive tests to support ranking, debugging, and explainability of legal candidates. The documentation and test suite are updated accordingly.

**Legal Ranker Integration and Schema Additions:**

* Introduced new schemas in `ranking.py` for `LegalRankerResult`, `RankedCandidate`, and `RankerFeatureBreakdown`, which define the structure of ranked results and feature-level scoring breakdowns. These are now imported and exported in `schemas/__init__.py`. [[1]](diffhunk://#diff-ed1875a69529cbb7f306274316b6215af5de7e85a9719233b3902211d550e387R1-R36) [[2]](diffhunk://#diff-9f8f808bbceb3e0ac3957e424acfc39f71c6c6da72fde7901ce3f308ff48f583R21-R25) [[3]](diffhunk://#diff-9f8f808bbceb3e0ac3957e424acfc39f71c6c6da72fde7901ce3f308ff48f583R44-R50)
* Added a `legal_ranker` field to the `QueryDebugData` schema to support debugging and introspection of the ranker's behavior.

**Query Orchestration and Service Changes:**

* Integrated the new `LegalRanker` service into the `QueryOrchestrator`, ensuring that legal candidates are reranked and their results, debug data, and warnings are included in the query response. [[1]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R5) [[2]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R18-R26) [[3]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R41-R47) [[4]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R58) [[5]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R79)

**Documentation Updates:**

* Updated the Query API documentation to describe the new Phase 6 features, including the legal ranker, its debug data, and example debug payloads. This clarifies the new ranking step and its output for API consumers. [[1]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL3-R28) [[2]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL84-R88) [[3]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aR115-R146)

**Testing Enhancements:**

* Added a comprehensive test suite for the legal ranker (`test_legal_ranker.py`) covering fallback behavior, ranking logic, feature scoring, normalization, and deterministic tie-breaking.
* Updated existing query API tests to assert the presence and correctness of legal ranker debug data and warnings in the API response. [[1]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R78-R83) [[2]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R94) [[3]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R127-R129)

**Miscellaneous Fixes:**

* Fixed import paths in the raw retriever client and test modules for consistency and correctness. [[1]](diffhunk://#diff-9eaea9df8d1a5d75a0736cbe17ed641680fb98eb9fb3be489a54e693cb73c332L6-R6) [[2]](diffhunk://#diff-6028c43db1af7f14beef1e13ab3bc4599a436a1534f7b6b6baa92a72c9b0d422L10-R10) [[3]](diffhunk://#diff-6028c43db1af7f14beef1e13ab3bc4599a436a1534f7b6b6baa92a72c9b0d422L82-R82)