### PR TITLE
Feat/canonical parser contracts foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Run the following command to scrape and parse a law directly from a link:
 
 ```powershell
 python scripts/ingest_single.py `
-    --url "https://legislatie.just.ro/Public/DetaliiDocument/224200" `
-    --law-id "ro.codul_muncii_2003" `
-    --out-dir ingestion/output/my_law_bundle
+    --url "https://web.archive.org/web/20250405171446mp_/https://legislatie.just.ro/Public/FormaPrintabila/00000G1KT5P4C47BW0232MK2YPXFN5DI" `
+    --law-id "ro.archive_lege_test" `
+    --out-dir ingestion/output/archive_test_bundle
+
 ```
 
 ### Option 2: Using a Local HTML File

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -6,6 +6,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from .db import dispose_engine
 from .routes.health import health, router as health_router
 from .routes.query import router as query_router
+from .routes.ingest import router as ingest_router
+from .routes.corpus import router as corpus_router
+from .routes.legal_units import router as legal_units_router
 from .config import settings
 
 
@@ -31,6 +34,9 @@ def create_app() -> FastAPI:
     )
     app.include_router(health_router, prefix="/api")
     app.include_router(query_router, prefix="/api")
+    app.include_router(ingest_router, prefix="/api")
+    app.include_router(corpus_router, prefix="/api")
+    app.include_router(legal_units_router, prefix="/api")
     app.add_api_route(
         "/health",
         health,

--- a/apps/api/app/routes/ingest.py
+++ b/apps/api/app/routes/ingest.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, HTTPException, BackgroundTasks
+from pydantic import BaseModel, HttpUrl
+from typing import Optional
+import subprocess
+from pathlib import Path
+
+router = APIRouter(prefix="/ingest", tags=["ingestion"])
+
+class IngestRequest(BaseModel):
+    url: HttpUrl
+    law_id: str
+    out_dir: Optional[str] = "ingestion/output/auto_ingest"
+
+class IngestResponse(BaseModel):
+    message: str
+    job_id: str
+
+def run_ingestion_task(url: str, law_id: str, out_dir: str):
+    # This runs the script we just built
+    cmd = [
+        "python", "scripts/ingest_single.py",
+        "--url", str(url),
+        "--law-id", law_id,
+        "--out-dir", out_dir
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+        print(f"Successfully ingested {law_id}")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to ingest {law_id}: {e}")
+
+@router.post("/", response_model=IngestResponse)
+async def trigger_ingestion(request: IngestRequest, background_tasks: BackgroundTasks):
+    """
+    Trigger a single-URL ingestion pipeline in the background.
+    """
+    background_tasks.add_task(
+        run_ingestion_task, 
+        str(request.url), 
+        request.law_id, 
+        request.out_dir
+    )
+    return {
+        "message": "Ingestion job started in the background",
+        "job_id": request.law_id
+    }

--- a/apps/api/app/routes/legal_units.py
+++ b/apps/api/app/routes/legal_units.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException
+from typing import List
+from pathlib import Path
+import json
+from ..schemas.legal import LegalUnit, LegalUnitList
+
+router = APIRouter(prefix="/legal-units", tags=["legal-units"])
+
+OUTPUT_BASE = Path("ingestion/output")
+
+@router.get("/{corpus_id}", response_model=LegalUnitList)
+async def get_legal_units(corpus_id: str, skip: int = 0, limit: int = 100):
+    """
+    Get the atomic units for a specific corpus.
+    """
+    units_file = OUTPUT_BASE / corpus_id / "legal_units.json"
+    if not units_file.exists():
+        raise HTTPException(status_code=404, detail="Corpus not found")
+
+    try:
+        with open(units_file, "r", encoding="utf-8") as f:
+            all_units = json.load(f)
+        
+        # Paginate
+        paginated = all_units[skip : skip + limit]
+        
+        return {
+            "units": paginated,
+            "total": len(all_units)
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error reading units: {str(e)}")

--- a/apps/api/app/schemas/__init__.py
+++ b/apps/api/app/schemas/__init__.py
@@ -18,6 +18,11 @@ from .graph import (
     ExpandedCandidate,
     GraphExpansionResult,
 )
+from .ranking import (
+    LegalRankerResult,
+    RankedCandidate,
+    RankerFeatureBreakdown,
+)
 from .retrieval import (
     RawRetrievalRequest,
     RawRetrievalResponse,
@@ -36,10 +41,13 @@ __all__ = [
     "GraphNode",
     "GraphPayload",
     "LegalUnit",
+    "LegalRankerResult",
     "QueryDebugData",
     "QueryPlan",
     "QueryRequest",
     "QueryResponse",
+    "RankedCandidate",
+    "RankerFeatureBreakdown",
     "VerifierStatus",
     "RawRetrievalRequest",
     "RawRetrievalResponse",

--- a/apps/api/app/schemas/corpus.py
+++ b/apps/api/app/schemas/corpus.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class CorpusBase(BaseModel):
+    id: str
+    title: str
+    source_url: Optional[str] = None
+
+class CorpusCreate(CorpusBase):
+    pass
+
+class Corpus(CorpusBase):
+    unit_count: int = 0
+    
+    class Config:
+        from_attributes = True
+
+class CorpusList(BaseModel):
+    items: List[Corpus]

--- a/apps/api/app/schemas/legal.py
+++ b/apps/api/app/schemas/legal.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+
+class ReferenceSchema(BaseModel):
+    raw_reference: str
+    target_article: Optional[str] = None
+    target_paragraph: Optional[str] = None
+    target_letter: Optional[str] = None
+    target_id: Optional[str] = None
+
+class LegalUnitBase(BaseModel):
+    id: str
+    path: str
+    type: str
+    text: str
+    references: List[ReferenceSchema] = []
+
+class LegalUnit(LegalUnitBase):
+    metadata: Dict[str, Any] = {}
+
+    class Config:
+        from_attributes = True
+
+class LegalUnitList(BaseModel):
+    units: List[LegalUnit]
+    total: int

--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -158,6 +158,7 @@ class QueryDebugData(BaseModel):
     query_understanding: QueryPlan | None = None
     retrieval: dict[str, Any] | None = None
     graph_expansion: dict[str, Any] | None = None
+    legal_ranker: dict[str, Any] | None = None
     evidence_units_count: int = Field(..., ge=0)
     citations_count: int = Field(..., ge=0)
     graph_nodes_count: int = Field(..., ge=0)

--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -51,13 +51,26 @@ class LegalUnit(BaseModel):
     incoming_reference_ids: list[str] = Field(default_factory=list)
 
 
-class EvidenceUnit(BaseModel):
+class EvidenceUnit(LegalUnit):
     evidence_id: str
-    legal_unit: LegalUnit
     excerpt: str
     rank: int = Field(..., ge=1)
     relevance_score: float = Field(..., ge=0.0, le=1.0)
     retrieval_method: str
+    retrieval_score: float = 0.0
+    rerank_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    mmr_score: float | None = None
+    support_role: Literal[
+        "direct_basis",
+        "definition",
+        "condition",
+        "exception",
+        "sanction",
+        "procedure",
+        "context",
+    ] = "direct_basis"
+    why_selected: list[str] = Field(default_factory=list)
+    score_breakdown: dict[str, float] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
 
 
@@ -224,6 +237,7 @@ class QueryDebugData(BaseModel):
     retrieval: dict[str, Any] | None = None
     graph_expansion: dict[str, Any] | None = None
     legal_ranker: dict[str, Any] | None = None
+    evidence_pack: dict[str, Any] | None = None
     evidence_units_count: int = Field(..., ge=0)
     citations_count: int = Field(..., ge=0)
     graph_nodes_count: int = Field(..., ge=0)

--- a/apps/api/app/schemas/ranking.py
+++ b/apps/api/app/schemas/ranking.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RankerFeatureBreakdown(BaseModel):
+    bm25_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    dense_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    exact_citation_match: float = Field(default=0.0, ge=0.0, le=1.0)
+    domain_match: float = Field(default=0.0, ge=0.0, le=1.0)
+    graph_proximity: float = Field(default=0.0, ge=0.0, le=1.0)
+    concept_overlap: float = Field(default=0.0, ge=0.0, le=1.0)
+    legal_term_overlap: float = Field(default=0.0, ge=0.0, le=1.0)
+    temporal_validity: float = Field(default=0.0, ge=0.0, le=1.0)
+    source_reliability: float = Field(default=0.0, ge=0.0, le=1.0)
+    parent_relevance: float = Field(default=0.0, ge=0.0, le=1.0)
+    is_exception: float = Field(default=0.0, ge=0.0, le=1.0)
+    is_definition: float = Field(default=0.0, ge=0.0, le=1.0)
+    is_sanction: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class RankedCandidate(BaseModel):
+    unit_id: str
+    rank: int = Field(..., ge=1)
+    rerank_score: float = Field(..., ge=0.0, le=1.0)
+    retrieval_score: float | None = None
+    unit: dict[str, Any] | None = None
+    score_breakdown: RankerFeatureBreakdown
+    why_ranked: list[str] = Field(default_factory=list)
+    source: str | None = None
+
+
+class LegalRankerResult(BaseModel):
+    ranked_candidates: list[RankedCandidate] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    debug: dict[str, Any] | None = None

--- a/apps/api/app/services/evidence_pack_compiler.py
+++ b/apps/api/app/services/evidence_pack_compiler.py
@@ -1,0 +1,663 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+import unicodedata
+from typing import Any
+
+from ..schemas import (
+    EvidencePackResult,
+    EvidenceUnit,
+    GraphEdge,
+    GraphExpansionResult,
+    GraphNode,
+    LegalUnit,
+    QueryPlan,
+    RankedCandidate,
+)
+
+EVIDENCE_PACK_NO_RANKED_CANDIDATES = "evidence_pack_no_ranked_candidates"
+EVIDENCE_PACK_PARTIAL = "evidence_pack_partial"
+EVIDENCE_PACK_MISSING_UNIT_TEXT = "evidence_pack_missing_unit_text"
+EVIDENCE_PACK_MISSING_UNIT_METADATA = "evidence_pack_missing_unit_metadata"
+
+SUPPORT_ROLES = (
+    "direct_basis",
+    "definition",
+    "condition",
+    "exception",
+    "sanction",
+    "procedure",
+    "context",
+)
+
+STOPWORDS = {
+    "a",
+    "al",
+    "ale",
+    "alin",
+    "art",
+    "cu",
+    "de",
+    "din",
+    "este",
+    "fara",
+    "in",
+    "la",
+    "pe",
+    "sau",
+    "se",
+    "si",
+}
+
+
+@dataclass
+class _EvidenceCandidate:
+    ranked: RankedCandidate
+    unit: dict[str, Any]
+    text: str
+    tokens: set[str]
+    support_role: str
+    why_selected: list[str] = field(default_factory=list)
+    mmr_score: float = 0.0
+
+
+class EvidencePackCompiler:
+    def __init__(
+        self,
+        mmr_lambda: float = 0.75,
+        candidate_pool_size: int = 40,
+        target_evidence_units: int = 12,
+        max_evidence_units: int = 14,
+    ) -> None:
+        self.mmr_lambda = mmr_lambda
+        self.candidate_pool_size = candidate_pool_size
+        self.target_evidence_units = target_evidence_units
+        self.max_evidence_units = max_evidence_units
+
+    def compile(
+        self,
+        *,
+        ranked_candidates: list[RankedCandidate],
+        graph_expansion: GraphExpansionResult | None = None,
+        plan: QueryPlan | None = None,
+        debug: bool = False,
+    ) -> EvidencePackResult:
+        if not ranked_candidates:
+            return self._fallback_result(debug=debug)
+
+        warnings: list[str] = []
+        unique_ranked = self._dedupe_ranked_candidates(ranked_candidates)
+        candidate_pool = self._candidate_pool(unique_ranked, plan=plan, warnings=warnings)
+        if not candidate_pool:
+            warnings.append(EVIDENCE_PACK_NO_RANKED_CANDIDATES)
+            return self._empty_result(
+                debug=debug,
+                input_ranked_candidate_count=len(ranked_candidates),
+                warnings=self._dedupe(warnings),
+            )
+
+        selected = self._select_with_mmr(candidate_pool)
+        self._ensure_role_candidate(selected, candidate_pool, "exception")
+        self._ensure_role_candidate(selected, candidate_pool, "definition")
+        self._ensure_role_candidate(selected, candidate_pool, "sanction")
+        self._include_parent_context(selected, candidate_pool)
+
+        if len(selected) < min(self.target_evidence_units, 8):
+            warnings.append(EVIDENCE_PACK_PARTIAL)
+
+        evidence_units = [
+            self._evidence_unit(candidate, rank=index)
+            for index, candidate in enumerate(selected, start=1)
+        ]
+        graph_nodes, graph_edges = self._build_graph(
+            selected=selected,
+            graph_expansion=graph_expansion,
+        )
+
+        result = EvidencePackResult(
+            evidence_units=evidence_units,
+            graph_nodes=graph_nodes,
+            graph_edges=graph_edges,
+            warnings=self._dedupe(warnings),
+            debug=None,
+        )
+        if debug:
+            result.debug = self._debug_payload(
+                fallback_used=False,
+                input_ranked_candidate_count=len(ranked_candidates),
+                candidate_pool_size=len(candidate_pool),
+                selected=selected,
+                warnings=result.warnings,
+            )
+        return result
+
+    def _fallback_result(self, *, debug: bool) -> EvidencePackResult:
+        warnings = [EVIDENCE_PACK_NO_RANKED_CANDIDATES]
+        result = EvidencePackResult(warnings=warnings)
+        if debug:
+            result.debug = {
+                "fallback_used": True,
+                "input_ranked_candidate_count": 0,
+                "candidate_pool_size": 0,
+                "selected_evidence_count": 0,
+                "lambda": self.mmr_lambda,
+                "target_evidence_units": self.target_evidence_units,
+                "max_evidence_units": self.max_evidence_units,
+                "selected_units": [],
+                "warnings": warnings,
+            }
+        return result
+
+    def _empty_result(
+        self,
+        *,
+        debug: bool,
+        input_ranked_candidate_count: int,
+        warnings: list[str],
+    ) -> EvidencePackResult:
+        result = EvidencePackResult(warnings=warnings)
+        if debug:
+            result.debug = {
+                "fallback_used": True,
+                "input_ranked_candidate_count": input_ranked_candidate_count,
+                "candidate_pool_size": 0,
+                "selected_evidence_count": 0,
+                "lambda": self.mmr_lambda,
+                "target_evidence_units": self.target_evidence_units,
+                "max_evidence_units": self.max_evidence_units,
+                "selected_units": [],
+                "warnings": warnings,
+            }
+        return result
+
+    def _dedupe_ranked_candidates(
+        self,
+        ranked_candidates: list[RankedCandidate],
+    ) -> list[RankedCandidate]:
+        best_by_unit_id: dict[str, RankedCandidate] = {}
+        for candidate in ranked_candidates:
+            current = best_by_unit_id.get(candidate.unit_id)
+            if current is None or self._candidate_quality(candidate) > self._candidate_quality(current):
+                best_by_unit_id[candidate.unit_id] = candidate
+        return sorted(
+            best_by_unit_id.values(),
+            key=lambda candidate: (candidate.rank, -candidate.rerank_score, candidate.unit_id),
+        )
+
+    def _candidate_quality(self, candidate: RankedCandidate) -> tuple[int, float, int]:
+        unit = candidate.unit or {}
+        info_score = sum(1 for value in unit.values() if value not in (None, "", [], {}))
+        text_score = 1 if self._candidate_text(unit) else 0
+        return (text_score, candidate.rerank_score, info_score)
+
+    def _candidate_pool(
+        self,
+        ranked_candidates: list[RankedCandidate],
+        *,
+        plan: QueryPlan | None,
+        warnings: list[str],
+    ) -> list[_EvidenceCandidate]:
+        pool: list[_EvidenceCandidate] = []
+        missing_text = False
+        missing_metadata = False
+        for ranked in ranked_candidates[: self.candidate_pool_size]:
+            unit = ranked.unit or {}
+            text = self._candidate_text(unit)
+            if not unit or not text:
+                missing_text = True
+                continue
+            if not self._has_required_metadata(unit):
+                missing_metadata = True
+            pool.append(
+                _EvidenceCandidate(
+                    ranked=ranked,
+                    unit=unit,
+                    text=text,
+                    tokens=self._tokenize(text),
+                    support_role=self._support_role(ranked, unit, plan=plan),
+                    why_selected=self._base_selection_reasons(ranked),
+                )
+            )
+        if missing_text:
+            warnings.append(EVIDENCE_PACK_MISSING_UNIT_TEXT)
+        if missing_metadata:
+            warnings.append(EVIDENCE_PACK_MISSING_UNIT_METADATA)
+        return pool
+
+    def _select_with_mmr(
+        self,
+        candidate_pool: list[_EvidenceCandidate],
+    ) -> list[_EvidenceCandidate]:
+        remaining = candidate_pool.copy()
+        selected: list[_EvidenceCandidate] = []
+        target = min(self.target_evidence_units, len(candidate_pool))
+        while remaining and len(selected) < target:
+            best = max(
+                remaining,
+                key=lambda candidate: self._mmr_sort_key(candidate, selected),
+            )
+            best.mmr_score = self._mmr_score(best, selected)
+            self._append_reason(best, "selected_by_mmr")
+            selected.append(best)
+            remaining.remove(best)
+        return selected
+
+    def _mmr_sort_key(
+        self,
+        candidate: _EvidenceCandidate,
+        selected: list[_EvidenceCandidate],
+    ) -> tuple[float, float, int, str]:
+        return (
+            self._mmr_score(candidate, selected),
+            candidate.ranked.rerank_score,
+            -candidate.ranked.rank,
+            candidate.ranked.unit_id,
+        )
+
+    def _mmr_score(
+        self,
+        candidate: _EvidenceCandidate,
+        selected: list[_EvidenceCandidate],
+    ) -> float:
+        max_similarity = 0.0
+        if selected:
+            max_similarity = max(
+                self._jaccard_similarity(candidate.tokens, selected_candidate.tokens)
+                for selected_candidate in selected
+            )
+        return round(
+            self.mmr_lambda * candidate.ranked.rerank_score
+            - (1.0 - self.mmr_lambda) * max_similarity,
+            6,
+        )
+
+    def _ensure_role_candidate(
+        self,
+        selected: list[_EvidenceCandidate],
+        candidate_pool: list[_EvidenceCandidate],
+        role: str,
+    ) -> None:
+        if len(selected) >= self.max_evidence_units:
+            return
+        if any(candidate.support_role == role for candidate in selected):
+            return
+        candidates = [
+            candidate
+            for candidate in candidate_pool
+            if candidate.support_role == role
+            and candidate.ranked.unit_id not in {item.ranked.unit_id for item in selected}
+        ]
+        if not candidates:
+            return
+        best = max(
+            candidates,
+            key=lambda candidate: (
+                candidate.ranked.rerank_score,
+                -candidate.ranked.rank,
+                candidate.ranked.unit_id,
+            ),
+        )
+        best.mmr_score = self._mmr_score(best, selected)
+        self._append_reason(best, f"{role}_candidate")
+        self._append_reason(best, "selected_by_role_coverage")
+        selected.append(best)
+
+    def _include_parent_context(
+        self,
+        selected: list[_EvidenceCandidate],
+        candidate_pool: list[_EvidenceCandidate],
+    ) -> None:
+        selected_unit_ids = {candidate.ranked.unit_id for candidate in selected}
+        pool_by_unit_id = {
+            candidate.ranked.unit_id: candidate
+            for candidate in candidate_pool
+        }
+        for candidate in list(selected):
+            if len(selected) >= self.max_evidence_units:
+                return
+            parent_id = candidate.unit.get("parent_id")
+            if not isinstance(parent_id, str) or not parent_id:
+                continue
+            if parent_id in selected_unit_ids:
+                continue
+            parent = pool_by_unit_id.get(parent_id)
+            if parent is None:
+                continue
+            parent.support_role = "context"
+            parent.mmr_score = self._mmr_score(parent, selected)
+            self._append_reason(parent, "parent_context_candidate")
+            self._append_reason(parent, "selected_parent_context")
+            selected.append(parent)
+            selected_unit_ids.add(parent_id)
+
+    def _evidence_unit(
+        self,
+        candidate: _EvidenceCandidate,
+        *,
+        rank: int,
+    ) -> EvidenceUnit:
+        ranked = candidate.ranked
+        legal_unit = self._legal_unit_from_dict(
+            unit=candidate.unit,
+            fallback_unit_id=ranked.unit_id,
+            text=candidate.text,
+        )
+        return EvidenceUnit(
+            **legal_unit.model_dump(),
+            evidence_id=f"evidence:{ranked.unit_id}",
+            excerpt=candidate.text,
+            rank=rank,
+            relevance_score=self._clamp(ranked.rerank_score),
+            retrieval_method=ranked.source or "legal_ranker_mmr",
+            retrieval_score=ranked.retrieval_score or 0.0,
+            rerank_score=self._clamp(ranked.rerank_score),
+            mmr_score=candidate.mmr_score,
+            support_role=candidate.support_role,
+            why_selected=self._dedupe(candidate.why_selected),
+            score_breakdown=ranked.score_breakdown.model_dump(mode="json"),
+        )
+
+    def _legal_unit_from_dict(
+        self,
+        *,
+        unit: dict[str, Any],
+        fallback_unit_id: str,
+        text: str,
+    ) -> LegalUnit:
+        law_id = str(unit.get("law_id") or unit.get("law") or "unknown")
+        law_title = str(
+            unit.get("law_title")
+            or unit.get("legal_act")
+            or unit.get("act_title")
+            or law_id
+        )
+        status = str(unit.get("status") or "unknown")
+        if status not in {"active", "historical", "repealed", "unknown"}:
+            status = "unknown"
+        hierarchy_path = unit.get("hierarchy_path")
+        if not isinstance(hierarchy_path, list) or not hierarchy_path:
+            hierarchy_path = [law_title, fallback_unit_id]
+        return LegalUnit(
+            id=str(unit.get("id") or unit.get("legal_unit_id") or fallback_unit_id),
+            canonical_id=unit.get("canonical_id"),
+            source_id=unit.get("source_id"),
+            law_id=law_id,
+            law_title=law_title,
+            act_type=unit.get("act_type"),
+            act_number=unit.get("act_number"),
+            publication_date=unit.get("publication_date"),
+            effective_date=unit.get("effective_date"),
+            version_start=unit.get("version_start"),
+            version_end=unit.get("version_end"),
+            status=status,
+            hierarchy_path=[str(item) for item in hierarchy_path],
+            article_number=self._optional_str(unit.get("article_number")),
+            paragraph_number=self._optional_str(unit.get("paragraph_number")),
+            letter_number=self._optional_str(unit.get("letter_number")),
+            point_number=self._optional_str(unit.get("point_number")),
+            raw_text=text,
+            normalized_text=self._optional_str(unit.get("normalized_text")),
+            legal_domain=str(unit.get("legal_domain") or unit.get("domain") or "unknown"),
+            legal_concepts=[
+                str(concept)
+                for concept in unit.get("legal_concepts", [])
+                if isinstance(unit.get("legal_concepts"), list)
+            ],
+            source_url=unit.get("source_url"),
+            parent_id=self._optional_str(unit.get("parent_id")),
+            children_ids=self._str_list(unit.get("children_ids")),
+            outgoing_reference_ids=self._str_list(unit.get("outgoing_reference_ids")),
+            incoming_reference_ids=self._str_list(unit.get("incoming_reference_ids")),
+        )
+
+    def _build_graph(
+        self,
+        *,
+        selected: list[_EvidenceCandidate],
+        graph_expansion: GraphExpansionResult | None,
+    ) -> tuple[list[GraphNode], list[GraphEdge]]:
+        nodes_by_id: dict[str, GraphNode] = {}
+        edges_by_id: dict[str, GraphEdge] = {}
+
+        if graph_expansion:
+            for node in graph_expansion.graph_nodes:
+                nodes_by_id[node.id] = node
+            for edge in graph_expansion.graph_edges:
+                edges_by_id[edge.id] = edge
+
+        for candidate in selected:
+            node = self._graph_node(candidate)
+            nodes_by_id.setdefault(node.id, node)
+
+        selected_ids = {candidate.ranked.unit_id for candidate in selected}
+        for candidate in selected:
+            parent_id = candidate.unit.get("parent_id")
+            if not isinstance(parent_id, str) or parent_id not in selected_ids:
+                continue
+            edge_id = f"edge:parent:{parent_id}:{candidate.ranked.unit_id}"
+            edges_by_id.setdefault(
+                edge_id,
+                GraphEdge(
+                    id=edge_id,
+                    source=f"legal_unit:{parent_id}",
+                    target=f"legal_unit:{candidate.ranked.unit_id}",
+                    type="contains",
+                    weight=1.0,
+                    confidence=1.0,
+                    explanation="Parent-child relation derived from input parent_id.",
+                    metadata={"derived_from_input_parent_id": True},
+                ),
+            )
+
+        return list(nodes_by_id.values()), list(edges_by_id.values())
+
+    def _graph_node(self, candidate: _EvidenceCandidate) -> GraphNode:
+        unit = candidate.unit
+        unit_id = candidate.ranked.unit_id
+        label = (
+            unit.get("label")
+            or unit.get("title")
+            or unit.get("law_title")
+            or unit.get("id")
+            or unit_id
+        )
+        return GraphNode(
+            id=f"legal_unit:{unit_id}",
+            type=self._graph_node_type(unit),
+            label=str(label),
+            legal_unit_id=unit_id,
+            domain=self._optional_str(unit.get("legal_domain") or unit.get("domain")),
+            status=self._optional_str(unit.get("status")),
+            importance=candidate.ranked.rerank_score,
+            metadata={
+                **self._scalar_metadata(unit),
+                "support_role": candidate.support_role,
+                "rerank_score": candidate.ranked.rerank_score,
+            },
+        )
+
+    def _support_role(
+        self,
+        ranked: RankedCandidate,
+        unit: dict[str, Any],
+        *,
+        plan: QueryPlan | None,
+    ) -> str:
+        haystack = self._haystack(ranked, unit)
+        if self._contains_any(haystack, ("exception", "exceptie", "except", "cu exceptia", "exception_to")):
+            return "exception"
+        if self._contains_any(haystack, ("definition", "defineste", "in sensul", "se intelege", "defines")):
+            return "definition"
+        if self._contains_any(haystack, ("sanction", "sanctiune", "amenda", "contraventie", "sanctions")):
+            return "sanction"
+        if (plan and "procedure" in plan.query_types) or self._contains_any(
+            haystack,
+            ("procedura", "termen", "pasi", "contestatie", "cerere", "procedure_step"),
+        ):
+            return "procedure"
+        if self._contains_any(haystack, ("daca", "in cazul", "cu conditia", "numai daca")):
+            return "condition"
+        if self._graph_node_type(unit) in {"root", "domain", "legal_act", "title", "chapter", "section"}:
+            return "context"
+        return "direct_basis"
+
+    def _base_selection_reasons(self, ranked: RankedCandidate) -> list[str]:
+        reasons = list(ranked.why_ranked)
+        if ranked.rerank_score >= 0.70:
+            reasons.append("high_rerank_score")
+        return reasons
+
+    def _debug_payload(
+        self,
+        *,
+        fallback_used: bool,
+        input_ranked_candidate_count: int,
+        candidate_pool_size: int,
+        selected: list[_EvidenceCandidate],
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        return {
+            "fallback_used": fallback_used,
+            "input_ranked_candidate_count": input_ranked_candidate_count,
+            "candidate_pool_size": candidate_pool_size,
+            "selected_evidence_count": len(selected),
+            "lambda": self.mmr_lambda,
+            "target_evidence_units": self.target_evidence_units,
+            "max_evidence_units": self.max_evidence_units,
+            "selected_units": [
+                {
+                    "unit_id": candidate.ranked.unit_id,
+                    "rerank_score": candidate.ranked.rerank_score,
+                    "mmr_score": candidate.mmr_score,
+                    "support_role": candidate.support_role,
+                    "why_selected": self._dedupe(candidate.why_selected),
+                }
+                for candidate in selected
+            ],
+            "warnings": warnings,
+        }
+
+    def _candidate_text(self, unit: dict[str, Any]) -> str:
+        for key in ("raw_text", "normalized_text", "text"):
+            value = unit.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    def _has_required_metadata(self, unit: dict[str, Any]) -> bool:
+        return all(unit.get(key) for key in ("law_id", "law_title", "legal_domain"))
+
+    def _graph_node_type(self, unit: dict[str, Any]) -> str:
+        unit_type = self._normalize_text(str(unit.get("type") or unit.get("unit_type") or ""))
+        mapping = {
+            "root": "root",
+            "domain": "domain",
+            "subdomain": "subdomain",
+            "legal_act": "legal_act",
+            "act": "legal_act",
+            "title": "title",
+            "titlu": "title",
+            "chapter": "chapter",
+            "capitol": "chapter",
+            "section": "section",
+            "sectiune": "section",
+            "article": "article",
+            "articol": "article",
+            "paragraph": "paragraph",
+            "paragraf": "paragraph",
+            "alineat": "paragraph",
+            "letter": "letter",
+            "litera": "letter",
+            "point": "point",
+            "punct": "point",
+            "annex": "annex",
+            "anexa": "annex",
+            "concept": "concept",
+        }
+        if unit_type in mapping:
+            return mapping[unit_type]
+        if unit.get("paragraph_number"):
+            return "paragraph"
+        if unit.get("letter_number"):
+            return "letter"
+        if unit.get("point_number"):
+            return "point"
+        if unit.get("article_number"):
+            return "article"
+        return "article"
+
+    def _haystack(self, ranked: RankedCandidate, unit: dict[str, Any]) -> str:
+        values: list[str] = [ranked.unit_id]
+        values.extend(ranked.why_ranked)
+        values.append(str(ranked.source or ""))
+        values.append(str(unit))
+        return self._normalize_text(" ".join(values))
+
+    def _contains_any(self, haystack: str, terms: tuple[str, ...]) -> bool:
+        return any(self._normalize_text(term) in haystack for term in terms)
+
+    def _tokenize(self, text: str) -> set[str]:
+        normalized = self._normalize_text(text)
+        return {
+            token
+            for token in re.split(r"[^a-z0-9_]+", normalized)
+            if len(token) > 1 and token not in STOPWORDS
+        }
+
+    def _jaccard_similarity(self, left: set[str], right: set[str]) -> float:
+        if not left or not right:
+            return 0.0
+        return len(left & right) / len(left | right)
+
+    def _scalar_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in metadata.items()
+            if isinstance(value, str | int | float | bool) or value is None
+        }
+
+    def _append_reason(self, candidate: _EvidenceCandidate, reason: str) -> None:
+        if reason not in candidate.why_selected:
+            candidate.why_selected.append(reason)
+
+    def _dedupe(self, values: list[str]) -> list[str]:
+        deduped: list[str] = []
+        for value in values:
+            if value not in deduped:
+                deduped.append(value)
+        return deduped
+
+    def _str_list(self, value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [str(item) for item in value]
+
+    def _optional_str(self, value: Any) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
+    def _normalize_text(self, text: str) -> str:
+        replacements = {
+            "Ã„Æ’": "a",
+            "Ã„â€š": "a",
+            "Ãˆâ„¢": "s",
+            "ÃˆËœ": "s",
+            "Ãˆâ€º": "t",
+            "ÃˆÅ¡": "t",
+            "ÃƒÂ¢": "a",
+            "ÃƒÂ®": "i",
+            "Ã…Å¸": "s",
+            "Ã…Â£": "t",
+        }
+        for broken, fixed in replacements.items():
+            text = text.replace(broken, fixed)
+        normalized = unicodedata.normalize("NFD", text.casefold())
+        stripped = "".join(
+            char for char in normalized if unicodedata.category(char) != "Mn"
+        )
+        return " ".join(stripped.replace(".", " ").replace("-", "_").split())
+
+    def _clamp(self, value: float) -> float:
+        return max(0.0, min(1.0, float(value)))

--- a/apps/api/app/services/legal_ranker.py
+++ b/apps/api/app/services/legal_ranker.py
@@ -1,0 +1,659 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+import unicodedata
+from typing import Any
+
+from ..schemas import (
+    ExpandedCandidate,
+    GraphExpansionResult,
+    LegalRankerResult,
+    QueryPlan,
+    RankedCandidate,
+    RankerFeatureBreakdown,
+    RawRetrievalResponse,
+    RetrievalCandidate,
+)
+
+LEGAL_RANKER_NO_CANDIDATES = "legal_ranker_no_candidates"
+
+RANKER_WEIGHTS: dict[str, float] = {
+    "bm25_score": 0.16,
+    "dense_score": 0.16,
+    "exact_citation_match": 0.10,
+    "domain_match": 0.10,
+    "graph_proximity": 0.10,
+    "concept_overlap": 0.08,
+    "legal_term_overlap": 0.07,
+    "temporal_validity": 0.07,
+    "source_reliability": 0.05,
+    "parent_relevance": 0.05,
+    "is_exception": 0.03,
+    "is_definition": 0.02,
+    "is_sanction": 0.01,
+}
+
+FEATURE_NAMES = tuple(RANKER_WEIGHTS.keys())
+
+RAW_BM25_KEYS = ("bm25_score", "bm25", "lexical", "lexical_score")
+RAW_DENSE_KEYS = ("dense_score", "dense", "vector", "vector_score")
+
+STOPWORDS = {
+    "a",
+    "al",
+    "ale",
+    "alin",
+    "art",
+    "cu",
+    "de",
+    "din",
+    "este",
+    "fara",
+    "in",
+    "la",
+    "mi",
+    "nr",
+    "pe",
+    "sa",
+    "sau",
+    "se",
+    "si",
+}
+
+
+@dataclass
+class _CandidateBundle:
+    unit_id: str
+    retrieval_candidate: RetrievalCandidate | None = None
+    expanded_candidate: ExpandedCandidate | None = None
+    unit: dict[str, Any] | None = None
+    score_breakdown: dict[str, float] = field(default_factory=dict)
+    graph_proximity: float = 0.0
+    retrieval_score: float | None = None
+    retrieval_rank: int | None = None
+    sources: set[str] = field(default_factory=set)
+    reasons: list[str] = field(default_factory=list)
+
+
+class LegalRanker:
+    def rank(
+        self,
+        *,
+        question: str,
+        plan: QueryPlan,
+        retrieval_response: RawRetrievalResponse,
+        graph_expansion: GraphExpansionResult,
+        debug: bool = False,
+    ) -> LegalRankerResult:
+        bundles = self._merge_candidates(
+            retrieval_response=retrieval_response,
+            graph_expansion=graph_expansion,
+        )
+        input_candidate_count = len(bundles)
+        if not bundles:
+            return self._fallback_result(debug=debug)
+
+        raw_feature_rows = [
+            self._extract_features(
+                question=question,
+                plan=plan,
+                bundle=bundle,
+            )
+            for bundle in bundles
+        ]
+        normalized_feature_rows = self._normalize_rows(raw_feature_rows)
+        scored_rows = [
+            (
+                bundle,
+                RankerFeatureBreakdown(**normalized_features),
+                self._weighted_score(normalized_features),
+            )
+            for bundle, normalized_features in zip(
+                bundles,
+                normalized_feature_rows,
+                strict=True,
+            )
+        ]
+        scored_rows.sort(key=self._sort_key)
+
+        ranked_candidates = [
+            self._ranked_candidate(
+                rank=index,
+                bundle=bundle,
+                score_breakdown=score_breakdown,
+                rerank_score=rerank_score,
+                plan=plan,
+            )
+            for index, (bundle, score_breakdown, rerank_score) in enumerate(
+                scored_rows,
+                start=1,
+            )
+        ]
+
+        result = LegalRankerResult(ranked_candidates=ranked_candidates)
+        if debug:
+            result.debug = self._debug_payload(
+                fallback_used=False,
+                input_candidate_count=input_candidate_count,
+                ranked_candidates=ranked_candidates,
+                warnings=[],
+            )
+        return result
+
+    def _fallback_result(self, *, debug: bool) -> LegalRankerResult:
+        result = LegalRankerResult(
+            ranked_candidates=[],
+            warnings=[LEGAL_RANKER_NO_CANDIDATES],
+            debug=None,
+        )
+        if debug:
+            result.debug = self._debug_payload(
+                fallback_used=True,
+                input_candidate_count=0,
+                ranked_candidates=[],
+                warnings=result.warnings,
+            )
+        return result
+
+    def _merge_candidates(
+        self,
+        *,
+        retrieval_response: RawRetrievalResponse,
+        graph_expansion: GraphExpansionResult,
+    ) -> list[_CandidateBundle]:
+        merged: dict[str, _CandidateBundle] = {}
+
+        for candidate in retrieval_response.candidates:
+            bundle = merged.setdefault(
+                candidate.unit_id,
+                _CandidateBundle(unit_id=candidate.unit_id),
+            )
+            self._merge_retrieval_candidate(bundle, candidate)
+
+        for expanded in (
+            graph_expansion.seed_candidates + graph_expansion.expanded_candidates
+        ):
+            bundle = merged.setdefault(
+                expanded.unit_id,
+                _CandidateBundle(unit_id=expanded.unit_id),
+            )
+            self._merge_expanded_candidate(bundle, expanded)
+            if expanded.retrieval_candidate:
+                self._merge_retrieval_candidate(
+                    bundle,
+                    expanded.retrieval_candidate,
+                )
+
+        return list(merged.values())
+
+    def _merge_retrieval_candidate(
+        self,
+        bundle: _CandidateBundle,
+        candidate: RetrievalCandidate,
+    ) -> None:
+        if (
+            bundle.retrieval_candidate is None
+            or self._unit_info_score(candidate.unit)
+            > self._unit_info_score(bundle.retrieval_candidate.unit)
+        ):
+            bundle.retrieval_candidate = candidate
+        if self._unit_info_score(candidate.unit) > self._unit_info_score(bundle.unit):
+            bundle.unit = candidate.unit
+        if candidate.retrieval_score is not None:
+            bundle.retrieval_score = max(
+                bundle.retrieval_score or 0.0,
+                candidate.retrieval_score,
+            )
+        bundle.retrieval_rank = (
+            candidate.rank
+            if bundle.retrieval_rank is None
+            else min(bundle.retrieval_rank, candidate.rank)
+        )
+        bundle.score_breakdown.update(candidate.score_breakdown)
+        bundle.sources.add("raw_retrieval")
+        if candidate.why_retrieved:
+            bundle.reasons.append(candidate.why_retrieved)
+
+    def _merge_expanded_candidate(
+        self,
+        bundle: _CandidateBundle,
+        candidate: ExpandedCandidate,
+    ) -> None:
+        bundle.expanded_candidate = candidate
+        bundle.graph_proximity = max(
+            bundle.graph_proximity,
+            self._clamp(candidate.graph_proximity),
+        )
+        bundle.score_breakdown.update(candidate.score_breakdown)
+        bundle.sources.add(candidate.source)
+        if candidate.expansion_reason:
+            bundle.reasons.append(candidate.expansion_reason)
+        if candidate.expansion_edge_type:
+            bundle.reasons.append(candidate.expansion_edge_type)
+
+    def _extract_features(
+        self,
+        *,
+        question: str,
+        plan: QueryPlan,
+        bundle: _CandidateBundle,
+    ) -> dict[str, float]:
+        unit = bundle.unit or {}
+        return {
+            "bm25_score": self._score_from_breakdown(
+                bundle.score_breakdown,
+                RAW_BM25_KEYS,
+            ),
+            "dense_score": self._score_from_breakdown(
+                bundle.score_breakdown,
+                RAW_DENSE_KEYS,
+            ),
+            "exact_citation_match": self._exact_citation_match(plan, bundle),
+            "domain_match": self._domain_match(plan, unit),
+            "graph_proximity": self._graph_proximity(bundle),
+            "concept_overlap": self._concept_overlap(question, plan, unit),
+            "legal_term_overlap": self._legal_term_overlap(question, plan, unit),
+            "temporal_validity": self._temporal_validity(unit),
+            "source_reliability": self._source_reliability(unit),
+            "parent_relevance": self._parent_relevance(unit),
+            "is_exception": self._indicator(
+                unit=unit,
+                bundle=bundle,
+                terms=(
+                    "exception",
+                    "exceptie",
+                    "except",
+                    "cu exceptia",
+                    "exception_to",
+                ),
+            ),
+            "is_definition": self._indicator(
+                unit=unit,
+                bundle=bundle,
+                terms=(
+                    "definition",
+                    "defineste",
+                    "in sensul",
+                    "se intelege",
+                    "defines",
+                ),
+            ),
+            "is_sanction": self._indicator(
+                unit=unit,
+                bundle=bundle,
+                terms=(
+                    "sanction",
+                    "sanctiune",
+                    "amenda",
+                    "contraventie",
+                    "sanctions",
+                ),
+            ),
+        }
+
+    def _normalize_rows(
+        self,
+        raw_feature_rows: list[dict[str, float]],
+    ) -> list[dict[str, float]]:
+        normalized = [{name: 0.0 for name in FEATURE_NAMES} for _ in raw_feature_rows]
+        for feature_name in FEATURE_NAMES:
+            values = [row.get(feature_name, 0.0) for row in raw_feature_rows]
+            if any(value > 1.0 for value in values):
+                normalized_values = self._min_max_normalize(values)
+            else:
+                normalized_values = [self._clamp(value) for value in values]
+            for row, value in zip(normalized, normalized_values, strict=True):
+                row[feature_name] = value
+        return normalized
+
+    def _min_max_normalize(self, values: list[float]) -> list[float]:
+        if all(value == 0.0 for value in values):
+            return [0.0 for _ in values]
+        minimum = min(values)
+        maximum = max(values)
+        if minimum == maximum:
+            return [0.5 if minimum != 0.0 else 0.0 for _ in values]
+        return [self._clamp((value - minimum) / (maximum - minimum)) for value in values]
+
+    def _weighted_score(self, features: dict[str, float]) -> float:
+        score = sum(
+            RANKER_WEIGHTS[feature_name] * features.get(feature_name, 0.0)
+            for feature_name in FEATURE_NAMES
+        )
+        return round(self._clamp(score), 6)
+
+    def _sort_key(
+        self,
+        row: tuple[_CandidateBundle, RankerFeatureBreakdown, float],
+    ) -> tuple[float, float, float, float, int, str]:
+        bundle, score_breakdown, rerank_score = row
+        return (
+            -rerank_score,
+            -score_breakdown.exact_citation_match,
+            -score_breakdown.domain_match,
+            -score_breakdown.graph_proximity,
+            bundle.retrieval_rank or 1_000_000,
+            bundle.unit_id,
+        )
+
+    def _ranked_candidate(
+        self,
+        *,
+        rank: int,
+        bundle: _CandidateBundle,
+        score_breakdown: RankerFeatureBreakdown,
+        rerank_score: float,
+        plan: QueryPlan,
+    ) -> RankedCandidate:
+        return RankedCandidate(
+            unit_id=bundle.unit_id,
+            rank=rank,
+            rerank_score=rerank_score,
+            retrieval_score=bundle.retrieval_score,
+            unit=bundle.unit,
+            score_breakdown=score_breakdown,
+            why_ranked=self._why_ranked(plan, bundle, score_breakdown),
+            source=self._source(bundle),
+        )
+
+    def _why_ranked(
+        self,
+        plan: QueryPlan,
+        bundle: _CandidateBundle,
+        score_breakdown: RankerFeatureBreakdown,
+    ) -> list[str]:
+        reasons: list[str] = []
+        if score_breakdown.bm25_score >= 0.70:
+            reasons.append("high_bm25_score")
+        if score_breakdown.dense_score >= 0.70:
+            reasons.append("high_dense_score")
+        if score_breakdown.exact_citation_match > 0:
+            reasons.append("exact_citation_match")
+        if score_breakdown.domain_match == 1.0 and plan.legal_domain:
+            reasons.append(f"domain_match:{self._normal_label(plan.legal_domain)}")
+        if score_breakdown.graph_proximity > 0 and bundle.expanded_candidate:
+            reasons.append("graph_proximity_from_expansion")
+        if score_breakdown.concept_overlap > 0:
+            reasons.append("concept_overlap")
+        if score_breakdown.legal_term_overlap > 0:
+            reasons.append("legal_term_overlap")
+        if score_breakdown.temporal_validity == 1.0:
+            reasons.append("active_legal_unit")
+        if score_breakdown.source_reliability == 1.0:
+            reasons.append("has_source_url")
+        if score_breakdown.is_exception > 0:
+            reasons.append("exception_candidate")
+        if score_breakdown.is_definition > 0:
+            reasons.append("definition_candidate")
+        if score_breakdown.is_sanction > 0:
+            reasons.append("sanction_candidate")
+        if score_breakdown.parent_relevance > 0:
+            reasons.append("parent_context_candidate")
+        for reason in bundle.reasons:
+            normalized_reason = self._normal_label(reason)
+            if normalized_reason and normalized_reason not in reasons:
+                reasons.append(normalized_reason)
+        return reasons
+
+    def _score_from_breakdown(
+        self,
+        score_breakdown: dict[str, float],
+        keys: tuple[str, ...],
+    ) -> float:
+        for key in keys:
+            if key in score_breakdown:
+                return float(score_breakdown[key])
+        return 0.0
+
+    def _exact_citation_match(
+        self,
+        plan: QueryPlan,
+        bundle: _CandidateBundle,
+    ) -> float:
+        if bundle.score_breakdown.get("exact_citation_boost", 0.0) > 0:
+            return 1.0
+        if bundle.score_breakdown.get("exact_citation_match", 0.0) > 0:
+            return 1.0
+        if not plan.exact_citations:
+            return 0.0
+
+        haystack = self._candidate_haystack(bundle)
+        for citation in plan.exact_citations:
+            article_match = True
+            if citation.article:
+                article = self._normalize_text(citation.article)
+                article_match = any(
+                    marker in haystack
+                    for marker in (
+                        f"art {article}",
+                        f"art_{article}",
+                        f"art-{article}",
+                        f"article {article}",
+                    )
+                )
+
+            paragraph_match = True
+            if citation.paragraph:
+                paragraph = self._normalize_text(citation.paragraph)
+                paragraph_match = any(
+                    marker in haystack
+                    for marker in (
+                        f"alin {paragraph}",
+                        f"alin_{paragraph}",
+                        f"paragraph {paragraph}",
+                    )
+                )
+
+            law_match = True
+            if citation.law_id_hint:
+                law = self._normalize_text(citation.law_id_hint)
+                law_match = law in haystack
+            elif citation.act_hint:
+                law = self._normalize_text(citation.act_hint)
+                law_match = law in haystack
+
+            if article_match and paragraph_match and law_match:
+                return 1.0
+        return 0.0
+
+    def _domain_match(self, plan: QueryPlan, unit: dict[str, Any]) -> float:
+        if not plan.legal_domain:
+            return 0.0
+        unit_domain = self._unit_value(unit, "legal_domain", "domain")
+        if not unit_domain:
+            return 0.3
+        plan_domain = self._normalize_text(plan.legal_domain)
+        normalized_unit_domain = self._normalize_text(str(unit_domain))
+        if (
+            plan_domain == normalized_unit_domain
+            or plan_domain in normalized_unit_domain
+            or normalized_unit_domain in plan_domain
+        ):
+            return 1.0
+        return 0.0
+
+    def _graph_proximity(self, bundle: _CandidateBundle) -> float:
+        if bundle.graph_proximity > 0:
+            return bundle.graph_proximity
+        if bundle.retrieval_candidate:
+            return 1.0
+        return 0.0
+
+    def _concept_overlap(
+        self,
+        question: str,
+        plan: QueryPlan,
+        unit: dict[str, Any],
+    ) -> float:
+        concepts = unit.get("legal_concepts")
+        if not concepts:
+            return 0.0
+        concept_tokens = self._tokens_from_value(concepts)
+        if not concept_tokens:
+            return 0.0
+        query_tokens = self._tokenize(question) | {
+            self._normalize_text(query_type) for query_type in plan.query_types
+        }
+        return len(concept_tokens & query_tokens) / len(concept_tokens)
+
+    def _legal_term_overlap(
+        self,
+        question: str,
+        plan: QueryPlan,
+        unit: dict[str, Any],
+    ) -> float:
+        text = self._unit_value(unit, "normalized_text", "raw_text", "text")
+        if not text:
+            return 0.0
+        question_tokens = self._tokenize(plan.normalized_question or question)
+        unit_tokens = self._tokenize(str(text))
+        if not question_tokens or not unit_tokens:
+            return 0.0
+        return len(question_tokens & unit_tokens) / len(question_tokens)
+
+    def _temporal_validity(self, unit: dict[str, Any]) -> float:
+        status = self._normalize_text(str(unit.get("status") or "unknown"))
+        if status == "active":
+            return 1.0
+        if status in {"unknown", ""}:
+            return 0.6
+        if status == "historical":
+            return 0.2
+        if status == "repealed":
+            return 0.0
+        return 0.6
+
+    def _source_reliability(self, unit: dict[str, Any]) -> float:
+        if unit.get("source_url"):
+            return 1.0
+        if any(unit.get(key) for key in ("law_id", "law_title", "raw_text")):
+            return 0.8
+        return 0.6
+
+    def _parent_relevance(self, unit: dict[str, Any]) -> float:
+        unit_type = self._normalize_text(str(unit.get("type") or unit.get("unit_type") or ""))
+        if unit.get("parent_id") and unit_type in {"paragraf", "paragraph", "alineat", "litera", "letter", "punct", "point"}:
+            return 0.6
+        if unit_type in {"articol", "article"}:
+            return 0.3
+        return 0.0
+
+    def _indicator(
+        self,
+        *,
+        unit: dict[str, Any],
+        bundle: _CandidateBundle,
+        terms: tuple[str, ...],
+    ) -> float:
+        haystack = self._candidate_haystack(bundle)
+        if unit:
+            haystack = f"{haystack} {self._normalize_text(str(unit))}"
+        return 1.0 if any(self._normalize_text(term) in haystack for term in terms) else 0.0
+
+    def _debug_payload(
+        self,
+        *,
+        fallback_used: bool,
+        input_candidate_count: int,
+        ranked_candidates: list[RankedCandidate],
+        warnings: list[str],
+    ) -> dict[str, Any]:
+        rows = [candidate.model_dump(mode="json") for candidate in ranked_candidates]
+        return {
+            "fallback_used": fallback_used,
+            "input_candidate_count": input_candidate_count,
+            "ranked_candidate_count": len(ranked_candidates),
+            "weights": RANKER_WEIGHTS,
+            "ranked_candidates": rows,
+            "rows": rows,
+            "warnings": warnings,
+        }
+
+    def _candidate_haystack(self, bundle: _CandidateBundle) -> str:
+        values: list[str] = [bundle.unit_id]
+        if bundle.unit:
+            values.extend(str(value) for value in bundle.unit.values())
+        values.extend(bundle.reasons)
+        if bundle.expanded_candidate:
+            values.extend(
+                str(value)
+                for value in (
+                    bundle.expanded_candidate.source,
+                    bundle.expanded_candidate.expansion_edge_type,
+                    bundle.expanded_candidate.expansion_reason,
+                )
+                if value
+            )
+        return self._normalize_text(" ".join(values))
+
+    def _unit_value(self, unit: dict[str, Any], *keys: str) -> Any:
+        for key in keys:
+            value = unit.get(key)
+            if value is not None:
+                return value
+        return None
+
+    def _unit_info_score(self, unit: dict[str, Any] | None) -> int:
+        if not unit:
+            return 0
+        return sum(1 for value in unit.values() if value not in (None, "", [], {}))
+
+    def _tokens_from_value(self, value: Any) -> set[str]:
+        if isinstance(value, list | tuple | set):
+            return {
+                token
+                for item in value
+                for token in self._tokenize(str(item))
+            }
+        return self._tokenize(str(value))
+
+    def _tokenize(self, text: str) -> set[str]:
+        normalized = self._normalize_text(text)
+        return {
+            token
+            for token in re.split(r"[^a-z0-9_]+", normalized)
+            if len(token) > 1 and token not in STOPWORDS
+        }
+
+    def _normalize_text(self, text: str) -> str:
+        replacements = {
+            "Äƒ": "ă",
+            "Ä‚": "Ă",
+            "È™": "ș",
+            "È˜": "Ș",
+            "È›": "ț",
+            "Èš": "Ț",
+            "Ã¢": "â",
+            "Ã‚": "Â",
+            "Ã®": "î",
+            "ÃŽ": "Î",
+            "ÅŸ": "ș",
+            "Åž": "Ș",
+            "Å£": "ț",
+            "Å¢": "Ț",
+        }
+        for broken, fixed in replacements.items():
+            text = text.replace(broken, fixed)
+        normalized = unicodedata.normalize("NFD", text.casefold())
+        stripped = "".join(
+            char for char in normalized if unicodedata.category(char) != "Mn"
+        )
+        return " ".join(stripped.replace(".", " ").replace("-", "_").split())
+
+    def _normal_label(self, text: str) -> str:
+        return self._normalize_text(text).replace(" ", "_")
+
+    def _source(self, bundle: _CandidateBundle) -> str | None:
+        if not bundle.sources:
+            return None
+        if "graph_expansion" in bundle.sources:
+            return "graph_expansion"
+        if "seed" in bundle.sources:
+            return "seed"
+        if "raw_retrieval" in bundle.sources:
+            return "raw_retrieval"
+        return sorted(bundle.sources)[0]
+
+    def _clamp(self, value: float) -> float:
+        return max(0.0, min(1.0, float(value)))

--- a/apps/api/app/services/mock_evidence.py
+++ b/apps/api/app/services/mock_evidence.py
@@ -14,8 +14,9 @@ from ..schemas import (
 
 MOCK_REFUSAL_REASON = "mock_evidence_pack_not_verified"
 MOCK_WARNING = (
-    "mock_unverified_evidence_pack: Phase 1 returns deterministic mock evidence "
-    "only; retrieval, LegalRanker, generation, and citation verification have not run."
+    "mock_unverified_answer: Phase 7 keeps answer generation and citation "
+    "verification mocked; compiled evidence, if present, is not converted into "
+    "a verified legal conclusion."
 )
 
 
@@ -42,7 +43,7 @@ class MockEvidenceService:
         answer = AnswerPayload(
             short_answer=(
                 "Phase 1 mock response only. No verified legal conclusion is provided; "
-                "the evidence below is deterministic placeholder data for API contract testing."
+                "Phase 7 may compile evidence units separately, but generation is not configured."
             ),
             detailed_answer=None,
             confidence=0.0,
@@ -72,7 +73,7 @@ class MockEvidenceService:
             warnings=warnings,
             debug_notes=[
                 "MockEvidenceService.build_pack returned static fixture data.",
-                "No database, vector search, graph expansion, ranker, generation, or verifier was called.",
+                "Generation and citation verification remain mocked and unverified.",
             ],
         )
 
@@ -117,12 +118,15 @@ class MockEvidenceService:
 
         return [
             EvidenceUnit(
+                **legal_unit.model_dump(),
                 evidence_id=f"mock-evidence-{index}",
-                legal_unit=legal_unit,
                 excerpt=excerpt,
                 rank=index,
                 relevance_score=0.0,
                 retrieval_method="mock_static_fixture",
+                retrieval_score=0.0,
+                rerank_score=0.0,
+                support_role="direct_basis",
                 warnings=[MOCK_WARNING],
             )
             for index, (legal_unit, excerpt) in enumerate(
@@ -136,7 +140,7 @@ class MockEvidenceService:
             Citation(
                 citation_id="mock-citation-1",
                 evidence_id=evidence_units[0].evidence_id,
-                legal_unit_id=evidence_units[0].legal_unit.id,
+                legal_unit_id=evidence_units[0].id,
                 label="Codul muncii art. 17 (mock, unverified)",
                 quote=evidence_units[0].excerpt,
                 verified=False,
@@ -144,7 +148,7 @@ class MockEvidenceService:
             Citation(
                 citation_id="mock-citation-2",
                 evidence_id=evidence_units[1].evidence_id,
-                legal_unit_id=evidence_units[1].legal_unit.id,
+                legal_unit_id=evidence_units[1].id,
                 label="Codul muncii art. 41 (mock, unverified)",
                 quote=evidence_units[1].excerpt,
                 verified=False,

--- a/apps/api/app/services/query_orchestrator.py
+++ b/apps/api/app/services/query_orchestrator.py
@@ -2,6 +2,7 @@ from uuid import NAMESPACE_URL, uuid5
 
 from ..schemas import QueryDebugData, QueryRequest, QueryResponse
 from .graph_expansion_policy import GraphExpansionPolicy
+from .legal_ranker import LegalRanker
 from .mock_evidence import MockEvidenceService
 from .query_understanding import QueryUnderstanding
 from .raw_retriever_client import RawRetrieverClient
@@ -14,6 +15,7 @@ class QueryOrchestrator:
         query_understanding: QueryUnderstanding | None = None,
         raw_retriever_client: RawRetrieverClient | None = None,
         graph_expansion_policy: GraphExpansionPolicy | None = None,
+        legal_ranker: LegalRanker | None = None,
     ) -> None:
         self.evidence_service = evidence_service or MockEvidenceService()
         self.query_understanding = query_understanding or QueryUnderstanding()
@@ -21,6 +23,7 @@ class QueryOrchestrator:
         self.graph_expansion_policy = (
             graph_expansion_policy or GraphExpansionPolicy()
         )
+        self.legal_ranker = legal_ranker or LegalRanker()
 
     async def run(self, request: QueryRequest) -> QueryResponse:
         query_id = self._query_id(request)
@@ -35,6 +38,13 @@ class QueryOrchestrator:
             retrieval_response=raw_retrieval,
             debug=request.debug,
         )
+        legal_ranker = self.legal_ranker.rank(
+            question=request.question,
+            plan=query_plan,
+            retrieval_response=raw_retrieval,
+            graph_expansion=graph_expansion,
+            debug=request.debug,
+        )
         evidence_pack = await self.evidence_service.build_pack(request, query_id)
         debug = None
         if request.debug:
@@ -45,6 +55,7 @@ class QueryOrchestrator:
                 query_understanding=query_plan,
                 retrieval=raw_retrieval.debug,
                 graph_expansion=graph_expansion.debug,
+                legal_ranker=legal_ranker.debug,
                 evidence_units_count=len(evidence_pack.evidence_units),
                 citations_count=len(evidence_pack.citations),
                 graph_nodes_count=len(evidence_pack.graph.nodes),
@@ -65,6 +76,7 @@ class QueryOrchestrator:
                 evidence_pack.warnings
                 + raw_retrieval.warnings
                 + graph_expansion.warnings
+                + legal_ranker.warnings
             ),
         )
 

--- a/apps/api/app/services/raw_retriever_client.py
+++ b/apps/api/app/services/raw_retriever_client.py
@@ -3,7 +3,7 @@ from typing import Any
 import httpx
 
 from ..schemas import QueryPlan, RawRetrievalRequest, RawRetrievalResponse
-from ..settings import settings
+from ..config import settings
 
 RAW_RETRIEVAL_NOT_CONFIGURED = "raw_retrieval_not_configured"
 RAW_RETRIEVAL_UNAVAILABLE = "raw_retrieval_unavailable"

--- a/docs/query-api.md
+++ b/docs/query-api.md
@@ -1,10 +1,11 @@
 # Query API
 
-Phase 5 exposes the `/api/query` contract, deterministic QueryUnderstanding,
+Phase 6 exposes the `/api/query` contract, deterministic QueryUnderstanding,
 DomainRouter debug data, ExactCitationDetector output, RawRetrieverClient
-request construction, GraphExpansionPolicy debug data, and a deterministic mock
-EvidencePack only. It is intended for frontend and API integration work before
-real retrieval, graph traversal, and answer generation are available.
+request construction, GraphExpansionPolicy debug data, LegalRanker debug data,
+and a deterministic mock EvidencePack only. It is intended for frontend and API
+integration work before real retrieval, graph traversal, EvidencePack
+compilation, and answer generation are available.
 
 Not implemented yet:
 
@@ -12,7 +13,7 @@ Not implemented yet:
 - `/api/retrieve/raw`, which is owned by Handoff 04
 - graph/neighbors endpoints, which are owned by Handoff 04
 - database-backed graph expansion
-- LegalRanker
+- EvidencePackCompiler, which is planned for Handoff 03 Phase 7
 - answer generation
 - citation verification
 
@@ -20,9 +21,11 @@ The query understanding layer is rule-based and inspectable. It does not call an
 LLM and it does not retrieve legal text. Exact citations are parsed only into
 future lookup hints; they are not resolved against `legal_units` yet.
 RawRetrieverClient prepares the future raw retrieval payload. GraphExpansionPolicy
-turns raw retrieval candidates into graph expansion seeds and policy metadata. If
-raw retrieval or graph neighbors are not configured, `/api/query` returns a safe
-fallback with `confidence: 0.0`, `verifier_passed: false`, and explicit warnings.
+turns raw retrieval candidates into graph expansion seeds and policy metadata.
+LegalRanker reranks raw and expanded candidates deterministically when they
+exist. If raw retrieval or graph neighbors are not configured, `/api/query`
+returns a safe fallback with `confidence: 0.0`, `verifier_passed: false`, and
+explicit warnings.
 
 ## Request
 
@@ -81,8 +84,8 @@ curl -X POST http://localhost:8000/api/query \
 ```
 
 When `debug` is `true`, the response includes a `debug` object with mock service
