### PR TITLE
feat(h03): implement phase 7 EvidencePackCompiler with MMR

### DIFF
--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -51,13 +51,26 @@ class LegalUnit(BaseModel):
     incoming_reference_ids: list[str] = Field(default_factory=list)
 
 
-class EvidenceUnit(BaseModel):
+class EvidenceUnit(LegalUnit):
     evidence_id: str
-    legal_unit: LegalUnit
     excerpt: str
     rank: int = Field(..., ge=1)
     relevance_score: float = Field(..., ge=0.0, le=1.0)
     retrieval_method: str
+    retrieval_score: float = 0.0
+    rerank_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    mmr_score: float | None = None
+    support_role: Literal[
+        "direct_basis",
+        "definition",
+        "condition",
+        "exception",
+        "sanction",
+        "procedure",
+        "context",
+    ] = "direct_basis"
+    why_selected: list[str] = Field(default_factory=list)
+    score_breakdown: dict[str, float] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
 
 
@@ -224,6 +237,7 @@ class QueryDebugData(BaseModel):
     retrieval: dict[str, Any] | None = None
     graph_expansion: dict[str, Any] | None = None
     legal_ranker: dict[str, Any] | None = None
+    evidence_pack: dict[str, Any] | None = None
     evidence_units_count: int = Field(..., ge=0)
     citations_count: int = Field(..., ge=0)
     graph_nodes_count: int = Field(..., ge=0)