-counts, notes, `query_understanding`, `retrieval`, and `graph_expansion`. When
-`debug` is `false`, `debug` is `null`.
+counts, notes, `query_understanding`, `retrieval`, `graph_expansion`, and
+`legal_ranker`. When `debug` is `false`, `debug` is `null`.
 
 Example debug excerpt:
 
@@ -104,6 +107,38 @@ Example debug excerpt:
         "max_depth": 2,
         "max_expanded_nodes": 80
       }
+    }
+  }
+}
+```
+
+LegalRanker debug excerpt when no candidates are available:
+
+```json
+{
+  "debug": {
+    "legal_ranker": {
+      "fallback_used": true,
+      "input_candidate_count": 0,
+      "ranked_candidate_count": 0,
+      "weights": {
+        "bm25_score": 0.16,
+        "dense_score": 0.16,
+        "exact_citation_match": 0.1,
+        "domain_match": 0.1,
+        "graph_proximity": 0.1,
+        "concept_overlap": 0.08,
+        "legal_term_overlap": 0.07,
+        "temporal_validity": 0.07,
+        "source_reliability": 0.05,
+        "parent_relevance": 0.05,
+        "is_exception": 0.03,
+        "is_definition": 0.02,
+        "is_sanction": 0.01
+      },
+      "ranked_candidates": [],
+      "rows": [],
+      "warnings": ["legal_ranker_no_candidates"]
     }
   }
 }

--- a/docs/query-api.md
+++ b/docs/query-api.md
@@ -1,11 +1,11 @@
 # Query API
 
-Phase 6 exposes the `/api/query` contract, deterministic QueryUnderstanding,
+Phase 7 exposes the `/api/query` contract, deterministic QueryUnderstanding,
 DomainRouter debug data, ExactCitationDetector output, RawRetrieverClient
 request construction, GraphExpansionPolicy debug data, LegalRanker debug data,
-and a deterministic mock EvidencePack only. It is intended for frontend and API
-integration work before real retrieval, graph traversal, EvidencePack
-compilation, and answer generation are available.
+and EvidencePackCompiler MMR selection. It is intended for frontend and API
+integration work before real retrieval, graph traversal, answer generation, and
+citation verification are available.
 
 Not implemented yet:
 
@@ -13,7 +13,6 @@ Not implemented yet:
 - `/api/retrieve/raw`, which is owned by Handoff 04
 - graph/neighbors endpoints, which are owned by Handoff 04
 - database-backed graph expansion
-- EvidencePackCompiler, which is planned for Handoff 03 Phase 7
 - answer generation
 - citation verification
 
@@ -23,9 +22,10 @@ future lookup hints; they are not resolved against `legal_units` yet.
 RawRetrieverClient prepares the future raw retrieval payload. GraphExpansionPolicy
 turns raw retrieval candidates into graph expansion seeds and policy metadata.
 LegalRanker reranks raw and expanded candidates deterministically when they