--- a/apps/api/app/services/evidence_pack_compiler.py
+++ b/apps/api/app/services/evidence_pack_compiler.py
@@ -1,0 +1,663 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+import unicodedata
+from typing import Any
+
+from ..schemas import (
+    EvidencePackResult,
+    EvidenceUnit,
+    GraphEdge,
+    GraphExpansionResult,
+    GraphNode,
+    LegalUnit,
+    QueryPlan,
+    RankedCandidate,
+)
+
+EVIDENCE_PACK_NO_RANKED_CANDIDATES = "evidence_pack_no_ranked_candidates"
+EVIDENCE_PACK_PARTIAL = "evidence_pack_partial"
+EVIDENCE_PACK_MISSING_UNIT_TEXT = "evidence_pack_missing_unit_text"
+EVIDENCE_PACK_MISSING_UNIT_METADATA = "evidence_pack_missing_unit_metadata"
+
+SUPPORT_ROLES = (
+    "direct_basis",
+    "definition",
+    "condition",
+    "exception",
+    "sanction",
+    "procedure",
+    "context",
+)
+
+STOPWORDS = {
+    "a",
+    "al",
+    "ale",
+    "alin",
+    "art",
+    "cu",
+    "de",
+    "din",
+    "este",
+    "fara",
+    "in",
+    "la",
+    "pe",
+    "sau",
+    "se",
+    "si",
+}
+
+
+@dataclass
+class _EvidenceCandidate:
+    ranked: RankedCandidate
+    unit: dict[str, Any]
+    text: str
+    tokens: set[str]
+    support_role: str
+    why_selected: list[str] = field(default_factory=list)
+    mmr_score: float = 0.0
+
+
+class EvidencePackCompiler:
+    def __init__(
+        self,
+        mmr_lambda: float = 0.75,
+        candidate_pool_size: int = 40,
+        target_evidence_units: int = 12,
+        max_evidence_units: int = 14,
+    ) -> None:
+        self.mmr_lambda = mmr_lambda
+        self.candidate_pool_size = candidate_pool_size
+        self.target_evidence_units = target_evidence_units
+        self.max_evidence_units = max_evidence_units
+
+    def compile(
+        self,
+        *,
+        ranked_candidates: list[RankedCandidate],
+        graph_expansion: GraphExpansionResult | None = None,
+        plan: QueryPlan | None = None,
+        debug: bool = False,
+    ) -> EvidencePackResult:
+        if not ranked_candidates:
+            return self._fallback_result(debug=debug)
+
+        warnings: list[str] = []
+        unique_ranked = self._dedupe_ranked_candidates(ranked_candidates)
+        candidate_pool = self._candidate_pool(unique_ranked, plan=plan, warnings=warnings)
+        if not candidate_pool:
+            warnings.append(EVIDENCE_PACK_NO_RANKED_CANDIDATES)
+            return self._empty_result(
+                debug=debug,
+                input_ranked_candidate_count=len(ranked_candidates),
+                warnings=self._dedupe(warnings),
+            )
+
+        selected = self._select_with_mmr(candidate_pool)
+        self._ensure_role_candidate(selected, candidate_pool, "exception")
+        self._ensure_role_candidate(selected, candidate_pool, "definition")
+        self._ensure_role_candidate(selected, candidate_pool, "sanction")
+        self._include_parent_context(selected, candidate_pool)
+
+        if len(selected) < min(self.target_evidence_units, 8):
+            warnings.append(EVIDENCE_PACK_PARTIAL)
+
+        evidence_units = [
+            self._evidence_unit(candidate, rank=index)
+            for index, candidate in enumerate(selected, start=1)
+        ]
+        graph_nodes, graph_edges = self._build_graph(
+            selected=selected,
+            graph_expansion=graph_expansion,
+        )
+
+        result = EvidencePackResult(
+            evidence_units=evidence_units,
+            graph_nodes=graph_nodes,
+            graph_edges=graph_edges,
+            warnings=self._dedupe(warnings),
+            debug=None,
+        )
+        if debug:
+            result.debug = self._debug_payload(
+                fallback_used=False,
+                input_ranked_candidate_count=len(ranked_candidates),
+                candidate_pool_size=len(candidate_pool),
+                selected=selected,
+                warnings=result.warnings,
+            )
+        return result
+
+    def _fallback_result(self, *, debug: bool) -> EvidencePackResult:
+        warnings = [EVIDENCE_PACK_NO_RANKED_CANDIDATES]
+        result = EvidencePackResult(warnings=warnings)
+        if debug:
+            result.debug = {
+                "fallback_used": True,
+                "input_ranked_candidate_count": 0,
+                "candidate_pool_size": 0,
+                "selected_evidence_count": 0,
+                "lambda": self.mmr_lambda,
+                "target_evidence_units": self.target_evidence_units,
+                "max_evidence_units": self.max_evidence_units,
+                "selected_units": [],
+                "warnings": warnings,
+            }
+        return result
+
+    def _empty_result(
+        self,
+        *,
+        debug: bool,
+        input_ranked_candidate_count: int,
+        warnings: list[str],
+    ) -> EvidencePackResult:
+        result = EvidencePackResult(warnings=warnings)
+        if debug:
+            result.debug = {
+                "fallback_used": True,
+                "input_ranked_candidate_count": input_ranked_candidate_count,
+                "candidate_pool_size": 0,
+                "selected_evidence_count": 0,
+                "lambda": self.mmr_lambda,
+                "target_evidence_units": self.target_evidence_units,
+                "max_evidence_units": self.max_evidence_units,
+                "selected_units": [],
+                "warnings": warnings,
+            }
+        return result
+
+    def _dedupe_ranked_candidates(
+        self,
+        ranked_candidates: list[RankedCandidate],
+    ) -> list[RankedCandidate]:
+        best_by_unit_id: dict[str, RankedCandidate] = {}
+        for candidate in ranked_candidates:
+            current = best_by_unit_id.get(candidate.unit_id)
+            if current is None or self._candidate_quality(candidate) > self._candidate_quality(current):
+                best_by_unit_id[candidate.unit_id] = candidate
+        return sorted(
+            best_by_unit_id.values(),
+            key=lambda candidate: (candidate.rank, -candidate.rerank_score, candidate.unit_id),
+        )
+
+    def _candidate_quality(self, candidate: RankedCandidate) -> tuple[int, float, int]:
+        unit = candidate.unit or {}
+        info_score = sum(1 for value in unit.values() if value not in (None, "", [], {}))
+        text_score = 1 if self._candidate_text(unit) else 0
+        return (text_score, candidate.rerank_score, info_score)
+
+    def _candidate_pool(
+        self,
+        ranked_candidates: list[RankedCandidate],
+        *,
+        plan: QueryPlan | None,
+        warnings: list[str],
+    ) -> list[_EvidenceCandidate]:
+        pool: list[_EvidenceCandidate] = []
+        missing_text = False
+        missing_metadata = False
+        for ranked in ranked_candidates[: self.candidate_pool_size]:
+            unit = ranked.unit or {}
+            text = self._candidate_text(unit)
+            if not unit or not text:
+                missing_text = True
+                continue
+            if not self._has_required_metadata(unit):
+                missing_metadata = True
+            pool.append(
+                _EvidenceCandidate(
+                    ranked=ranked,
+                    unit=unit,
+                    text=text,
+                    tokens=self._tokenize(text),
+                    support_role=self._support_role(ranked, unit, plan=plan),
+                    why_selected=self._base_selection_reasons(ranked),
+                )
+            )
+        if missing_text:
+            warnings.append(EVIDENCE_PACK_MISSING_UNIT_TEXT)
+        if missing_metadata:
+            warnings.append(EVIDENCE_PACK_MISSING_UNIT_METADATA)
+        return pool
+
+    def _select_with_mmr(
+        self,
+        candidate_pool: list[_EvidenceCandidate],
+    ) -> list[_EvidenceCandidate]:
+        remaining = candidate_pool.copy()
+        selected: list[_EvidenceCandidate] = []
+        target = min(self.target_evidence_units, len(candidate_pool))
+        while remaining and len(selected) < target:
+            best = max(
+                remaining,
+                key=lambda candidate: self._mmr_sort_key(candidate, selected),
+            )
+            best.mmr_score = self._mmr_score(best, selected)
+            self._append_reason(best, "selected_by_mmr")
+            selected.append(best)
+            remaining.remove(best)
+        return selected
+
+    def _mmr_sort_key(
+        self,
+        candidate: _EvidenceCandidate,
+        selected: list[_EvidenceCandidate],
+    ) -> tuple[float, float, int, str]:
+        return (
+            self._mmr_score(candidate, selected),
+            candidate.ranked.rerank_score,
+            -candidate.ranked.rank,
+            candidate.ranked.unit_id,
+        )
+
+    def _mmr_score(
+        self,
+        candidate: _EvidenceCandidate,
+        selected: list[_EvidenceCandidate],
+    ) -> float:
+        max_similarity = 0.0
+        if selected:
+            max_similarity = max(
+                self._jaccard_similarity(candidate.tokens, selected_candidate.tokens)
+                for selected_candidate in selected
+            )
+        return round(
+            self.mmr_lambda * candidate.ranked.rerank_score
+            - (1.0 - self.mmr_lambda) * max_similarity,
+            6,
+        )
+
+    def _ensure_role_candidate(
+        self,
+        selected: list[_EvidenceCandidate],
+        candidate_pool: list[_EvidenceCandidate],
+        role: str,
+    ) -> None:
+        if len(selected) >= self.max_evidence_units:
+            return
+        if any(candidate.support_role == role for candidate in selected):
+            return
+        candidates = [
+            candidate
+            for candidate in candidate_pool
+            if candidate.support_role == role
+            and candidate.ranked.unit_id not in {item.ranked.unit_id for item in selected}
+        ]
+        if not candidates:
+            return
+        best = max(
+            candidates,
+            key=lambda candidate: (
+                candidate.ranked.rerank_score,
+                -candidate.ranked.rank,
+                candidate.ranked.unit_id,
+            ),
+        )
+        best.mmr_score = self._mmr_score(best, selected)
+        self._append_reason(best, f"{role}_candidate")
+        self._append_reason(best, "selected_by_role_coverage")
+        selected.append(best)
+
+    def _include_parent_context(
+        self,
+        selected: list[_EvidenceCandidate],
+        candidate_pool: list[_EvidenceCandidate],
+    ) -> None:
+        selected_unit_ids = {candidate.ranked.unit_id for candidate in selected}
+        pool_by_unit_id = {
+            candidate.ranked.unit_id: candidate
+            for candidate in candidate_pool
+        }
+        for candidate in list(selected):
+            if len(selected) >= self.max_evidence_units:
+                return
+            parent_id = candidate.unit.get("parent_id")
+            if not isinstance(parent_id, str) or not parent_id:
+                continue
+            if parent_id in selected_unit_ids:
+                continue
+            parent = pool_by_unit_id.get(parent_id)
+            if parent is None:
+                continue
+            parent.support_role = "context"
+            parent.mmr_score = self._mmr_score(parent, selected)
+            self._append_reason(parent, "parent_context_candidate")
+            self._append_reason(parent, "selected_parent_context")
+            selected.append(parent)
+            selected_unit_ids.add(parent_id)
+
+    def _evidence_unit(
+        self,
+        candidate: _EvidenceCandidate,
+        *,
+        rank: int,
+    ) -> EvidenceUnit:
+        ranked = candidate.ranked
+        legal_unit = self._legal_unit_from_dict(
+            unit=candidate.unit,
+            fallback_unit_id=ranked.unit_id,
+            text=candidate.text,
+        )
+        return EvidenceUnit(
+            **legal_unit.model_dump(),
+            evidence_id=f"evidence:{ranked.unit_id}",
+            excerpt=candidate.text,
+            rank=rank,
+            relevance_score=self._clamp(ranked.rerank_score),
+            retrieval_method=ranked.source or "legal_ranker_mmr",
+            retrieval_score=ranked.retrieval_score or 0.0,
+            rerank_score=self._clamp(ranked.rerank_score),
+            mmr_score=candidate.mmr_score,
+            support_role=candidate.support_role,
+            why_selected=self._dedupe(candidate.why_selected),
+            score_breakdown=ranked.score_breakdown.model_dump(mode="json"),
+        )
+
+    def _legal_unit_from_dict(
+        self,
+        *,
+        unit: dict[str, Any],
+        fallback_unit_id: str,
+        text: str,
+    ) -> LegalUnit:
+        law_id = str(unit.get("law_id") or unit.get("law") or "unknown")
+        law_title = str(
+            unit.get("law_title")
+            or unit.get("legal_act")
+            or unit.get("act_title")
+            or law_id
+        )
+        status = str(unit.get("status") or "unknown")
+        if status not in {"active", "historical", "repealed", "unknown"}:
+            status = "unknown"
+        hierarchy_path = unit.get("hierarchy_path")
+        if not isinstance(hierarchy_path, list) or not hierarchy_path:
+            hierarchy_path = [law_title, fallback_unit_id]
+        return LegalUnit(
+            id=str(unit.get("id") or unit.get("legal_unit_id") or fallback_unit_id),
+            canonical_id=unit.get("canonical_id"),
+            source_id=unit.get("source_id"),
+            law_id=law_id,
+            law_title=law_title,
+            act_type=unit.get("act_type"),
+            act_number=unit.get("act_number"),
+            publication_date=unit.get("publication_date"),
+            effective_date=unit.get("effective_date"),
+            version_start=unit.get("version_start"),
+            version_end=unit.get("version_end"),
+            status=status,
+            hierarchy_path=[str(item) for item in hierarchy_path],
+            article_number=self._optional_str(unit.get("article_number")),
+            paragraph_number=self._optional_str(unit.get("paragraph_number")),
+            letter_number=self._optional_str(unit.get("letter_number")),
+            point_number=self._optional_str(unit.get("point_number")),
+            raw_text=text,
+            normalized_text=self._optional_str(unit.get("normalized_text")),
+            legal_domain=str(unit.get("legal_domain") or unit.get("domain") or "unknown"),
+            legal_concepts=[
+                str(concept)
+                for concept in unit.get("legal_concepts", [])
+                if isinstance(unit.get("legal_concepts"), list)
+            ],
+            source_url=unit.get("source_url"),
+            parent_id=self._optional_str(unit.get("parent_id")),
+            children_ids=self._str_list(unit.get("children_ids")),
+            outgoing_reference_ids=self._str_list(unit.get("outgoing_reference_ids")),
+            incoming_reference_ids=self._str_list(unit.get("incoming_reference_ids")),
+        )
+
+    def _build_graph(
+        self,
+        *,
+        selected: list[_EvidenceCandidate],
+        graph_expansion: GraphExpansionResult | None,
+    ) -> tuple[list[GraphNode], list[GraphEdge]]:
+        nodes_by_id: dict[str, GraphNode] = {}
+        edges_by_id: dict[str, GraphEdge] = {}
+
+        if graph_expansion:
+            for node in graph_expansion.graph_nodes:
+                nodes_by_id[node.id] = node
+            for edge in graph_expansion.graph_edges:
+                edges_by_id[edge.id] = edge
+
+        for candidate in selected:
+            node = self._graph_node(candidate)
+            nodes_by_id.setdefault(node.id, node)
+
+        selected_ids = {candidate.ranked.unit_id for candidate in selected}
+        for candidate in selected:
+            parent_id = candidate.unit.get("parent_id")
+            if not isinstance(parent_id, str) or parent_id not in selected_ids:
+                continue
+            edge_id = f"edge:parent:{parent_id}:{candidate.ranked.unit_id}"
+            edges_by_id.setdefault(
+                edge_id,
+                GraphEdge(
+                    id=edge_id,
+                    source=f"legal_unit:{parent_id}",
+                    target=f"legal_unit:{candidate.ranked.unit_id}",
+                    type="contains",
+                    weight=1.0,
+                    confidence=1.0,
+                    explanation="Parent-child relation derived from input parent_id.",
+                    metadata={"derived_from_input_parent_id": True},
+                ),
+            )
+
+        return list(nodes_by_id.values()), list(edges_by_id.values())
+
+    def _graph_node(self, candidate: _EvidenceCandidate) -> GraphNode:
+        unit = candidate.unit
+        unit_id = candidate.ranked.unit_id
+        label = (
+            unit.get("label")
+            or unit.get("title")
+            or unit.get("law_title")
+            or unit.get("id")
+            or unit_id
+        )
+        return GraphNode(
+            id=f"legal_unit:{unit_id}",
+            type=self._graph_node_type(unit),
+            label=str(label),
+            legal_unit_id=unit_id,
+            domain=self._optional_str(unit.get("legal_domain") or unit.get("domain")),
+            status=self._optional_str(unit.get("status")),
+            importance=candidate.ranked.rerank_score,
+            metadata={
+                **self._scalar_metadata(unit),
+                "support_role": candidate.support_role,
+                "rerank_score": candidate.ranked.rerank_score,
+            },
+        )
+
+    def _support_role(
+        self,
+        ranked: RankedCandidate,
+        unit: dict[str, Any],
+        *,
+        plan: QueryPlan | None,
+    ) -> str:
+        haystack = self._haystack(ranked, unit)
+        if self._contains_any(haystack, ("exception", "exceptie", "except", "cu exceptia", "exception_to")):
+            return "exception"
+        if self._contains_any(haystack, ("definition", "defineste", "in sensul", "se intelege", "defines")):
+            return "definition"
+        if self._contains_any(haystack, ("sanction", "sanctiune", "amenda", "contraventie", "sanctions")):
+            return "sanction"
+        if (plan and "procedure" in plan.query_types) or self._contains_any(
+            haystack,
+            ("procedura", "termen", "pasi", "contestatie", "cerere", "procedure_step"),
+        ):
+            return "procedure"
+        if self._contains_any(haystack, ("daca", "in cazul", "cu conditia", "numai daca")):
+            return "condition"
+        if self._graph_node_type(unit) in {"root", "domain", "legal_act", "title", "chapter", "section"}:
+            return "context"
+        return "direct_basis"
+
+    def _base_selection_reasons(self, ranked: RankedCandidate) -> list[str]:
+        reasons = list(ranked.why_ranked)
+        if ranked.rerank_score >= 0.70:
+            reasons.append("high_rerank_score")
+        return reasons
+
+    def _debug_payload(
+        self,
+        *,
+        fallback_used: bool,
+        input_ranked_candidate_count: int,
+        candidate_pool_size: int,
+        selected: list[_EvidenceCandidate],
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        return {
+            "fallback_used": fallback_used,
+            "input_ranked_candidate_count": input_ranked_candidate_count,
+            "candidate_pool_size": candidate_pool_size,
+            "selected_evidence_count": len(selected),
+            "lambda": self.mmr_lambda,
+            "target_evidence_units": self.target_evidence_units,
+            "max_evidence_units": self.max_evidence_units,
+            "selected_units": [
+                {
+                    "unit_id": candidate.ranked.unit_id,
+                    "rerank_score": candidate.ranked.rerank_score,
+                    "mmr_score": candidate.mmr_score,
+                    "support_role": candidate.support_role,
+                    "why_selected": self._dedupe(candidate.why_selected),
+                }
+                for candidate in selected
+            ],
+            "warnings": warnings,
+        }
+
+    def _candidate_text(self, unit: dict[str, Any]) -> str:
+        for key in ("raw_text", "normalized_text", "text"):
+            value = unit.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    def _has_required_metadata(self, unit: dict[str, Any]) -> bool:
+        return all(unit.get(key) for key in ("law_id", "law_title", "legal_domain"))
+
+    def _graph_node_type(self, unit: dict[str, Any]) -> str:
+        unit_type = self._normalize_text(str(unit.get("type") or unit.get("unit_type") or ""))
+        mapping = {
+            "root": "root",
+            "domain": "domain",
+            "subdomain": "subdomain",
+            "legal_act": "legal_act",
+            "act": "legal_act",
+            "title": "title",
+            "titlu": "title",
+            "chapter": "chapter",
+            "capitol": "chapter",
+            "section": "section",
+            "sectiune": "section",
+            "article": "article",
+            "articol": "article",
+            "paragraph": "paragraph",
+            "paragraf": "paragraph",
+            "alineat": "paragraph",
+            "letter": "letter",
+            "litera": "letter",
+            "point": "point",
+            "punct": "point",
+            "annex": "annex",
+            "anexa": "annex",
+            "concept": "concept",
+        }
+        if unit_type in mapping:
+            return mapping[unit_type]
+        if unit.get("paragraph_number"):
+            return "paragraph"
+        if unit.get("letter_number"):
+            return "letter"
+        if unit.get("point_number"):
+            return "point"
+        if unit.get("article_number"):
+            return "article"
+        return "article"
+
+    def _haystack(self, ranked: RankedCandidate, unit: dict[str, Any]) -> str:
+        values: list[str] = [ranked.unit_id]
+        values.extend(ranked.why_ranked)
+        values.append(str(ranked.source or ""))
+        values.append(str(unit))
+        return self._normalize_text(" ".join(values))
+
+    def _contains_any(self, haystack: str, terms: tuple[str, ...]) -> bool:
+        return any(self._normalize_text(term) in haystack for term in terms)
+
+    def _tokenize(self, text: str) -> set[str]:
+        normalized = self._normalize_text(text)
+        return {
+            token
+            for token in re.split(r"[^a-z0-9_]+", normalized)
+            if len(token) > 1 and token not in STOPWORDS
+        }
+
+    def _jaccard_similarity(self, left: set[str], right: set[str]) -> float:
+        if not left or not right:
+            return 0.0
+        return len(left & right) / len(left | right)
+
+    def _scalar_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in metadata.items()
+            if isinstance(value, str | int | float | bool) or value is None
+        }
+
+    def _append_reason(self, candidate: _EvidenceCandidate, reason: str) -> None:
+        if reason not in candidate.why_selected:
+            candidate.why_selected.append(reason)
+
+    def _dedupe(self, values: list[str]) -> list[str]:
+        deduped: list[str] = []
+        for value in values:
+            if value not in deduped:
+                deduped.append(value)
+        return deduped
+
+    def _str_list(self, value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [str(item) for item in value]
+
+    def _optional_str(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
+    def _normalize_text(self, text: str) -> str:
+        replacements = {
+            "Ã„Æ’": "a",
+            "Ã„â€š": "a",
+            "Ãˆâ„¢": "s",
+            "ÃˆËœ": "s",
+            "Ãˆâ€º": "t",
+            "ÃˆÅ¡": "t",
+            "ÃƒÂ¢": "a",
+            "ÃƒÂ®": "i",
+            "Ã…Å¸": "s",
+            "Ã…Â£": "t",
+        }
+        for broken, fixed in replacements.items():
+            text = text.replace(broken, fixed)
+        normalized = unicodedata.normalize("NFD", text.casefold())
+        stripped = "".join(
+            char for char in normalized if unicodedata.category(char) != "Mn"
+        )
+        return " ".join(stripped.replace(".", " ").replace("-", "_").split())
+
+    def _clamp(self, value: float) -> float:
+        return max(0.0, min(1.0, float(value)))

--- a/apps/api/app/services/mock_evidence.py
+++ b/apps/api/app/services/mock_evidence.py
@@ -14,8 +14,9 @@ from ..schemas import (
 
 MOCK_REFUSAL_REASON = "mock_evidence_pack_not_verified"
 MOCK_WARNING = (
-    "mock_unverified_evidence_pack: Phase 1 returns deterministic mock evidence "
-    "only; retrieval, LegalRanker, generation, and citation verification have not run."
+    "mock_unverified_answer: Phase 7 keeps answer generation and citation "
+    "verification mocked; compiled evidence, if present, is not converted into "
+    "a verified legal conclusion."
 )
 
 
@@ -42,7 +43,7 @@ class MockEvidenceService:
         answer = AnswerPayload(
             short_answer=(
                 "Phase 1 mock response only. No verified legal conclusion is provided; "
-                "the evidence below is deterministic placeholder data for API contract testing."
+                "Phase 7 may compile evidence units separately, but generation is not configured."
             ),
             detailed_answer=None,
             confidence=0.0,
@@ -72,7 +73,7 @@ class MockEvidenceService:
             warnings=warnings,
             debug_notes=[
                 "MockEvidenceService.build_pack returned static fixture data.",
-                "No database, vector search, graph expansion, ranker, generation, or verifier was called.",
+                "Generation and citation verification remain mocked and unverified.",
             ],
         )
 
@@ -117,12 +118,15 @@ class MockEvidenceService:
 
         return [
             EvidenceUnit(
+                **legal_unit.model_dump(),
                 evidence_id=f"mock-evidence-{index}",
-                legal_unit=legal_unit,
                 excerpt=excerpt,
                 rank=index,
                 relevance_score=0.0,
                 retrieval_method="mock_static_fixture",
+                retrieval_score=0.0,
+                rerank_score=0.0,
+                support_role="direct_basis",
                 warnings=[MOCK_WARNING],
             )
             for index, (legal_unit, excerpt) in enumerate(
@@ -136,7 +140,7 @@ class MockEvidenceService:
             Citation(
                 citation_id="mock-citation-1",
                 evidence_id=evidence_units[0].evidence_id,
-                legal_unit_id=evidence_units[0].legal_unit.id,
+                legal_unit_id=evidence_units[0].id,
                 label="Codul muncii art. 17 (mock, unverified)",
                 quote=evidence_units[0].excerpt,
                 verified=False,
@@ -144,7 +148,7 @@ class MockEvidenceService:
             Citation(
                 citation_id="mock-citation-2",
                 evidence_id=evidence_units[1].evidence_id,
-                legal_unit_id=evidence_units[1].legal_unit.id,
+                legal_unit_id=evidence_units[1].id,
                 label="Codul muncii art. 41 (mock, unverified)",
                 quote=evidence_units[1].excerpt,
                 verified=False,

--- a/docs/query-api.md
+++ b/docs/query-api.md
@@ -1,11 +1,11 @@
 # Query API
 
-Phase 6 exposes the `/api/query` contract, deterministic QueryUnderstanding,
+Phase 7 exposes the `/api/query` contract, deterministic QueryUnderstanding,
 DomainRouter debug data, ExactCitationDetector output, RawRetrieverClient
 request construction, GraphExpansionPolicy debug data, LegalRanker debug data,
-and a deterministic mock EvidencePack only. It is intended for frontend and API
-integration work before real retrieval, graph traversal, EvidencePack
-compilation, and answer generation are available.
+and EvidencePackCompiler MMR selection. It is intended for frontend and API
+integration work before real retrieval, graph traversal, answer generation, and
+citation verification are available.
 
 Not implemented yet:
 
@@ -13,7 +13,6 @@ Not implemented yet:
 - `/api/retrieve/raw`, which is owned by Handoff 04
 - graph/neighbors endpoints, which are owned by Handoff 04
 - database-backed graph expansion
-- EvidencePackCompiler, which is planned for Handoff 03 Phase 7
 - answer generation
 - citation verification
 
@@ -23,9 +22,10 @@ future lookup hints; they are not resolved against `legal_units` yet.
 RawRetrieverClient prepares the future raw retrieval payload. GraphExpansionPolicy
 turns raw retrieval candidates into graph expansion seeds and policy metadata.
 LegalRanker reranks raw and expanded candidates deterministically when they
-exist. If raw retrieval or graph neighbors are not configured, `/api/query`
-returns a safe fallback with `confidence: 0.0`, `verifier_passed: false`, and
-explicit warnings.
+exist. EvidencePackCompiler selects and diversifies ranked candidates with MMR
+when candidates include LegalUnit text. If raw retrieval or graph neighbors are
+not configured, `/api/query` returns a safe fallback with empty evidence,
+`confidence: 0.0`, `verifier_passed: false`, and explicit warnings.
 
 ## Request
 
@@ -48,23 +48,14 @@ curl -X POST http://localhost:8000/api/query \
   "query_id": "9f8d85df-8d8b-59d5-b905-f76c351c7f10",
   "question": "Poate angajatorul sa-mi scada salariul fara act aditional?",
   "answer": {
-    "short_answer": "Phase 1 mock response only. No verified legal conclusion is provided; the evidence below is deterministic placeholder data for API contract testing.",
+    "short_answer": "Phase 1 mock response only. No verified legal conclusion is provided; Phase 7 may compile evidence units separately, but generation is not configured.",
     "detailed_answer": null,
     "confidence": 0.0,
     "not_legal_advice": true,
     "refusal_reason": "mock_evidence_pack_not_verified"
   },
-  "citations": [
-    {
-      "citation_id": "mock-citation-1",
-      "evidence_id": "mock-evidence-1",
-      "legal_unit_id": "mock:ro:codul-muncii:art-17",
-      "label": "Codul muncii art. 17 (mock, unverified)",
-      "quote": "Mock excerpt for art. 17. This placeholder was not retrieved from an official source.",
-      "source_url": null,
-      "verified": false
-    }
-  ],
+  "citations": [],
+  "evidence_units": [],
   "verifier": {
     "groundedness_score": 0.0,
     "claims_total": 0,
@@ -75,7 +66,7 @@ curl -X POST http://localhost:8000/api/query \
     "verifier_passed": false,
     "claim_results": [],
     "warnings": [
-      "mock_unverified_evidence_pack: Phase 1 returns deterministic mock evidence only; retrieval, LegalRanker, generation, and citation verification have not run."
+      "mock_unverified_answer: Phase 7 keeps answer generation and citation verification mocked; compiled evidence, if present, is not converted into a verified legal conclusion."
     ],
     "repair_applied": false,
     "refusal_reason": "mock_evidence_pack_not_verified"
@@ -83,9 +74,52 @@ curl -X POST http://localhost:8000/api/query \
 }
 ```
 
+When ranked candidates contain LegalUnit text, `evidence_units` use a flat
+LegalUnit-plus-evidence shape. The LegalUnit fields are not nested under
+`legal_unit`.
+
+```json
+{
+  "evidence_units": [
+    {
+      "id": "ro.codul_muncii.art_41",
+      "law_id": "ro.codul_muncii",
+      "law_title": "Codul muncii",
+      "status": "active",
+      "hierarchy_path": ["Codul muncii", "art. 41"],
+      "article_number": "41",
+      "paragraph_number": null,
+      "raw_text": "Contractul individual de munca poate fi modificat prin acordul partilor.",
+      "normalized_text": null,
+      "legal_domain": "munca",
+      "legal_concepts": ["contract", "salariu"],
+      "source_url": "https://legislatie.just.ro/test",
+      "evidence_id": "evidence:ro.codul_muncii.art_41",
+      "excerpt": "Contractul individual de munca poate fi modificat prin acordul partilor.",
+      "rank": 1,
+      "relevance_score": 0.86,
+      "retrieval_method": "raw_retrieval",
+      "retrieval_score": 0.78,
+      "rerank_score": 0.86,
+      "mmr_score": 0.645,
+      "support_role": "direct_basis",
+      "why_selected": ["domain_match:munca", "selected_by_mmr"],
+      "score_breakdown": {
+        "bm25_score": 0.9,
+        "dense_score": 0.7,
+        "domain_match": 1.0,
+        "graph_proximity": 1.0
+      },
+      "warnings": []
+    }
+  ]
+}
+```
+
 When `debug` is `true`, the response includes a `debug` object with mock service
-counts, notes, `query_understanding`, `retrieval`, `graph_expansion`, and
-`legal_ranker`. When `debug` is `false`, `debug` is `null`.
+counts, notes, `query_understanding`, `retrieval`, `graph_expansion`,
+`legal_ranker`, and `evidence_pack`. When `debug` is `false`, `debug` is
+`null`.
 
 Example debug excerpt:
 
@@ -139,6 +173,55 @@ LegalRanker debug excerpt when no candidates are available:
       "ranked_candidates": [],
       "rows": [],
       "warnings": ["legal_ranker_no_candidates"]
+    }
+  }
+}
+```
+
+EvidencePackCompiler debug excerpt when no ranked candidates are available:
+
+```json
+{
+  "debug": {
+    "evidence_pack": {
+      "fallback_used": true,
+      "input_ranked_candidate_count": 0,
+      "candidate_pool_size": 0,
+      "selected_evidence_count": 0,
+      "lambda": 0.75,
+      "target_evidence_units": 12,
+      "max_evidence_units": 14,
+      "selected_units": [],
+      "warnings": ["evidence_pack_no_ranked_candidates"]
+    }
+  }
+}
+```
+
+EvidencePackCompiler debug excerpt with ranked fixture candidates:
+
+```json
+{
+  "debug": {
+    "evidence_pack": {
+      "fallback_used": false,
+      "input_ranked_candidate_count": 1,
+      "candidate_pool_size": 1,
+      "selected_evidence_count": 1,
+      "selected_units": [
+        {
+          "unit_id": "ro.codul_muncii.art_41",
+          "rerank_score": 0.86,
+          "mmr_score": 0.645,
+          "support_role": "direct_basis",
+          "why_selected": [
+            "domain_match:munca",
+            "high_bm25_score",
+            "selected_by_mmr"
+          ]
+        }
+      ],
+      "warnings": ["evidence_pack_partial"]
     }
   }
 }

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -1,6 +1,9 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from apps.api.app.main import app
+from apps.api.app.schemas import QueryRequest, RawRetrievalResponse, RetrievalCandidate
+from apps.api.app.services.query_orchestrator import QueryOrchestrator
 
 
 VALID_QUERY = {
@@ -16,7 +19,7 @@ def post_query(payload: dict) -> object:
         return client.post("/api/query", json=payload)
 
 
-def test_post_api_query_returns_mock_evidence_pack():
+def test_post_api_query_returns_unverified_fallback_without_retrieval():
     response = post_query({**VALID_QUERY, "debug": False})
 
     assert response.status_code == 200
@@ -26,12 +29,12 @@ def test_post_api_query_returns_mock_evidence_pack():
     assert payload["answer"]["confidence"] == 0.0
     assert payload["answer"]["not_legal_advice"] is True
     assert payload["answer"]["refusal_reason"] == "mock_evidence_pack_not_verified"
-    assert len(payload["citations"]) >= 2
-    assert len(payload["evidence_units"]) >= 3
+    assert payload["citations"] == []
+    assert payload["evidence_units"] == []
     assert payload["verifier"]["verifier_passed"] is False
-    assert payload["graph"]["nodes"]
-    assert payload["graph"]["edges"]
-    assert payload["warnings"]
+    assert payload["graph"]["nodes"] == []
+    assert payload["graph"]["edges"] == []
+    assert "evidence_pack_no_ranked_candidates" in payload["warnings"]
 
 
 def test_post_api_query_uses_snake_case_fields():
@@ -40,9 +43,9 @@ def test_post_api_query_uses_snake_case_fields():
     payload = response.json()
     assert "query_id" in payload
     assert "short_answer" in payload["answer"]
-    assert "id" in payload["evidence_units"][0]["legal_unit"]
     assert "groundedness_score" in payload["verifier"]
-    assert "source" in payload["graph"]["edges"][0]
+    assert "evidence_units" in payload
+    assert "nodes" in payload["graph"]
 
 
 def test_post_api_query_debug_true_includes_debug_payload():
@@ -52,7 +55,7 @@ def test_post_api_query_debug_true_includes_debug_payload():
     debug = response.json()["debug"]
     assert debug["orchestrator"] == "QueryOrchestrator"
     assert debug["evidence_service"] == "MockEvidenceService"
-    assert debug["evidence_units_count"] >= 3
+    assert debug["evidence_units_count"] == 0
     assert debug["query_understanding"]["legal_domain"] == "muncă"
     assert debug["query_understanding"]["domain_confidence"] >= 0.70
     assert "prohibition" in debug["query_understanding"]["query_types"]
@@ -81,6 +84,11 @@ def test_post_api_query_debug_true_includes_debug_payload():
     assert legal_ranker["ranked_candidate_count"] == 0
     assert legal_ranker["ranked_candidates"] == []
     assert "legal_ranker_no_candidates" in legal_ranker["warnings"]
+    evidence_pack = debug["evidence_pack"]
+    assert evidence_pack["fallback_used"] is True
+    assert evidence_pack["input_ranked_candidate_count"] == 0
+    assert evidence_pack["selected_evidence_count"] == 0
+    assert "evidence_pack_no_ranked_candidates" in evidence_pack["warnings"]
 
 
 def test_post_api_query_debug_false_returns_null_debug():
@@ -92,6 +100,7 @@ def test_post_api_query_debug_false_returns_null_debug():
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
     assert "legal_ranker_no_candidates" in payload["warnings"]
+    assert "evidence_pack_no_ranked_candidates" in payload["warnings"]
 
 
 def test_post_api_query_debug_true_includes_exact_citations():
@@ -125,13 +134,89 @@ def test_post_api_query_debug_true_includes_exact_citations():
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
     assert "legal_ranker_no_candidates" in payload["warnings"]
+    assert "evidence_pack_no_ranked_candidates" in payload["warnings"]
     assert payload["debug"]["graph_expansion"]["fallback_used"] is True
     assert payload["debug"]["legal_ranker"]["fallback_used"] is True
+    assert payload["debug"]["evidence_pack"]["fallback_used"] is True
+
+
+class FakeRawRetrieverClient:
+    async def retrieve(self, plan, *, top_k: int = 50, debug: bool = False):
+        return RawRetrievalResponse(
+            candidates=[
+                RetrievalCandidate(
+                    unit_id="ro.codul_muncii.art_41",
+                    rank=1,
+                    retrieval_score=0.78,
+                    score_breakdown={"bm25": 0.9, "dense": 0.7},
+                    why_retrieved="fixture_candidate",
+                    unit={
+                        "id": "ro.codul_muncii.art_41",
+                        "law_id": "ro.codul_muncii",
+                        "law_title": "Codul muncii",
+                        "status": "active",
+                        "hierarchy_path": ["Codul muncii", "art. 41"],
+                        "article_number": "41",
+                        "raw_text": "Contractul individual de munca poate fi modificat prin acordul partilor.",
+                        "legal_domain": "munca",
+                        "legal_concepts": ["contract", "salariu"],
+                        "source_url": "https://legislatie.just.ro/test",
+                        "type": "articol",
+                    },
+                )
+            ],
+            retrieval_methods=["fixture"],
+            warnings=[],
+            debug={
+                "fallback_used": False,
+                "request_payload": {
+                    "question": plan.question,
+                    "retrieval_filters": plan.retrieval_filters,
+                    "exact_citations": [],
+                    "top_k": top_k,
+                    "debug": debug,
+                },
+            }
+            if debug
+            else None,
+        )
+
+
+@pytest.mark.anyio
+async def test_query_orchestrator_populates_evidence_units_with_fake_candidates():
+    orchestrator = QueryOrchestrator(raw_retriever_client=FakeRawRetrieverClient())
+    response = await orchestrator.run(QueryRequest(**VALID_QUERY, debug=True))
+
+    assert len(response.evidence_units) == 1
+    evidence = response.evidence_units[0]
+    assert evidence.id == "ro.codul_muncii.art_41"
+    assert evidence.law_title == "Codul muncii"
+    assert evidence.raw_text == "Contractul individual de munca poate fi modificat prin acordul partilor."
+    assert evidence.excerpt == "Contractul individual de munca poate fi modificat prin acordul partilor."
+    assert evidence.retrieval_score == 0.78
+    assert evidence.rerank_score is not None
+    assert evidence.support_role in {"direct_basis", "condition"}
+    assert "selected_by_mmr" in evidence.why_selected
+    assert evidence.score_breakdown
+    evidence_payload = response.model_dump(mode="json")["evidence_units"][0]
+    assert "legal_unit" not in evidence_payload
+    assert evidence_payload["id"] == "ro.codul_muncii.art_41"
+    assert evidence_payload["law_title"] == "Codul muncii"
+    assert evidence_payload["retrieval_score"] == 0.78
+    assert evidence_payload["support_role"] in {"direct_basis", "condition"}
+    assert isinstance(evidence_payload["why_selected"], list)
+    assert evidence_payload["score_breakdown"]
+    assert response.graph.nodes
+    assert response.debug.evidence_pack["fallback_used"] is False
+    assert response.debug.evidence_pack["selected_evidence_count"] == 1
+    assert response.answer.confidence == 0.0
+    assert response.verifier.verifier_passed is False
 
 
 def test_handoff04_graph_endpoints_are_not_registered():
     paths = {route.path for route in app.routes}
 
+    assert "/api/retrieve/raw" not in paths
     assert "/api/legal-units/{id}/neighbors" not in paths
     assert "/api/explore/root" not in paths
     assert "/api/explore/node/{id}/children" not in paths

--- a/tests/test_evidence_pack_compiler.py
+++ b/tests/test_evidence_pack_compiler.py
@@ -1,0 +1,235 @@
+from apps.api.app.schemas import (
+    GraphExpansionResult,
+    RankedCandidate,
+    RankerFeatureBreakdown,
+)
+from apps.api.app.services.evidence_pack_compiler import (
+    EVIDENCE_PACK_NO_RANKED_CANDIDATES,
+    EvidencePackCompiler,
+)
+
+
+def unit(unit_id: str, text: str, **overrides):
+    data = {
+        "id": unit_id,
+        "law_id": "ro.codul_muncii",
+        "law_title": "Codul muncii",
+        "status": "active",
+        "hierarchy_path": ["Codul muncii"],
+        "article_number": "41",
+        "raw_text": text,
+        "legal_domain": "munca",
+        "legal_concepts": ["salariu", "contract"],
+        "source_url": "https://legislatie.just.ro/test",
+        "type": "articol",
+    }
+    data.update(overrides)
+    return data
+
+
+def ranked(
+    unit_id: str,
+    *,
+    rank: int = 1,
+    score: float = 0.8,
+    text: str = "salariu contract act aditional",
+    why_ranked: list[str] | None = None,
+    unit_overrides: dict | None = None,
+) -> RankedCandidate:
+    return RankedCandidate(
+        unit_id=unit_id,
+        rank=rank,
+        rerank_score=score,
+        retrieval_score=score - 0.1,
+        unit=unit(unit_id, text, **(unit_overrides or {})),
+        score_breakdown=RankerFeatureBreakdown(
+            bm25_score=score,
+            dense_score=score,
+            domain_match=1.0,
+            graph_proximity=1.0,
+        ),
+        why_ranked=why_ranked or ["domain_match:munca"],
+        source="raw_retrieval",
+    )
+
+
+def test_no_ranked_candidates_returns_safe_fallback():
+    result = EvidencePackCompiler().compile(
+        ranked_candidates=[],
+        debug=True,
+    )
+
+    assert result.evidence_units == []
+    assert result.graph_nodes == []
+    assert result.graph_edges == []
+    assert result.warnings == [EVIDENCE_PACK_NO_RANKED_CANDIDATES]
+    assert result.debug["fallback_used"] is True
+    assert result.debug["input_ranked_candidate_count"] == 0
+    assert result.debug["selected_evidence_count"] == 0
+
+
+def test_mmr_penalizes_redundant_text_and_diversifies_selection():
+    compiler = EvidencePackCompiler(target_evidence_units=2, max_evidence_units=2)
+    first = ranked(
+        "ro.codul_muncii.art_41",
+        rank=1,
+        score=0.9,
+        text="salariu contract act aditional angajator",
+    )
+    redundant = ranked(
+        "ro.codul_muncii.art_42",
+        rank=2,
+        score=0.88,
+        text="salariu contract act aditional angajator",
+    )
+    diverse = ranked(
+        "ro.codul_muncii.art_260",
+        rank=3,
+        score=0.7,
+        text="amenda contraventie inspectorat sanctiune",
+    )
+
+    result = compiler.compile(
+        ranked_candidates=[first, redundant, diverse],
+        debug=True,
+    )
+
+    assert [item.id for item in result.evidence_units] == [
+        "ro.codul_muncii.art_41",
+        "ro.codul_muncii.art_260",
+    ]
+    assert result.debug["selected_units"][1]["unit_id"] == "ro.codul_muncii.art_260"
+
+
+def test_duplicate_unit_ids_are_selected_once():
+    result = EvidencePackCompiler(target_evidence_units=3).compile(
+        ranked_candidates=[
+            ranked("ro.codul_muncii.art_41", rank=1, score=0.7),
+            ranked("ro.codul_muncii.art_41", rank=2, score=0.9),
+        ],
+        debug=True,
+    )
+
+    assert len(result.evidence_units) == 1
+    assert result.evidence_units[0].id == "ro.codul_muncii.art_41"
+
+
+def test_support_roles_are_classified_deterministically():
+    compiler = EvidencePackCompiler(target_evidence_units=4, max_evidence_units=4)
+    result = compiler.compile(
+        ranked_candidates=[
+            ranked(
+                "ro.codul_muncii.exception",
+                rank=1,
+                score=0.9,
+                text="Cu exceptia cazurilor prevazute de lege.",
+                why_ranked=["exception_candidate"],
+            ),
+            ranked(
+                "ro.codul_muncii.definition",
+                rank=2,
+                score=0.8,
+                text="In sensul prezentei legi, salariatul se intelege ca persoana fizica.",
+                why_ranked=["definition_candidate"],
+            ),
+            ranked(
+                "ro.codul_muncii.sanction",
+                rank=3,
+                score=0.7,
+                text="Constituie contraventie si se sanctioneaza cu amenda.",
+                why_ranked=["sanction_candidate"],
+            ),
+            ranked(
+                "ro.codul_muncii.condition",
+                rank=4,
+                score=0.6,
+                text="Modificarea se poate face numai daca partile sunt de acord.",
+            ),
+        ],
+        debug=True,
+    )
+
+    roles = {
+        evidence.id: evidence.support_role
+        for evidence in result.evidence_units
+    }
+    assert roles["ro.codul_muncii.exception"] == "exception"
+    assert roles["ro.codul_muncii.definition"] == "definition"
+    assert roles["ro.codul_muncii.sanction"] == "sanction"
+    assert roles["ro.codul_muncii.condition"] == "condition"
+
+
+def test_parent_context_is_included_only_when_parent_exists_in_input():
+    compiler = EvidencePackCompiler(target_evidence_units=1, max_evidence_units=2)
+    child = ranked(
+        "ro.codul_muncii.art_41.alin_1",
+        rank=1,
+        score=0.9,
+        unit_overrides={
+            "paragraph_number": "1",
+            "parent_id": "ro.codul_muncii.art_41",
+            "type": "alineat",
+        },
+    )
+    parent = ranked(
+        "ro.codul_muncii.art_41",
+        rank=2,
+        score=0.2,
+        text="Articolul 41 reglementeaza modificarea contractului.",
+        unit_overrides={"type": "articol"},
+    )
+
+    result = compiler.compile(
+        ranked_candidates=[child, parent],
+        graph_expansion=GraphExpansionResult(),
+        debug=True,
+    )
+
+    assert [evidence.id for evidence in result.evidence_units] == [
+        "ro.codul_muncii.art_41.alin_1",
+        "ro.codul_muncii.art_41",
+    ]
+    assert result.evidence_units[1].support_role == "context"
+
+
+def test_parent_context_is_not_included_when_parent_is_missing():
+    compiler = EvidencePackCompiler(target_evidence_units=1, max_evidence_units=2)
+    child = ranked(
+        "ro.codul_muncii.art_41.alin_1",
+        rank=1,
+        score=0.9,
+        unit_overrides={
+            "paragraph_number": "1",
+            "parent_id": "ro.codul_muncii.art_41",
+            "type": "alineat",
+        },
+    )
+
+    result = compiler.compile(ranked_candidates=[child], debug=True)
+
+    assert [evidence.id for evidence in result.evidence_units] == [
+        "ro.codul_muncii.art_41.alin_1",
+    ]
+
+
+def test_compiler_preserves_text_source_scores_and_selection_reasons():
+    result = EvidencePackCompiler(target_evidence_units=1).compile(
+        ranked_candidates=[
+            ranked(
+                "ro.codul_muncii.art_41",
+                score=0.86,
+                why_ranked=["domain_match:munca", "high_bm25_score"],
+            )
+        ],
+        debug=True,
+    )
+
+    evidence = result.evidence_units[0]
+    assert evidence.id == "ro.codul_muncii.art_41"
+    assert evidence.excerpt == "salariu contract act aditional"
+    assert evidence.source_url == "https://legislatie.just.ro/test"
+    assert evidence.rerank_score == 0.86
+    assert evidence.retrieval_score == 0.76
+    assert evidence.score_breakdown["bm25_score"] == 0.86
+    assert "high_bm25_score" in evidence.why_selected
+    assert "selected_by_mmr" in evidence.why_selected


### PR DESCRIPTION
This pull request implements Phase 7 of the `/api/query` contract, introducing support for EvidencePackCompiler-style evidence unit selection and MMR (Maximal Marginal Relevance) diversification, along with substantial updates to the API schema, documentation, and tests. The changes move the evidence representation to a flat, enriched structure, add new debug information, and ensure the API contract and tests reflect the new evidence selection logic and fallback behavior.

The most important changes include:

**API Schema and Evidence Representation:**

* The `EvidenceUnit` model now inherits from `LegalUnit` and is flattened, removing the nested `legal_unit` field. It includes additional fields for retrieval, rerank, MMR scores, support role, selection reasons, and score breakdowns. This enables direct representation of selected legal evidence units with detailed provenance and scoring information.
* The `QueryDebugData` schema is extended to include an `evidence_pack` field, which provides debug information about the evidence selection process.

**Mock Evidence Service and Fallback Behavior:**

* The mock evidence service and its warnings/messages have been updated to reflect Phase 7: answer generation and citation verification remain mocked, and fallback responses are provided when no ranked candidates are available. [[1]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL17-R19) [[2]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL45-R46) [[3]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL75-R76)
* Evidence units are now constructed with the flat, enriched schema, and citations reference the unit's top-level `id` rather than a nested field. [[1]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baR121-R129) [[2]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL139-R151)

**Documentation Updates:**

* The `docs/query-api.md` has been thoroughly updated to describe Phase 7, the new evidence unit structure, the EvidencePackCompiler debug payloads, and updated example requests/responses. It clarifies the fallback and evidence selection logic and provides new JSON examples. [[1]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL3-L16) [[2]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL26-R28) [[3]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL51-R58) [[4]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL78-R122) [[5]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aR181-R229)

**Testing Improvements:**

* Tests have been updated to expect the new evidence structure, fallback behavior, and debug payloads. Assertions reflect that evidence and citations are empty when no candidates are available, and new tests verify the population of evidence units when ranked candidates are present. A new async test with a fake retriever client ensures that the evidence unit structure and debug output are correct when candidates exist. [[1]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R1-R6) [[2]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L19-R22) [[3]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L29-R37) [[4]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L43-R48) [[5]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L55-R58) [[6]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R87-R91) [[7]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R103) [[8]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R137-R219)

**Other Fixes and Cleanups:**

* Minor changes to ensure snake_case field names in API responses and to clarify test and fallback behaviors. [[1]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L43-R48) [[2]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L19-R22)

These changes collectively advance the `/api/query` endpoint to support evidence selection and debugging for frontend and integration work, in preparation for future implementation of generation and verification.

**References:**  
[[1]](diffhunk://#diff-f14d76d4a4582f33ea6ddb2e237372a3e64bba18a9eab0c980af1af918190d63L54-R73) [[2]](diffhunk://#diff-f14d76d4a4582f33ea6ddb2e237372a3e64bba18a9eab0c980af1af918190d63R240) [[3]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL17-R19) [[4]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL45-R46) [[5]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL75-R76) [[6]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baR121-R129) [[7]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL139-R151) [[8]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL3-L16) [[9]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL26-R28) [[10]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL51-R58) [[11]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL78-R122) [[12]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aR181-R229) [[13]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R1-R6) [[14]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L19-R22) [[15]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L29-R37) [[16]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L43-R48) [[17]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L55-R58) [[18]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R87-R91) [[19]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R103) [[20]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R137-R219)