-exist. If raw retrieval or graph neighbors are not configured, `/api/query`
-returns a safe fallback with `confidence: 0.0`, `verifier_passed: false`, and
-explicit warnings.
+exist. EvidencePackCompiler selects and diversifies ranked candidates with MMR
+when candidates include LegalUnit text. If raw retrieval or graph neighbors are
+not configured, `/api/query` returns a safe fallback with empty evidence,
+`confidence: 0.0`, `verifier_passed: false`, and explicit warnings.
 
 ## Request
 
@@ -48,23 +48,14 @@ curl -X POST http://localhost:8000/api/query \
   "query_id": "9f8d85df-8d8b-59d5-b905-f76c351c7f10",
   "question": "Poate angajatorul sa-mi scada salariul fara act aditional?",
   "answer": {
-    "short_answer": "Phase 1 mock response only. No verified legal conclusion is provided; the evidence below is deterministic placeholder data for API contract testing.",
+    "short_answer": "Phase 1 mock response only. No verified legal conclusion is provided; Phase 7 may compile evidence units separately, but generation is not configured.",
     "detailed_answer": null,
     "confidence": 0.0,
     "not_legal_advice": true,
     "refusal_reason": "mock_evidence_pack_not_verified"
   },
-  "citations": [
-    {
-      "citation_id": "mock-citation-1",
-      "evidence_id": "mock-evidence-1",
-      "legal_unit_id": "mock:ro:codul-muncii:art-17",
-      "label": "Codul muncii art. 17 (mock, unverified)",
-      "quote": "Mock excerpt for art. 17. This placeholder was not retrieved from an official source.",
-      "source_url": null,
-      "verified": false
-    }
-  ],
+  "citations": [],
+  "evidence_units": [],
   "verifier": {
     "groundedness_score": 0.0,
     "claims_total": 0,
@@ -75,7 +66,7 @@ curl -X POST http://localhost:8000/api/query \
     "verifier_passed": false,
     "claim_results": [],
     "warnings": [
-      "mock_unverified_evidence_pack: Phase 1 returns deterministic mock evidence only; retrieval, LegalRanker, generation, and citation verification have not run."
+      "mock_unverified_answer: Phase 7 keeps answer generation and citation verification mocked; compiled evidence, if present, is not converted into a verified legal conclusion."
     ],
     "repair_applied": false,
     "refusal_reason": "mock_evidence_pack_not_verified"
@@ -83,9 +74,52 @@ curl -X POST http://localhost:8000/api/query \
 }
 ```
 
+When ranked candidates contain LegalUnit text, `evidence_units` use a flat
+LegalUnit-plus-evidence shape. The LegalUnit fields are not nested under
+`legal_unit`.
+
+```json
+{
+  "evidence_units": [
+    {
+      "id": "ro.codul_muncii.art_41",
+      "law_id": "ro.codul_muncii",
+      "law_title": "Codul muncii",
+      "status": "active",
+      "hierarchy_path": ["Codul muncii", "art. 41"],
+      "article_number": "41",
+      "paragraph_number": null,
+      "raw_text": "Contractul individual de munca poate fi modificat prin acordul partilor.",
+      "normalized_text": null,
+      "legal_domain": "munca",
+      "legal_concepts": ["contract", "salariu"],
+      "source_url": "https://legislatie.just.ro/test",
+      "evidence_id": "evidence:ro.codul_muncii.art_41",
+      "excerpt": "Contractul individual de munca poate fi modificat prin acordul partilor.",
+      "rank": 1,
+      "relevance_score": 0.86,
+      "retrieval_method": "raw_retrieval",
+      "retrieval_score": 0.78,
+      "rerank_score": 0.86,
+      "mmr_score": 0.645,
+      "support_role": "direct_basis",
+      "why_selected": ["domain_match:munca", "selected_by_mmr"],
+      "score_breakdown": {
+        "bm25_score": 0.9,
+        "dense_score": 0.7,
+        "domain_match": 1.0,
+        "graph_proximity": 1.0
+      },
+      "warnings": []
+    }
+  ]
+}
+```
+
 When `debug` is `true`, the response includes a `debug` object with mock service
-counts, notes, `query_understanding`, `retrieval`, `graph_expansion`, and
-`legal_ranker`. When `debug` is `false`, `debug` is `null`.
+counts, notes, `query_understanding`, `retrieval`, `graph_expansion`,
+`legal_ranker`, and `evidence_pack`. When `debug` is `false`, `debug` is
+`null`.
 
 Example debug excerpt:
 
@@ -139,6 +173,55 @@ LegalRanker debug excerpt when no candidates are available:
       "ranked_candidates": [],
       "rows": [],
       "warnings": ["legal_ranker_no_candidates"]
+    }
+  }
+}
+```
+
+EvidencePackCompiler debug excerpt when no ranked candidates are available:
+
+```json
+{
+  "debug": {
+    "evidence_pack": {
+      "fallback_used": true,
+      "input_ranked_candidate_count": 0,
+      "candidate_pool_size": 0,
+      "selected_evidence_count": 0,
+      "lambda": 0.75,
+      "target_evidence_units": 12,
+      "max_evidence_units": 14,
+      "selected_units": [],
+      "warnings": ["evidence_pack_no_ranked_candidates"]
+    }
+  }
+}
+```
+
+EvidencePackCompiler debug excerpt with ranked fixture candidates:
+
+```json
+{
+  "debug": {
+    "evidence_pack": {
+      "fallback_used": false,
+      "input_ranked_candidate_count": 1,
+      "candidate_pool_size": 1,
+      "selected_evidence_count": 1,
+      "selected_units": [
+        {
+          "unit_id": "ro.codul_muncii.art_41",
+          "rerank_score": 0.86,
+          "mmr_score": 0.645,
+          "support_role": "direct_basis",
+          "why_selected": [
+            "domain_match:munca",
+            "high_bm25_score",
+            "selected_by_mmr"
+          ]
+        }
+      ],
+      "warnings": ["evidence_pack_partial"]
     }
   }
 }

--- a/ingestion/contracts/__init__.py
+++ b/ingestion/contracts/__init__.py
@@ -1,0 +1,308 @@
+"""
+Canonical ingestion contracts for parser output readiness.
+
+LegalUnit is the citable legal unit and source of legal truth. LegalChunk is a
+retrieval/vector record derived from one or more LegalUnit records. In v1, each
+LegalChunk is 1:1 with a LegalUnit, and evidence/citations must keep using the
+LegalUnit id rather than the chunk id.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import date, datetime, timezone
+from typing import Any, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+LegalStatus = Literal["active", "historical", "repealed", "unknown"]
+
+ParsedLegalEdgeType = Literal[
+    "contains",
+    "references",
+    "amends",
+    "repeals",
+    "derogates_from",
+    "exception_to",
+    "defines",
+    "sanctions",
+    "creates_obligation",
+    "creates_right",
+    "creates_prohibition",
+    "procedure_step",
+    "same_topic_as",
+    "semantically_related",
+    "historical_version_of",
+]
+
+ReferenceResolutionStatus = Literal[
+    "resolved_high_confidence",
+    "resolved_medium_confidence",
+    "candidate_ambiguous",
+    "external_unresolved",
+    "unresolved",
+]
+
+LEGAL_UNIT_FIELDS = {
+    "id",
+    "canonical_id",
+    "source_id",
+    "law_id",
+    "law_title",
+    "act_type",
+    "act_number",
+    "publication_date",
+    "effective_date",
+    "version_start",
+    "version_end",
+    "status",
+    "hierarchy_path",
+    "article_number",
+    "paragraph_number",
+    "letter_number",
+    "point_number",
+    "raw_text",
+    "normalized_text",
+    "legal_domain",
+    "legal_concepts",
+    "source_url",
+    "parent_id",
+    "children_ids",
+    "outgoing_reference_ids",
+    "incoming_reference_ids",
+}
+
+
+class IngestionContract(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ParserActMetadata(IngestionContract):
+    law_id: str
+    law_title: str
+    legal_domain: str
+    act_type: str | None = None
+    act_number: str | None = None
+    source_id: str | None = None
+    source_url: str | None = None
+    publication_date: date | None = None
+    effective_date: date | None = None
+    version_start: date | None = None
+    version_end: date | None = None
+    status: LegalStatus = "unknown"
+    parser_version: str = "0.1.0"
+
+
+class ParsedLegalUnit(IngestionContract):
+    id: str
+    canonical_id: str | None = None
+    source_id: str | None = None
+    law_id: str
+    law_title: str
+    act_type: str | None = None
+    act_number: str | None = None
+    publication_date: date | None = None
+    effective_date: date | None = None
+    version_start: date | None = None
+    version_end: date | None = None
+    status: LegalStatus
+    hierarchy_path: list[str]
+    article_number: str | None = None
+    paragraph_number: str | None = None
+    letter_number: str | None = None
+    point_number: str | None = None
+    raw_text: str
+    normalized_text: str | None = None
+    legal_domain: str
+    legal_concepts: list[str] = Field(default_factory=list)
+    source_url: str | None = None
+    parent_id: str | None = None
+    children_ids: list[str] = Field(default_factory=list)
+    outgoing_reference_ids: list[str] = Field(default_factory=list)
+    incoming_reference_ids: list[str] = Field(default_factory=list)
+    parser_warnings: list[str] = Field(default_factory=list)
+
+    def to_legal_unit_dict(self) -> dict[str, Any]:
+        """Return the API LegalUnit-compatible shape used by retrieval/evidence."""
+        return self.model_dump(include=LEGAL_UNIT_FIELDS)
+
+
+class ParsedLegalEdge(IngestionContract):
+    id: str
+    source_id: str
+    target_id: str
+    type: ParsedLegalEdgeType
+    weight: float = Field(default=1.0, ge=0.0)
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class LegalChunk(IngestionContract):
+    """Vector/retrieval record derived from LegalUnit, not a citation target."""
+
+    chunk_id: str
+    legal_unit_id: str
+    legal_unit_ids: list[str]
+    chunk_type: Literal["legal_unit", "multi_unit"] = "legal_unit"
+    chunk_version: str = "v1"
+    law_id: str
+    law_title: str
+    legal_domain: str
+    hierarchy_path: list[str]
+    article_number: str | None = None
+    paragraph_number: str | None = None
+    letter_number: str | None = None
+    point_number: str | None = None
+    raw_text: str
+    normalized_text: str | None = None
+    embedding_text: str = Field(min_length=1)
+    source_url: str | None = None
+    source_id: str | None = None
+    text_hash: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def from_legal_unit(
+        cls,
+        legal_unit: ParsedLegalUnit | BaseModel | Mapping[str, Any],
+        *,
+        chunk_version: str = "v1",
+        metadata: dict[str, Any] | None = None,
+    ) -> "LegalChunk":
+        unit = _legal_unit_mapping(legal_unit)
+        legal_unit_id = unit["id"]
+        embedding_text = _build_embedding_text(unit)
+
+        return cls(
+            chunk_id=f"chunk.{legal_unit_id}.{chunk_version}",
+            legal_unit_id=legal_unit_id,
+            legal_unit_ids=[legal_unit_id],
+            chunk_version=chunk_version,
+            law_id=unit["law_id"],
+            law_title=unit["law_title"],
+            legal_domain=unit["legal_domain"],
+            hierarchy_path=list(unit.get("hierarchy_path", [])),
+            article_number=unit.get("article_number"),
+            paragraph_number=unit.get("paragraph_number"),
+            letter_number=unit.get("letter_number"),
+            point_number=unit.get("point_number"),
+            raw_text=unit["raw_text"],
+            normalized_text=unit.get("normalized_text"),
+            embedding_text=embedding_text,
+            source_url=unit.get("source_url"),
+            source_id=unit.get("source_id"),
+            text_hash=_stable_text_hash(embedding_text),
+            metadata=metadata or {},
+        )
+
+
+class ReferenceCandidate(IngestionContract):
+    source_unit_id: str
+    raw_reference: str
+    reference_type: str
+    target_law_hint: str | None = None
+    target_article: str | None = None
+    target_paragraph: str | None = None
+    target_letter: str | None = None
+    target_point: str | None = None
+    resolved_target_id: str | None = None
+    resolution_status: ReferenceResolutionStatus = "unresolved"
+    resolution_confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    resolver_notes: list[str] = Field(default_factory=list)
+
+
+class CorpusManifest(IngestionContract):
+    batch_id: str
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    schema_version: str = "1.0.0"
+    sources: list[ParserActMetadata] = Field(default_factory=list)
+    output_dir: str
+    files: dict[str, str] = Field(default_factory=dict)
+
+
+class ValidationReport(IngestionContract):
+    schema_version: str = "1.0"
+    parser_version: str
+    corpus_quality: float = Field(ge=0.0, le=1.0)
+    units_count: int = Field(ge=0)
+    edges_count: int = Field(ge=0)
+    chunks_count: int = Field(default=0, ge=0)
+    reference_candidates_count: int = Field(default=0, ge=0)
+    quality_metrics: dict[str, float]
+    warnings: list[str] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+
+    @field_validator("quality_metrics")
+    @classmethod
+    def validate_quality_metrics(cls, metrics: dict[str, float]) -> dict[str, float]:
+        for name, value in metrics.items():
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"quality_metrics.{name} must be in [0, 1]")
+        return metrics
+
+
+class EmbeddingInputRecord(IngestionContract):
+    chunk_id: str
+    legal_unit_id: str
+    embedding_text: str = Field(min_length=1)
+    text_hash: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def from_chunk(
+        cls,
+        chunk: LegalChunk | BaseModel | Mapping[str, Any],
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> "EmbeddingInputRecord":
+        chunk_data = _model_mapping(chunk)
+        return cls(
+            chunk_id=chunk_data["chunk_id"],
+            legal_unit_id=chunk_data["legal_unit_id"],
+            embedding_text=chunk_data["embedding_text"],
+            text_hash=chunk_data["text_hash"],
+            metadata=metadata if metadata is not None else chunk_data.get("metadata", {}),
+        )
+
+
+def _legal_unit_mapping(legal_unit: ParsedLegalUnit | BaseModel | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(legal_unit, ParsedLegalUnit):
+        return legal_unit.to_legal_unit_dict()
+    return _model_mapping(legal_unit)
+
+
+def _model_mapping(value: BaseModel | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    return dict(value)
+
+
+def _build_embedding_text(unit: Mapping[str, Any]) -> str:
+    hierarchy = " > ".join(unit.get("hierarchy_path") or [])
+    body = unit.get("normalized_text") or unit.get("raw_text") or ""
+    parts = [
+        f"Domain: {unit.get('legal_domain', '')}",
+        f"Law: {unit.get('law_title', '')}",
+    ]
+    if hierarchy:
+        parts.append(f"Path: {hierarchy}")
+    parts.append("")
+    parts.append(body)
+    return "\n".join(parts).strip()
+
+
+def _stable_text_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "CorpusManifest",
+    "EmbeddingInputRecord",
+    "LegalChunk",
+    "ParserActMetadata",
+    "ParsedLegalEdge",
+    "ParsedLegalUnit",
+    "ReferenceCandidate",
+    "ValidationReport",
+]

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from apps.api.app.main import app
-from apps.api.app.routers import health as health_module
+from apps.api.app.routes import health as health_module
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -79,7 +79,7 @@ def test_legacy_health_does_not_require_database():
 
 
 def test_api_health_db_returns_503_without_database_url(monkeypatch):
-    import apps.api.app.db as db_module
+    import apps.api.app.db.session as db_module
 
     monkeypatch.setattr(db_module.settings, "database_url", None)
     monkeypatch.setattr(db_module, "_engine", None)

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -75,6 +75,12 @@ def test_post_api_query_debug_true_includes_debug_payload():
     assert "sanctions" in priorities
     assert "creates_obligation" in priorities
     assert "creates_prohibition" in priorities
+    legal_ranker = debug["legal_ranker"]
+    assert legal_ranker["fallback_used"] is True
+    assert legal_ranker["input_candidate_count"] == 0
+    assert legal_ranker["ranked_candidate_count"] == 0
+    assert legal_ranker["ranked_candidates"] == []
+    assert "legal_ranker_no_candidates" in legal_ranker["warnings"]
 
 
 def test_post_api_query_debug_false_returns_null_debug():
@@ -85,6 +91,7 @@ def test_post_api_query_debug_false_returns_null_debug():
     assert payload["debug"] is None
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
+    assert "legal_ranker_no_candidates" in payload["warnings"]
 
 
 def test_post_api_query_debug_true_includes_exact_citations():
@@ -117,7 +124,9 @@ def test_post_api_query_debug_true_includes_exact_citations():
     assert payload["verifier"]["verifier_passed"] is False
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
+    assert "legal_ranker_no_candidates" in payload["warnings"]
     assert payload["debug"]["graph_expansion"]["fallback_used"] is True
+    assert payload["debug"]["legal_ranker"]["fallback_used"] is True
 
 
 def test_handoff04_graph_endpoints_are_not_registered():

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -1,6 +1,9 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from apps.api.app.main import app
+from apps.api.app.schemas import QueryRequest, RawRetrievalResponse, RetrievalCandidate
+from apps.api.app.services.query_orchestrator import QueryOrchestrator
 
 
 VALID_QUERY = {
@@ -16,7 +19,7 @@ def post_query(payload: dict) -> object:
         return client.post("/api/query", json=payload)
 
 
-def test_post_api_query_returns_mock_evidence_pack():
+def test_post_api_query_returns_unverified_fallback_without_retrieval():
     response = post_query({**VALID_QUERY, "debug": False})
 
     assert response.status_code == 200
@@ -26,12 +29,12 @@ def test_post_api_query_returns_mock_evidence_pack():
     assert payload["answer"]["confidence"] == 0.0
     assert payload["answer"]["not_legal_advice"] is True
     assert payload["answer"]["refusal_reason"] == "mock_evidence_pack_not_verified"
-    assert len(payload["citations"]) >= 2
-    assert len(payload["evidence_units"]) >= 3
+    assert payload["citations"] == []
+    assert payload["evidence_units"] == []
     assert payload["verifier"]["verifier_passed"] is False
-    assert payload["graph"]["nodes"]
-    assert payload["graph"]["edges"]
-    assert payload["warnings"]
+    assert payload["graph"]["nodes"] == []
+    assert payload["graph"]["edges"] == []
+    assert "evidence_pack_no_ranked_candidates" in payload["warnings"]
 
 
 def test_post_api_query_uses_snake_case_fields():
@@ -40,9 +43,9 @@ def test_post_api_query_uses_snake_case_fields():
     payload = response.json()
     assert "query_id" in payload
     assert "short_answer" in payload["answer"]
-    assert "id" in payload["evidence_units"][0]["legal_unit"]
     assert "groundedness_score" in payload["verifier"]
-    assert "source" in payload["graph"]["edges"][0]
+    assert "evidence_units" in payload
+    assert "nodes" in payload["graph"]
 
 
 def test_post_api_query_debug_true_includes_debug_payload():
@@ -52,7 +55,7 @@ def test_post_api_query_debug_true_includes_debug_payload():
     debug = response.json()["debug"]
     assert debug["orchestrator"] == "QueryOrchestrator"
     assert debug["evidence_service"] == "MockEvidenceService"
-    assert debug["evidence_units_count"] >= 3
+    assert debug["evidence_units_count"] == 0
     assert debug["query_understanding"]["legal_domain"] == "muncă"
     assert debug["query_understanding"]["domain_confidence"] >= 0.70
     assert "prohibition" in debug["query_understanding"]["query_types"]
@@ -81,6 +84,11 @@ def test_post_api_query_debug_true_includes_debug_payload():
     assert legal_ranker["ranked_candidate_count"] == 0
     assert legal_ranker["ranked_candidates"] == []
     assert "legal_ranker_no_candidates" in legal_ranker["warnings"]
+    evidence_pack = debug["evidence_pack"]
+    assert evidence_pack["fallback_used"] is True
+    assert evidence_pack["input_ranked_candidate_count"] == 0
+    assert evidence_pack["selected_evidence_count"] == 0
+    assert "evidence_pack_no_ranked_candidates" in evidence_pack["warnings"]
 
 
 def test_post_api_query_debug_false_returns_null_debug():
@@ -92,6 +100,7 @@ def test_post_api_query_debug_false_returns_null_debug():
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
     assert "legal_ranker_no_candidates" in payload["warnings"]
+    assert "evidence_pack_no_ranked_candidates" in payload["warnings"]
 
 
 def test_post_api_query_debug_true_includes_exact_citations():
@@ -125,13 +134,89 @@ def test_post_api_query_debug_true_includes_exact_citations():
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
     assert "legal_ranker_no_candidates" in payload["warnings"]
+    assert "evidence_pack_no_ranked_candidates" in payload["warnings"]
     assert payload["debug"]["graph_expansion"]["fallback_used"] is True
     assert payload["debug"]["legal_ranker"]["fallback_used"] is True
+    assert payload["debug"]["evidence_pack"]["fallback_used"] is True
+
+
+class FakeRawRetrieverClient:
+    async def retrieve(self, plan, *, top_k: int = 50, debug: bool = False):
+        return RawRetrievalResponse(
+            candidates=[
+                RetrievalCandidate(
+                    unit_id="ro.codul_muncii.art_41",
+                    rank=1,
+                    retrieval_score=0.78,
+                    score_breakdown={"bm25": 0.9, "dense": 0.7},
+                    why_retrieved="fixture_candidate",
+                    unit={
+                        "id": "ro.codul_muncii.art_41",
+                        "law_id": "ro.codul_muncii",
+                        "law_title": "Codul muncii",
+                        "status": "active",
+                        "hierarchy_path": ["Codul muncii", "art. 41"],
+                        "article_number": "41",
+                        "raw_text": "Contractul individual de munca poate fi modificat prin acordul partilor.",
+                        "legal_domain": "munca",
+                        "legal_concepts": ["contract", "salariu"],
+                        "source_url": "https://legislatie.just.ro/test",
+                        "type": "articol",
+                    },
+                )
+            ],
+            retrieval_methods=["fixture"],
+            warnings=[],
+            debug={
+                "fallback_used": False,
+                "request_payload": {
+                    "question": plan.question,
+                    "retrieval_filters": plan.retrieval_filters,
+                    "exact_citations": [],
+                    "top_k": top_k,
+                    "debug": debug,
+                },
+            }
+            if debug
+            else None,
+        )
+
+
+@pytest.mark.anyio
+async def test_query_orchestrator_populates_evidence_units_with_fake_candidates():
+    orchestrator = QueryOrchestrator(raw_retriever_client=FakeRawRetrieverClient())
+    response = await orchestrator.run(QueryRequest(**VALID_QUERY, debug=True))
+
+    assert len(response.evidence_units) == 1
+    evidence = response.evidence_units[0]
+    assert evidence.id == "ro.codul_muncii.art_41"
+    assert evidence.law_title == "Codul muncii"
+    assert evidence.raw_text == "Contractul individual de munca poate fi modificat prin acordul partilor."
+    assert evidence.excerpt == "Contractul individual de munca poate fi modificat prin acordul partilor."
+    assert evidence.retrieval_score == 0.78
+    assert evidence.rerank_score is not None
+    assert evidence.support_role in {"direct_basis", "condition"}
+    assert "selected_by_mmr" in evidence.why_selected
+    assert evidence.score_breakdown
+    evidence_payload = response.model_dump(mode="json")["evidence_units"][0]
+    assert "legal_unit" not in evidence_payload
+    assert evidence_payload["id"] == "ro.codul_muncii.art_41"
+    assert evidence_payload["law_title"] == "Codul muncii"
+    assert evidence_payload["retrieval_score"] == 0.78
+    assert evidence_payload["support_role"] in {"direct_basis", "condition"}
+    assert isinstance(evidence_payload["why_selected"], list)
+    assert evidence_payload["score_breakdown"]
+    assert response.graph.nodes
+    assert response.debug.evidence_pack["fallback_used"] is False
+    assert response.debug.evidence_pack["selected_evidence_count"] == 1
+    assert response.answer.confidence == 0.0
+    assert response.verifier.verifier_passed is False
 
 
 def test_handoff04_graph_endpoints_are_not_registered():
     paths = {route.path for route in app.routes}
 
+    assert "/api/retrieve/raw" not in paths
     assert "/api/legal-units/{id}/neighbors" not in paths
     assert "/api/explore/root" not in paths
     assert "/api/explore/node/{id}/children" not in paths

--- a/tests/test_evidence_pack_compiler.py
+++ b/tests/test_evidence_pack_compiler.py
@@ -1,0 +1,235 @@
+from apps.api.app.schemas import (
+    GraphExpansionResult,
+    RankedCandidate,
+    RankerFeatureBreakdown,
+)
+from apps.api.app.services.evidence_pack_compiler import (
+    EVIDENCE_PACK_NO_RANKED_CANDIDATES,
+    EvidencePackCompiler,
+)
+
+
+def unit(unit_id: str, text: str, **overrides):
+    data = {
+        "id": unit_id,
+        "law_id": "ro.codul_muncii",
+        "law_title": "Codul muncii",
+        "status": "active",
+        "hierarchy_path": ["Codul muncii"],
+        "article_number": "41",
+        "raw_text": text,
+        "legal_domain": "munca",
+        "legal_concepts": ["salariu", "contract"],
+        "source_url": "https://legislatie.just.ro/test",
+        "type": "articol",
+    }
+    data.update(overrides)
+    return data
+
+
+def ranked(
+    unit_id: str,
+    *,
+    rank: int = 1,
+    score: float = 0.8,
+    text: str = "salariu contract act aditional",
+    why_ranked: list[str] | None = None,
+    unit_overrides: dict | None = None,
+) -> RankedCandidate:
+    return RankedCandidate(
+        unit_id=unit_id,
+        rank=rank,
+        rerank_score=score,
+        retrieval_score=score - 0.1,
+        unit=unit(unit_id, text, **(unit_overrides or {})),
+        score_breakdown=RankerFeatureBreakdown(
+            bm25_score=score,
+            dense_score=score,
+            domain_match=1.0,
+            graph_proximity=1.0,
+        ),
+        why_ranked=why_ranked or ["domain_match:munca"],
+        source="raw_retrieval",
+    )
+
+
+def test_no_ranked_candidates_returns_safe_fallback():
+    result = EvidencePackCompiler().compile(
+        ranked_candidates=[],
+        debug=True,
+    )
+
+    assert result.evidence_units == []
+    assert result.graph_nodes == []
+    assert result.graph_edges == []
+    assert result.warnings == [EVIDENCE_PACK_NO_RANKED_CANDIDATES]
+    assert result.debug["fallback_used"] is True
+    assert result.debug["input_ranked_candidate_count"] == 0
+    assert result.debug["selected_evidence_count"] == 0
+
+
+def test_mmr_penalizes_redundant_text_and_diversifies_selection():
+    compiler = EvidencePackCompiler(target_evidence_units=2, max_evidence_units=2)
+    first = ranked(
+        "ro.codul_muncii.art_41",
+        rank=1,
+        score=0.9,
+        text="salariu contract act aditional angajator",
+    )
+    redundant = ranked(
+        "ro.codul_muncii.art_42",
+        rank=2,
+        score=0.88,
+        text="salariu contract act aditional angajator",
+    )
+    diverse = ranked(
+        "ro.codul_muncii.art_260",
+        rank=3,
+        score=0.7,
+        text="amenda contraventie inspectorat sanctiune",
+    )
+
+    result = compiler.compile(
+        ranked_candidates=[first, redundant, diverse],
+        debug=True,
+    )
+
+    assert [item.id for item in result.evidence_units] == [
+        "ro.codul_muncii.art_41",
+        "ro.codul_muncii.art_260",
+    ]
+    assert result.debug["selected_units"][1]["unit_id"] == "ro.codul_muncii.art_260"
+
+
+def test_duplicate_unit_ids_are_selected_once():
+    result = EvidencePackCompiler(target_evidence_units=3).compile(
+        ranked_candidates=[
+            ranked("ro.codul_muncii.art_41", rank=1, score=0.7),
+            ranked("ro.codul_muncii.art_41", rank=2, score=0.9),
+        ],
+        debug=True,
+    )
+
+    assert len(result.evidence_units) == 1
+    assert result.evidence_units[0].id == "ro.codul_muncii.art_41"
+
+
+def test_support_roles_are_classified_deterministically():
+    compiler = EvidencePackCompiler(target_evidence_units=4, max_evidence_units=4)
+    result = compiler.compile(
+        ranked_candidates=[
+            ranked(
+                "ro.codul_muncii.exception",
+                rank=1,
+                score=0.9,
+                text="Cu exceptia cazurilor prevazute de lege.",
+                why_ranked=["exception_candidate"],
+            ),
+            ranked(
+                "ro.codul_muncii.definition",
+                rank=2,
+                score=0.8,
+                text="In sensul prezentei legi, salariatul se intelege ca persoana fizica.",
+                why_ranked=["definition_candidate"],
+            ),
+            ranked(
+                "ro.codul_muncii.sanction",
+                rank=3,
+                score=0.7,
+                text="Constituie contraventie si se sanctioneaza cu amenda.",
+                why_ranked=["sanction_candidate"],
+            ),
+            ranked(
+                "ro.codul_muncii.condition",
+                rank=4,
+                score=0.6,
+                text="Modificarea se poate face numai daca partile sunt de acord.",
+            ),
+        ],
+        debug=True,
+    )
+
+    roles = {
+        evidence.id: evidence.support_role
+        for evidence in result.evidence_units
+    }
+    assert roles["ro.codul_muncii.exception"] == "exception"
+    assert roles["ro.codul_muncii.definition"] == "definition"
+    assert roles["ro.codul_muncii.sanction"] == "sanction"
+    assert roles["ro.codul_muncii.condition"] == "condition"
+
+
+def test_parent_context_is_included_only_when_parent_exists_in_input():
+    compiler = EvidencePackCompiler(target_evidence_units=1, max_evidence_units=2)
+    child = ranked(
+        "ro.codul_muncii.art_41.alin_1",
+        rank=1,
+        score=0.9,
+        unit_overrides={
+            "paragraph_number": "1",
+            "parent_id": "ro.codul_muncii.art_41",
+            "type": "alineat",
+        },
+    )
+    parent = ranked(
+        "ro.codul_muncii.art_41",
+        rank=2,
+        score=0.2,
+        text="Articolul 41 reglementeaza modificarea contractului.",
+        unit_overrides={"type": "articol"},
+    )
+
+    result = compiler.compile(
+        ranked_candidates=[child, parent],
+        graph_expansion=GraphExpansionResult(),
+        debug=True,
+    )
+
+    assert [evidence.id for evidence in result.evidence_units] == [
+        "ro.codul_muncii.art_41.alin_1",
+        "ro.codul_muncii.art_41",
+    ]
+    assert result.evidence_units[1].support_role == "context"
+
+
+def test_parent_context_is_not_included_when_parent_is_missing():
+    compiler = EvidencePackCompiler(target_evidence_units=1, max_evidence_units=2)
+    child = ranked(
+        "ro.codul_muncii.art_41.alin_1",
+        rank=1,
+        score=0.9,
+        unit_overrides={
+            "paragraph_number": "1",
+            "parent_id": "ro.codul_muncii.art_41",
+            "type": "alineat",
+        },
+    )
+
+    result = compiler.compile(ranked_candidates=[child], debug=True)
+
+    assert [evidence.id for evidence in result.evidence_units] == [
+        "ro.codul_muncii.art_41.alin_1",
+    ]
+
+
+def test_compiler_preserves_text_source_scores_and_selection_reasons():
+    result = EvidencePackCompiler(target_evidence_units=1).compile(
+        ranked_candidates=[
+            ranked(
+                "ro.codul_muncii.art_41",
+                score=0.86,
+                why_ranked=["domain_match:munca", "high_bm25_score"],
+            )
+        ],
+        debug=True,
+    )
+
+    evidence = result.evidence_units[0]
+    assert evidence.id == "ro.codul_muncii.art_41"
+    assert evidence.excerpt == "salariu contract act aditional"
+    assert evidence.source_url == "https://legislatie.just.ro/test"
+    assert evidence.rerank_score == 0.86
+    assert evidence.retrieval_score == 0.76
+    assert evidence.score_breakdown["bm25_score"] == 0.86
+    assert "high_bm25_score" in evidence.why_selected
+    assert "selected_by_mmr" in evidence.why_selected

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -1,0 +1,151 @@
+import pytest
+from pydantic import ValidationError
+
+from apps.api.app.schemas.query import LegalUnit
+from ingestion.contracts import (
+    CorpusManifest,
+    EmbeddingInputRecord,
+    LegalChunk,
+    ParserActMetadata,
+    ParsedLegalEdge,
+    ParsedLegalUnit,
+    ReferenceCandidate,
+    ValidationReport,
+)
+
+
+def make_parsed_unit() -> ParsedLegalUnit:
+    return ParsedLegalUnit(
+        id="ro.codul_muncii.art_1.alin_1",
+        canonical_id="ro.codul_muncii.art_1.alin_1",
+        source_id="legislatie.just.ro:53/2003",
+        law_id="ro.codul_muncii",
+        law_title="Codul muncii",
+        act_type="lege",
+        act_number="53/2003",
+        status="active",
+        hierarchy_path=["Art. 1", "(1)"],
+        article_number="1",
+        paragraph_number="1",
+        raw_text="(1) Prezentul cod reglementeaza raporturile de munca.",
+        normalized_text="Prezentul cod reglementeaza raporturile de munca.",
+        legal_domain="dreptul_muncii",
+        legal_concepts=["raporturi_de_munca"],
+        source_url="https://legislatie.just.ro/Public/DetaliiDocument/53",
+        parent_id="ro.codul_muncii.art_1",
+        parser_warnings=["legacy-parser-shape"],
+    )
+
+
+def test_parsed_legal_unit_exports_api_legal_unit_shape():
+    parsed = make_parsed_unit()
+
+    legal_unit_dict = parsed.to_legal_unit_dict()
+    validated = LegalUnit.model_validate(legal_unit_dict)
+
+    assert "parser_warnings" not in legal_unit_dict
+    assert validated.id == parsed.id
+    assert validated.law_id == parsed.law_id
+    assert validated.raw_text == parsed.raw_text
+    assert validated.legal_concepts == ["raporturi_de_munca"]
+
+
+def test_legal_chunk_from_legal_unit_is_deterministic_and_citable_bridge_is_preserved():
+    parsed = make_parsed_unit()
+
+    chunk = LegalChunk.from_legal_unit(parsed)
+    repeated = LegalChunk.from_legal_unit(parsed)
+
+    assert chunk.chunk_id == "chunk.ro.codul_muncii.art_1.alin_1.v1"
+    assert chunk.legal_unit_id == parsed.id
+    assert chunk.legal_unit_ids == [parsed.id]
+    assert chunk.embedding_text.strip()
+    assert chunk.text_hash == repeated.text_hash
+
+
+def test_parsed_legal_edge_accepts_only_canonical_edge_types():
+    edge = ParsedLegalEdge(
+        id="edge.ro.codul_muncii.art_1.contains.ro.codul_muncii.art_1.alin_1",
+        source_id="ro.codul_muncii.art_1",
+        target_id="ro.codul_muncii.art_1.alin_1",
+        type="contains",
+    )
+
+    assert edge.type == "contains"
+    with pytest.raises(ValidationError):
+        ParsedLegalEdge(
+            id="edge.invalid",
+            source_id="ro.codul_muncii.art_1",
+            target_id="ro.codul_muncii.art_2",
+            type="retrieved_for_query",
+        )
+
+
+def test_reference_candidate_accepts_only_canonical_resolution_statuses():
+    candidate = ReferenceCandidate(
+        source_unit_id="ro.codul_muncii.art_5",
+        raw_reference="art. 4 alin. (1)",
+        reference_type="article",
+        target_article="4",
+        target_paragraph="1",
+        resolution_status="resolved_high_confidence",
+        resolution_confidence=0.95,
+    )
+
+    assert candidate.resolution_status == "resolved_high_confidence"
+    with pytest.raises(ValidationError):
+        ReferenceCandidate(
+            source_unit_id="ro.codul_muncii.art_5",
+            raw_reference="art. 4",
+            reference_type="article",
+            resolution_status="resolved",
+        )
+
+
+def test_embedding_input_record_preserves_chunk_and_legal_unit_ids():
+    chunk = LegalChunk.from_legal_unit(make_parsed_unit())
+
+    record = EmbeddingInputRecord.from_chunk(chunk)
+
+    assert record.chunk_id == chunk.chunk_id
+    assert record.legal_unit_id == chunk.legal_unit_id
+    assert record.embedding_text == chunk.embedding_text
+    assert record.text_hash == chunk.text_hash
+
+
+def test_validation_report_metrics_are_unit_interval_values():
+    report = ValidationReport(
+        parser_version="0.1.0",
+        corpus_quality=0.9,
+        units_count=1,
+        edges_count=1,
+        chunks_count=1,
+        reference_candidates_count=1,
+        quality_metrics={"schema_validity": 1.0, "reference_resolution": 0.5},
+    )
+
+    assert report.quality_metrics["schema_validity"] == 1.0
+    with pytest.raises(ValidationError):
+        ValidationReport(
+            parser_version="0.1.0",
+            corpus_quality=0.9,
+            units_count=1,
+            edges_count=1,
+            quality_metrics={"schema_validity": 1.01},
+        )
+
+
+def test_contracts_instantiate_without_db_or_network_dependencies():
+    metadata = ParserActMetadata(
+        law_id="ro.codul_muncii",
+        law_title="Codul muncii",
+        legal_domain="dreptul_muncii",
+    )
+    manifest = CorpusManifest(
+        batch_id="demo_corpus_v1",
+        sources=[metadata],
+        output_dir="ingestion/output/demo_corpus_v1",
+    )
+
+    assert manifest.sources[0].law_id == "ro.codul_muncii"
+    assert manifest.files == {}

--- a/tests/test_legal_ranker.py
+++ b/tests/test_legal_ranker.py
@@ -1,0 +1,233 @@
+from apps.api.app.schemas import (
+    ExpandedCandidate,
+    GraphExpansionResult,
+    QueryRequest,
+    RawRetrievalResponse,
+    RetrievalCandidate,
+)
+from apps.api.app.services.legal_ranker import (
+    LEGAL_RANKER_NO_CANDIDATES,
+    LegalRanker,
+)
+from apps.api.app.services.query_understanding import QueryUnderstanding
+
+
+def build_plan(question: str):
+    request = QueryRequest(
+        question=question,
+        jurisdiction="RO",
+        date="current",
+        mode="strict_citations",
+        debug=True,
+    )
+    return QueryUnderstanding().build_plan(request)
+
+
+def candidate(
+    unit_id: str,
+    *,
+    rank: int = 1,
+    score_breakdown: dict[str, float] | None = None,
+    unit: dict | None = None,
+) -> RetrievalCandidate:
+    return RetrievalCandidate(
+        unit_id=unit_id,
+        rank=rank,
+        retrieval_score=score_breakdown.get("bm25", 0.0) if score_breakdown else 0.0,
+        score_breakdown=score_breakdown or {},
+        unit=unit or {
+            "legal_domain": "munca",
+            "status": "active",
+            "law_id": "ro.codul_muncii",
+            "raw_text": "salariu contract act aditional",
+            "type": "articol",
+        },
+    )
+
+
+def empty_graph() -> GraphExpansionResult:
+    return GraphExpansionResult()
+
+
+def test_no_candidates_returns_safe_fallback():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[]),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    assert result.ranked_candidates == []
+    assert result.warnings == [LEGAL_RANKER_NO_CANDIDATES]
+    assert result.debug["fallback_used"] is True
+    assert result.debug["input_candidate_count"] == 0
+    assert result.debug["ranked_candidate_count"] == 0
+
+
+def test_candidates_are_sorted_by_descending_rerank_score():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    low = candidate("ro.codul_muncii.art_10", score_breakdown={"bm25": 0.1})
+    high = candidate(
+        "ro.codul_muncii.art_41",
+        score_breakdown={"bm25": 0.9, "dense": 0.8},
+    )
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[low, high]),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    assert [candidate.unit_id for candidate in result.ranked_candidates] == [
+        "ro.codul_muncii.art_41",
+        "ro.codul_muncii.art_10",
+    ]
+    assert result.ranked_candidates[0].rerank_score > result.ranked_candidates[1].rerank_score
+
+
+def test_exact_citation_candidate_gets_boost_and_ranks_first():
+    plan = build_plan("Ce spune art. 41 alin. (1) din Codul muncii?")
+    exact = candidate(
+        "ro.codul_muncii.art_41.alin_1",
+        rank=2,
+        score_breakdown={"bm25": 0.2},
+    )
+    generic = candidate(
+        "ro.codul_muncii.art_99",
+        rank=1,
+        score_breakdown={"bm25": 0.2},
+    )
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[generic, exact]),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    top = result.ranked_candidates[0]
+    assert top.unit_id == "ro.codul_muncii.art_41.alin_1"
+    assert top.score_breakdown.exact_citation_match == 1.0
+    assert "exact_citation_match" in top.why_ranked
+
+
+def test_domain_match_for_labor_question():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(
+            candidates=[
+                candidate(
+                    "ro.codul_muncii.art_41",
+                    unit={"legal_domain": "munca", "status": "active"},
+                )
+            ]
+        ),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    ranked = result.ranked_candidates[0]
+    assert ranked.score_breakdown.domain_match == 1.0
+    assert "domain_match:munca" in ranked.why_ranked
+
+
+def test_graph_proximity_influences_score():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    graph = GraphExpansionResult(
+        expanded_candidates=[
+            ExpandedCandidate(
+                unit_id="ro.codul_muncii.art_41",
+                source="graph_expansion",
+                graph_distance=1,
+                graph_proximity=0.9,
+            ),
+            ExpandedCandidate(
+                unit_id="ro.codul_muncii.art_42",
+                source="graph_expansion",
+                graph_distance=1,
+                graph_proximity=0.1,
+            ),
+        ]
+    )
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[]),
+        graph_expansion=graph,
+        debug=True,
+    )
+
+    assert result.ranked_candidates[0].unit_id == "ro.codul_muncii.art_41"
+    assert result.ranked_candidates[0].score_breakdown.graph_proximity == 0.9
+
+
+def test_repealed_status_gets_zero_temporal_validity():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(
+            candidates=[
+                candidate(
+                    "ro.codul_muncii.art_41",
+                    unit={"legal_domain": "munca", "status": "repealed"},
+                )
+            ]
+        ),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    assert result.ranked_candidates[0].score_breakdown.temporal_validity == 0.0
+
+
+def test_scores_are_normalized_and_clamped_to_unit_interval():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(
+            candidates=[
+                candidate("ro.codul_muncii.art_1", score_breakdown={"bm25": 10.0}),
+                candidate("ro.codul_muncii.art_2", score_breakdown={"bm25": -2.0}),
+            ]
+        ),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    for ranked in result.ranked_candidates:
+        assert 0.0 <= ranked.rerank_score <= 1.0
+        for value in ranked.score_breakdown.model_dump().values():
+            assert 0.0 <= value <= 1.0
+
+
+def test_tie_break_is_deterministic_by_raw_rank_then_unit_id():
+    plan = build_plan("Poate angajatorul sa-mi scada salariul fara act aditional?")
+    first = candidate("ro.codul_muncii.art_a", rank=1, score_breakdown={"bm25": 0.5})
+    second = candidate("ro.codul_muncii.art_b", rank=2, score_breakdown={"bm25": 0.5})
+
+    result = LegalRanker().rank(
+        question=plan.question,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[second, first]),
+        graph_expansion=empty_graph(),
+        debug=True,
+    )
+
+    assert [candidate.unit_id for candidate in result.ranked_candidates] == [
+        "ro.codul_muncii.art_a",
+        "ro.codul_muncii.art_b",
+    ]


### PR DESCRIPTION
This pull request introduces several new API endpoints and schema improvements to support ingestion, legal unit access, and legal ranking, along with enhancements to the query pipeline and mock evidence handling. The changes enable background ingestion of legal documents, retrieval and pagination of legal units, and integration of a deterministic LegalRanker into the query workflow. Additionally, the data models for evidence units and ranking are expanded to support richer debugging and feature breakdowns.

**New API Endpoints and Features:**

* Added `/api/ingest` endpoint for background ingestion of legal documents from a URL, running the ingestion script as a background task. (`apps/api/app/routes/ingest.py`, `apps/api/app/main.py`) [[1]](diffhunk://#diff-990083eefff0f6cdb612991248ba2bd9fa48d96e85151ad2c8389bb3015e9cb8R1-R46) [[2]](diffhunk://#diff-0771a71b48a4e4d43c41b6b707518e44ec24d56323a1d19c5fff1781ad81052aR9-R11) [[3]](diffhunk://#diff-0771a71b48a4e4d43c41b6b707518e44ec24d56323a1d19c5fff1781ad81052aR37-R39)
* Added `/api/legal-units/{corpus_id}` endpoint to retrieve and paginate atomic legal units from ingested corpora. (`apps/api/app/routes/legal_units.py`, `apps/api/app/main.py`) [[1]](diffhunk://#diff-02f4446ce173743207ae5bcdf850474f2633b6a48c4ba3f942e1b3c5cab2bd53R1-R32) [[2]](diffhunk://#diff-0771a71b48a4e4d43c41b6b707518e44ec24d56323a1d19c5fff1781ad81052aR9-R11) [[3]](diffhunk://#diff-0771a71b48a4e4d43c41b6b707518e44ec24d56323a1d19c5fff1781ad81052aR37-R39)

**LegalRanker Integration:**

* Introduced `LegalRanker` into the query orchestrator, including its debug output and warnings in the `/api/query` response for deeper inspection of ranking logic. (`apps/api/app/services/query_orchestrator.py`, `apps/api/app/schemas/ranking.py`, `apps/api/app/schemas/__init__.py`) [[1]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R5) [[2]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R18-R26) [[3]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R41-R47) [[4]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R58) [[5]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R79) [[6]](diffhunk://#diff-ed1875a69529cbb7f306274316b6215af5de7e85a9719233b3902211d550e387R1-R36) [[7]](diffhunk://#diff-9f8f808bbceb3e0ac3957e424acfc39f71c6c6da72fde7901ce3f308ff48f583R21-R25) [[8]](diffhunk://#diff-9f8f808bbceb3e0ac3957e424acfc39f71c6c6da72fde7901ce3f308ff48f583R44-R50)

**Schema and Data Model Enhancements:**

* Expanded the `LegalUnit` schema and introduced `EvidenceUnit` as a subclass, including new fields for ranking, scores, support roles, and feature breakdowns to support richer evidence and ranking explanations. (`apps/api/app/schemas/legal.py`, `apps/api/app/schemas/query.py`, `apps/api/app/schemas/ranking.py`) [[1]](diffhunk://#diff-d887429ba31930fa9da914218bb9bfbce47feeb58802f504e8fc3d49b8b2c52aR1-R26) [[2]](diffhunk://#diff-f14d76d4a4582f33ea6ddb2e237372a3e64bba18a9eab0c980af1af918190d63L54-R73) [[3]](diffhunk://#diff-f14d76d4a4582f33ea6ddb2e237372a3e64bba18a9eab0c980af1af918190d63R239-R240) [[4]](diffhunk://#diff-ed1875a69529cbb7f306274316b6215af5de7e85a9719233b3902211d550e387R1-R36)
* Added schemas for corpus metadata and lists to support new endpoints. (`apps/api/app/schemas/corpus.py`)

**Documentation and Mock Data Updates:**

* Updated documentation to describe Phase 7, including LegalRanker and MMR-based evidence selection, and revised mock evidence and citation handling to match the new API contract. (`docs/query-api.md`, `apps/api/app/services/mock_evidence.py`) [[1]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL3-R28) [[2]](diffhunk://#diff-ef36c396d4e7f3949432ee83872e7cf55284e7a7c9686543385d945f0c69af2aL48-R58) [[3]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL17-R19) [[4]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL45-R46) [[5]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL75-R76) [[6]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baR121-R129) [[7]](diffhunk://#diff-614d5cf0f60771d631f16290282a84ff0d94cb46115dc824b51c086542e3f4baL139-R151)
* Updated ingestion instructions in the `README.md` to use an archived legal document and new output directory. (`README.md`)

**Other Improvements:**

* Fixed import of `settings` in the raw retriever client for consistency. (`apps/api/app/services/raw_retriever_client.py`)

These changes collectively advance the API towards a more feature-complete legal QA pipeline, with improved ingestion, legal unit access, ranking transparency, and evidence handling.