### PR TITLE
feat(ingestion): add canonical LegalUnit export layer

### DIFF
--- a/ingestion/contracts/__init__.py
+++ b/ingestion/contracts/__init__.py
@@ -123,9 +123,12 @@ class ParsedLegalUnit(IngestionContract):
     incoming_reference_ids: list[str] = Field(default_factory=list)
     parser_warnings: list[str] = Field(default_factory=list)
 
-    def to_legal_unit_dict(self) -> dict[str, Any]:
-        """Return the API LegalUnit-compatible shape used by retrieval/evidence."""
-        return self.model_dump(include=LEGAL_UNIT_FIELDS)
+    def to_legal_unit_dict(self, *, include_parser_warnings: bool = False) -> dict[str, Any]:
+        """Return the LegalUnit shape used by retrieval/evidence."""
+        fields = set(LEGAL_UNIT_FIELDS)
+        if include_parser_warnings:
+            fields.add("parser_warnings")
+        return self.model_dump(include=fields)
 
 
 class ParsedLegalEdge(IngestionContract):

--- a/ingestion/exporters.py
+++ b/ingestion/exporters.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Any, Mapping
+
+from pydantic import BaseModel
+
+from ingestion.contracts import ParserActMetadata, ParsedLegalUnit
+from ingestion.legal_domains import get_registered_legal_domain
+from ingestion.legal_ids import (
+    make_canonical_id,
+    make_law_id,
+    make_parent_unit_id,
+    make_unit_id,
+)
+from ingestion.normalizer import normalize_legal_text
+
+
+CITABLE_LEVELS = {"articol", "alineat", "litera", "punct"}
+
+
+def parsed_legal_unit_to_legal_unit_dict(
+    unit: ParsedLegalUnit,
+    *,
+    include_parser_warnings: bool = True,
+) -> dict[str, Any]:
+    """Export the canonical ingestion LegalUnit dict for JSON/import consumers."""
+    return unit.to_legal_unit_dict(include_parser_warnings=include_parser_warnings)
+
+
+def build_parsed_legal_unit(
+    *,
+    law_title: str,
+    raw_text: str,
+    hierarchy_path: list[tuple[str, str]] | None = None,
+    law_id: str | None = None,
+    source_id: str | None = None,
+    source_url: str | None = None,
+    status: str | None = None,
+    act_type: str | None = None,
+    act_number: str | None = None,
+    publication_date: date | None = None,
+    effective_date: date | None = None,
+    version_start: date | None = None,
+    version_end: date | None = None,
+    legal_concepts: list[str] | None = None,
+    parser_warnings: list[str] | None = None,
+) -> ParsedLegalUnit:
+    path = hierarchy_path or []
+    resolved_law_id = law_id or make_law_id(law_title)
+    resolved_domain = get_registered_legal_domain(resolved_law_id) or "unknown"
+    warnings = list(parser_warnings or [])
+
+    if resolved_domain == "unknown":
+        warnings.append("legal_domain_unknown")
+    if source_id is None:
+        warnings.append("source_id_unknown")
+    if source_url is None:
+        warnings.append("source_url_unknown")
+    if status is None or status == "unknown":
+        warnings.append("status_unknown")
+    if publication_date is None:
+        warnings.append("publication_date_unknown")
+    if effective_date is None:
+        warnings.append("effective_date_unknown")
+    if version_start is None:
+        warnings.append("version_start_unknown")
+    if version_end is None:
+        warnings.append("version_end_unknown")
+
+    parsed_act_type, parsed_act_number = _parse_act_identity(law_title)
+    resolved_act_type = act_type if act_type is not None else parsed_act_type
+    resolved_act_number = act_number if act_number is not None else parsed_act_number
+
+    return ParsedLegalUnit(
+        id=make_unit_id(resolved_law_id, path),
+        canonical_id=make_canonical_id(resolved_law_id, path),
+        source_id=source_id,
+        law_id=resolved_law_id,
+        law_title=law_title,
+        act_type=resolved_act_type,
+        act_number=resolved_act_number,
+        publication_date=publication_date,
+        effective_date=effective_date,
+        version_start=version_start,
+        version_end=version_end,
+        status=status or "unknown",
+        hierarchy_path=render_hierarchy_path(path),
+        article_number=_level_value(path, "articol"),
+        paragraph_number=_level_value(path, "alineat"),
+        letter_number=_level_value(path, "litera"),
+        point_number=_level_value(path, "punct"),
+        raw_text=raw_text,
+        normalized_text=normalize_legal_text(raw_text),
+        legal_domain=resolved_domain,
+        legal_concepts=legal_concepts or [],
+        source_url=source_url,
+        parent_id=make_parent_unit_id(resolved_law_id, path),
+        children_ids=[],
+        outgoing_reference_ids=[],
+        incoming_reference_ids=[],
+        parser_warnings=warnings,
+    )
+
+
+def build_legal_unit_dict(
+    *,
+    law_title: str,
+    raw_text: str,
+    hierarchy_path: list[tuple[str, str]] | None = None,
+    law_id: str | None = None,
+    source_id: str | None = None,
+    source_url: str | None = None,
+    status: str | None = None,
+    parser_warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    parsed = build_parsed_legal_unit(
+        law_title=law_title,
+        raw_text=raw_text,
+        hierarchy_path=hierarchy_path,
+        law_id=law_id,
+        source_id=source_id,
+        source_url=source_url,
+        status=status,
+        parser_warnings=parser_warnings,
+    )
+    return parsed_legal_unit_to_legal_unit_dict(parsed)
+
+
+def legacy_unit_to_parsed_legal_unit(
+    legacy_unit: Mapping[str, Any],
+    act_metadata: ParserActMetadata | BaseModel | Mapping[str, Any],
+) -> ParsedLegalUnit:
+    metadata = _metadata_dict(act_metadata)
+    law_id = metadata.get("law_id") or legacy_unit.get("corpus_id")
+    law_title = metadata.get("law_title") or law_id or "unknown"
+    source_url = metadata.get("source_url")
+    source_id = metadata.get("source_id")
+    status = metadata.get("status")
+    raw_text = str(legacy_unit.get("raw_text") or legacy_unit.get("text") or "")
+    path = citable_path_from_unit_id(str(legacy_unit.get("id", "")), law_id)
+
+    return build_parsed_legal_unit(
+        law_title=law_title,
+        law_id=law_id,
+        raw_text=raw_text,
+        hierarchy_path=path,
+        source_id=source_id,
+        source_url=source_url,
+        status=status,
+        act_type=metadata.get("act_type"),
+        act_number=metadata.get("act_number"),
+        publication_date=metadata.get("publication_date"),
+        effective_date=metadata.get("effective_date"),
+        version_start=metadata.get("version_start"),
+        version_end=metadata.get("version_end"),
+        parser_warnings=["legacy_unit_converted"],
+    )
+
+
+def legacy_unit_to_legal_unit_dict(
+    legacy_unit: Mapping[str, Any],
+    act_metadata: ParserActMetadata | BaseModel | Mapping[str, Any],
+) -> dict[str, Any]:
+    parsed = legacy_unit_to_parsed_legal_unit(legacy_unit, act_metadata)
+    return parsed_legal_unit_to_legal_unit_dict(parsed)
+
+
+def render_hierarchy_path(hierarchy_path: list[tuple[str, str]]) -> list[str]:
+    rendered: list[str] = []
+    for level_type, value in hierarchy_path:
+        level = level_type.lower()
+        if level == "articol":
+            rendered.append(f"Art. {_strip_article_label(value)}")
+        elif level == "alineat":
+            rendered.append(f"Alin. ({_strip_wrapping_punctuation(value)})")
+        elif level == "litera":
+            rendered.append(f"Lit. {_strip_wrapping_punctuation(value).lower()})")
+        elif level == "punct":
+            rendered.append(f"Pct. {_strip_wrapping_punctuation(value)}")
+        else:
+            rendered.append(str(value))
+    return rendered
+
+
+def citable_path_from_unit_id(unit_id: str, law_id: str | None = None) -> list[tuple[str, str]]:
+    if law_id and unit_id.startswith(f"{law_id}."):
+        raw_segments = unit_id.removeprefix(f"{law_id}.").split(".")
+    else:
+        raw_segments = unit_id.split(".")[2:]
+
+    path: list[tuple[str, str]] = []
+    for segment in raw_segments:
+        if segment.startswith("art_"):
+            path.append(("articol", segment.removeprefix("art_")))
+        elif segment.startswith("alin_"):
+            path.append(("alineat", segment.removeprefix("alin_")))
+        elif segment.startswith("lit_"):
+            path.append(("litera", segment.removeprefix("lit_")))
+        elif segment.startswith("pct_"):
+            path.append(("punct", segment.removeprefix("pct_")))
+    return path
+
+
+def _metadata_dict(metadata: ParserActMetadata | BaseModel | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(metadata, BaseModel):
+        return metadata.model_dump()
+    return dict(metadata)
+
+
+def _level_value(hierarchy_path: list[tuple[str, str]], level_type: str) -> str | None:
+    for current_type, value in reversed(hierarchy_path):
+        if current_type.lower() == level_type:
+            if level_type == "articol":
+                return _strip_article_label(value)
+            return _strip_wrapping_punctuation(value).lower() if level_type == "litera" else _strip_wrapping_punctuation(value)
+    return None
+
+
+def _strip_article_label(value: str) -> str:
+    text = str(value).strip()
+    text = re.sub(r"^(?:art\.?|articolul)\s*", "", text, flags=re.IGNORECASE)
+    return text.strip()
+
+
+def _strip_wrapping_punctuation(value: str) -> str:
+    text = str(value).strip()
+    text = re.sub(r"^(?:alin\.?|lit\.?|pct\.?)\s*", "", text, flags=re.IGNORECASE)
+    return text.strip().strip("() .")
+
+
+def _parse_act_identity(law_title: str) -> tuple[str | None, str | None]:
+    text = str(law_title).strip()
+    match = re.search(r"\b(legea|lege)\s+(?:nr\.?\s*)?(\d+\s*/\s*\d+)\b", text, re.IGNORECASE)
+    if match:
+        return "lege", re.sub(r"\s+", "", match.group(2))
+    if re.search(r"\bcodul\b", text, re.IGNORECASE):
+        return "cod", None
+    return None, None

--- a/ingestion/legal_domains.py
+++ b/ingestion/legal_domains.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+LEGAL_DOMAIN_REGISTRY: dict[str, str] = {
+    "ro.codul_muncii": "munca",
+    "ro.constitutia": "constitutional",
+    "ro.codul_civil": "civil",
+    "ro.codul_fiscal": "fiscal",
+    "ro.og_2_2001": "contraventional",
+    "ro.oug_195_2002": "rutier",
+    "ro.lege_190_2018": "protectia_datelor",
+}
+
+
+def get_registered_legal_domain(law_id: str | None) -> str | None:
+    if not law_id:
+        return None
+    return LEGAL_DOMAIN_REGISTRY.get(law_id)

--- a/ingestion/legal_ids.py
+++ b/ingestion/legal_ids.py
@@ -1,36 +1,162 @@
+from __future__ import annotations
+
 import re
+import unicodedata
+
+
+_SUPERSCRIPT_DIGITS = {
+    "⁰": "_0",
+    "¹": "_1",
+    "²": "_2",
+    "³": "_3",
+    "⁴": "_4",
+    "⁵": "_5",
+    "⁶": "_6",
+    "⁷": "_7",
+    "⁸": "_8",
+    "⁹": "_9",
+}
+
+_PREFIX_MAP = {
+    "titlu": "titlu",
+    "capitol": "capitol",
+    "sectiune": "sectiune",
+    "sectiunea": "sectiune",
+    "articol": "art",
+    "article": "art",
+    "alineat": "alin",
+    "paragraph": "alin",
+    "litera": "lit",
+    "letter": "lit",
+    "punct": "pct",
+    "point": "pct",
+}
+
+
+def _ascii_lower(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text)
+    without_marks = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return without_marks.lower()
+
+
+def _replace_superscript_digits(text: str) -> str:
+    for superscript, replacement in _SUPERSCRIPT_DIGITS.items():
+        text = text.replace(superscript, replacement)
+    return text
+
+
+def _slugify(text: str) -> str:
+    text = _ascii_lower(_replace_superscript_digits(text))
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    text = re.sub(r"_+", "_", text).strip("_")
+    return text
+
 
 def normalize_number(text: str) -> str:
     """
-    Normalizes Romanian legal numbering.
-    Example: '41^1' -> '41_1'
+    Normalize Romanian legal numbering.
+
+    Examples:
+        "41^1" -> "41_1"
+        "41¹"  -> "41_1"
+        "(1)"  -> "1"
+        "K)"   -> "k"
     """
     if not text:
         return ""
-    # Replace ^ with _
-    normalized = text.replace('^', '_')
-    # Remove any dots or non-alphanumeric except underscore
-    normalized = re.sub(r'[^a-zA-Z0-9_]', '', normalized)
-    return normalized.lower()
+
+    normalized = _replace_superscript_digits(str(text).strip())
+    normalized = normalized.replace("^", "_")
+    normalized = _ascii_lower(normalized)
+    normalized = re.sub(r"^(?:art\.?|articolul|alin\.?|lit\.?|pct\.?)\s*", "", normalized)
+    normalized = re.sub(r"[^a-z0-9_]", "", normalized)
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return normalized
+
+
+def make_law_id(law_title: str) -> str:
+    """
+    Build a deterministic Romanian law id from a known act title.
+
+    Examples:
+        "Codul muncii" -> "ro.codul_muncii"
+        "Legea nr. 53/2003" -> "ro.lege_53_2003"
+    """
+    title = _ascii_lower(str(law_title).strip())
+    compact = re.sub(r"\s+", " ", title)
+
+    numbered_patterns = [
+        (r"\b(?:legea|lege)\s+(?:nr\.?\s*)?(\d+)\s*/\s*(\d+)\b", "lege"),
+        (r"\b(?:oug|o\.u\.g\.|ordonanta de urgenta)\s+(?:nr\.?\s*)?(\d+)\s*/\s*(\d+)\b", "oug"),
+        (r"\b(?:og|o\.g\.|ordonanta guvernului)\s+(?:nr\.?\s*)?(\d+)\s*/\s*(\d+)\b", "og"),
+        (r"\b(?:hg|h\.g\.|hotararea guvernului)\s+(?:nr\.?\s*)?(\d+)\s*/\s*(\d+)\b", "hg"),
+    ]
+    for pattern, prefix in numbered_patterns:
+        match = re.search(pattern, compact)
+        if match:
+            return f"ro.{prefix}_{match.group(1)}_{match.group(2)}"
+
+    if re.fullmatch(r"constitutia(?: romaniei)?", compact):
+        return "ro.constitutia"
+
+    slug = _slugify(compact)
+    if slug.startswith("codul_"):
+        return f"ro.{slug}"
+    if slug.startswith("legea_"):
+        slug = "lege_" + slug.removeprefix("legea_")
+    return f"ro.{slug}"
+
+
+def make_article_segment(article_number: str) -> str:
+    return f"art_{normalize_number(article_number)}"
+
+
+def make_paragraph_segment(paragraph_number: str) -> str:
+    return f"alin_{normalize_number(paragraph_number)}"
+
+
+def make_letter_segment(letter_number: str) -> str:
+    return f"lit_{normalize_number(letter_number)}"
+
+
+def make_point_segment(point_number: str) -> str:
+    return f"pct_{normalize_number(point_number)}"
+
+
+def make_unit_segment(level_type: str, level_value: str) -> str:
+    level = _ascii_lower(level_type)
+    prefix = _PREFIX_MAP.get(level, level)
+
+    if prefix == "art":
+        return make_article_segment(level_value)
+    if prefix == "alin":
+        return make_paragraph_segment(level_value)
+    if prefix == "lit":
+        return make_letter_segment(level_value)
+    if prefix == "pct":
+        return make_point_segment(level_value)
+    return f"{prefix}_{normalize_number(level_value)}"
+
 
 def make_unit_id(corpus_id: str, hierarchy_path: list) -> str:
     """
-    Generates a deterministic ID for a legal unit.
-    Example: ro.codul_muncii.art_41.alin_1
+    Generate a deterministic legal unit id.
+
+    Existing parser callers pass tuple paths such as
+    [("articol", "41"), ("alineat", "1")], which remain supported.
     """
     parts = [corpus_id]
-    for level_type, level_val in hierarchy_path:
-        norm_val = normalize_number(level_val)
-        # Map Romanian types to standard prefixes
-        prefix_map = {
-            'titlu': 'titlu',
-            'capitol': 'capitol',
-            'sectiune': 'sectiune',
-            'articol': 'art',
-            'alineat': 'alin',
-            'litera': 'lit'
-        }
-        prefix = prefix_map.get(level_type.lower(), level_type.lower())
-        parts.append(f"{prefix}_{norm_val}")
-    
-    return ".".join(parts)
+    parts.extend(make_unit_segment(level_type, level_val) for level_type, level_val in hierarchy_path)
+    return ".".join(part for part in parts if part)
+
+
+def make_parent_unit_id(law_id: str, hierarchy_path: list) -> str | None:
+    if not hierarchy_path:
+        return None
+    return make_unit_id(law_id, hierarchy_path[:-1])
+
+
+def make_canonical_id(law_id: str, hierarchy_path: list) -> str:
+    base = law_id.removeprefix("ro.")
+    segments = [make_unit_segment(level_type, level_val) for level_type, level_val in hierarchy_path]
+    return ":".join([base, *segments]) if segments else base

--- a/ingestion/normalizer.py
+++ b/ingestion/normalizer.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+def normalize_legal_text(raw_text: str | None) -> str | None:
+    """Derive retrieval-friendly text without replacing the source raw_text."""
+    if raw_text is None:
+        return None
+
+    normalized = unicodedata.normalize("NFC", raw_text)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized or None

--- a/ingestion/parser_rules.py
+++ b/ingestion/parser_rules.py
@@ -1,8 +1,8 @@
 import re
 
 # Regex for Romanian legal structures
-# Handles variations like "Art. 41", "Art. 41^1", etc.
-ARTICLE_RE = re.compile(r'^(?:Art\.|Articolul)\s*(\d+(?:\^\d+)?)', re.IGNORECASE)
+# Handles variations like "Art. 41", "Art. 41^1", "Art. 41¹", etc.
+ARTICLE_RE = re.compile(r'^(?:Art\.|Articolul)\s*(\d+(?:\^\d+|[⁰¹²³⁴⁵⁶⁷⁸⁹]+)?)', re.IGNORECASE)
 
 # Handles paragraph numbers like "(1)", "(2)"
 PARA_RE = re.compile(r'^\((\d+)\)')

--- a/tests/test_canonical_legalunit_output.py
+++ b/tests/test_canonical_legalunit_output.py
@@ -1,0 +1,137 @@
+from apps.api.app.schemas.query import LegalUnit
+from ingestion.exporters import (
+    build_parsed_legal_unit,
+    legacy_unit_to_legal_unit_dict,
+    parsed_legal_unit_to_legal_unit_dict,
+)
+
+
+def test_article_legal_unit_output_is_backend_compatible():
+    raw_text = "Art. 41\nDreptul la munca nu poate fi ingradit."
+    parsed = build_parsed_legal_unit(
+        law_title="Codul muncii",
+        raw_text=raw_text,
+        hierarchy_path=[("articol", "41")],
+    )
+
+    unit = parsed_legal_unit_to_legal_unit_dict(parsed)
+    validated = LegalUnit.model_validate(unit)
+
+    assert validated.id == "ro.codul_muncii.art_41"
+    assert unit["canonical_id"] == "codul_muncii:art_41"
+    assert unit["parent_id"] == "ro.codul_muncii"
+    assert unit["hierarchy_path"] == ["Art. 41"]
+    assert unit["article_number"] == "41"
+    assert unit["paragraph_number"] is None
+    assert unit["raw_text"] == raw_text
+    assert unit["normalized_text"] == "Art. 41 Dreptul la munca nu poate fi ingradit."
+    assert unit["legal_domain"] == "munca"
+    assert unit["legal_concepts"] == []
+    assert unit["source_url"] is None
+    assert unit["status"] == "unknown"
+    assert "source_url_unknown" in unit["parser_warnings"]
+    assert "status_unknown" in unit["parser_warnings"]
+
+
+def test_paragraph_legal_unit_parent_and_hierarchy_are_coherent():
+    parsed = build_parsed_legal_unit(
+        law_title="Codul muncii",
+        raw_text="(1) Dreptul la munca este garantat.",
+        hierarchy_path=[("articol", "41"), ("alineat", "(1)")],
+        source_url="https://legislatie.just.ro/Public/DetaliiDocument/53",
+        source_id="legislatie.just.ro:53/2003",
+    )
+
+    unit = parsed_legal_unit_to_legal_unit_dict(parsed)
+
+    assert LegalUnit.model_validate(unit).id == "ro.codul_muncii.art_41.alin_1"
+    assert unit["canonical_id"] == "codul_muncii:art_41:alin_1"
+    assert unit["parent_id"] == "ro.codul_muncii.art_41"
+    assert unit["hierarchy_path"] == ["Art. 41", "Alin. (1)"]
+    assert unit["legal_concepts"] == []
+    assert "source_url_unknown" not in unit["parser_warnings"]
+    assert "source_id_unknown" not in unit["parser_warnings"]
+
+
+def test_letter_legal_unit_handles_uppercase_letter():
+    parsed = build_parsed_legal_unit(
+        law_title="Codul muncii",
+        raw_text="k) un criteriu enumerat de lege.",
+        hierarchy_path=[("articol", "17"), ("alineat", "(3)"), ("litera", "K)")],
+    )
+
+    unit = parsed_legal_unit_to_legal_unit_dict(parsed)
+
+    assert LegalUnit.model_validate(unit).id == "ro.codul_muncii.art_17.alin_3.lit_k"
+    assert unit["canonical_id"] == "codul_muncii:art_17:alin_3:lit_k"
+    assert unit["parent_id"] == "ro.codul_muncii.art_17.alin_3"
+    assert unit["hierarchy_path"] == ["Art. 17", "Alin. (3)", "Lit. k)"]
+    assert unit["letter_number"] == "k"
+
+
+def test_article_superscript_id_is_stable_and_raw_text_is_faithful():
+    raw_text = "Art. 41¹\nText introdus pentru articol suplimentar."
+    parsed = build_parsed_legal_unit(
+        law_title="Codul muncii",
+        raw_text=raw_text,
+        hierarchy_path=[("articol", "41¹"), ("alineat", "(2)")],
+    )
+
+    unit = parsed_legal_unit_to_legal_unit_dict(parsed)
+
+    assert LegalUnit.model_validate(unit).id == "ro.codul_muncii.art_41_1.alin_2"
+    assert unit["canonical_id"] == "codul_muncii:art_41_1:alin_2"
+    assert unit["parent_id"] == "ro.codul_muncii.art_41_1"
+    assert unit["raw_text"] == raw_text
+    assert unit["normalized_text"] != unit["raw_text"]
+
+
+def test_unknown_policy_uses_unknown_null_and_empty_defaults():
+    parsed = build_parsed_legal_unit(
+        law_title="Legea nr. 999/2099",
+        raw_text="Art. 1\nText fara metadata sigura.",
+        hierarchy_path=[("articol", "1")],
+    )
+
+    unit = parsed_legal_unit_to_legal_unit_dict(parsed)
+
+    assert LegalUnit.model_validate(unit).id == "ro.lege_999_2099.art_1"
+    assert unit["legal_domain"] == "unknown"
+    assert unit["legal_concepts"] == []
+    assert unit["source_id"] is None
+    assert unit["source_url"] is None
+    assert unit["publication_date"] is None
+    assert unit["effective_date"] is None
+    assert unit["version_start"] is None
+    assert unit["version_end"] is None
+    assert unit["status"] == "unknown"
+    assert "legal_domain_unknown" in unit["parser_warnings"]
+    assert "source_url_unknown" in unit["parser_warnings"]
+    assert "status_unknown" in unit["parser_warnings"]
+
+
+def test_legacy_structural_unit_can_be_exported_without_changing_parser_output():
+    legacy_unit = {
+        "id": "ro.codul_muncii.art_41.alin_1",
+        "type": "alineat",
+        "raw_text": "(1) Dreptul la munca este garantat.",
+        "hierarchy_path": ["41", "1"],
+        "corpus_id": "ro.codul_muncii",
+    }
+
+    unit = legacy_unit_to_legal_unit_dict(
+        legacy_unit,
+        {
+            "law_id": "ro.codul_muncii",
+            "law_title": "Codul muncii",
+            "status": "unknown",
+            "source_url": "https://legislatie.just.ro/Public/DetaliiDocument/53",
+        },
+    )
+
+    assert LegalUnit.model_validate(unit).id == "ro.codul_muncii.art_41.alin_1"
+    assert unit["raw_text"] == legacy_unit["raw_text"]
+    assert unit["parent_id"] == "ro.codul_muncii.art_41"
+    assert unit["legal_domain"] == "munca"
+    assert "legacy_unit_converted" in unit["parser_warnings"]
+    assert "references" not in unit

--- a/tests/test_legal_ids.py
+++ b/tests/test_legal_ids.py
@@ -1,0 +1,72 @@
+from ingestion.legal_ids import (
+    make_article_segment,
+    make_canonical_id,
+    make_law_id,
+    make_letter_segment,
+    make_parent_unit_id,
+    make_paragraph_segment,
+    make_unit_id,
+)
+
+
+def test_law_id_codul_muncii():
+    assert make_law_id("Codul muncii") == "ro.codul_muncii"
+
+
+def test_law_id_legea_nr_53_2003():
+    assert make_law_id("Legea nr. 53/2003") == "ro.lege_53_2003"
+
+
+def test_article_id_segments_are_stable():
+    assert make_article_segment("41") == "art_41"
+    assert make_article_segment("41^1") == "art_41_1"
+    assert make_article_segment("41¹") == "art_41_1"
+
+
+def test_paragraph_and_letter_segments_are_stable():
+    assert make_paragraph_segment("(1)") == "alin_1"
+    assert make_letter_segment("K)") == "lit_k"
+
+
+def test_unit_id_examples_are_stable():
+    assert make_unit_id("ro.codul_muncii", []) == "ro.codul_muncii"
+    assert make_unit_id("ro.codul_muncii", [("articol", "41")]) == "ro.codul_muncii.art_41"
+    assert (
+        make_unit_id("ro.codul_muncii", [("articol", "41"), ("alineat", "(1)")])
+        == "ro.codul_muncii.art_41.alin_1"
+    )
+    assert (
+        make_unit_id(
+            "ro.codul_muncii",
+            [("articol", "17"), ("alineat", "(3)"), ("litera", "K)")],
+        )
+        == "ro.codul_muncii.art_17.alin_3.lit_k"
+    )
+    assert make_unit_id("ro.codul_muncii", [("articol", "41¹")]) == "ro.codul_muncii.art_41_1"
+    assert (
+        make_unit_id("ro.codul_muncii", [("articol", "41^1"), ("alineat", "(2)")])
+        == "ro.codul_muncii.art_41_1.alin_2"
+    )
+
+
+def test_canonical_id_examples_are_stable():
+    assert make_canonical_id("ro.codul_muncii", []) == "codul_muncii"
+    assert make_canonical_id("ro.codul_muncii", [("articol", "41")]) == "codul_muncii:art_41"
+    assert (
+        make_canonical_id("ro.codul_muncii", [("articol", "41"), ("alineat", "(1)")])
+        == "codul_muncii:art_41:alin_1"
+    )
+    assert (
+        make_canonical_id(
+            "ro.codul_muncii",
+            [("articol", "17"), ("alineat", "(3)"), ("litera", "K)")],
+        )
+        == "codul_muncii:art_17:alin_3:lit_k"
+    )
+
+
+def test_parent_id_is_coherent():
+    path = [("articol", "17"), ("alineat", "(3)"), ("litera", "K)")]
+    assert make_parent_unit_id("ro.codul_muncii", path) == "ro.codul_muncii.art_17.alin_3"
+    assert make_parent_unit_id("ro.codul_muncii", [("articol", "17")]) == "ro.codul_muncii"
+    assert make_parent_unit_id("ro.codul_muncii", []) is None


### PR DESCRIPTION
This pull request introduces a significant refactor and standardization of the ingestion pipeline for Romanian legal documents, focusing on canonical ID generation, normalization, and export compatibility. The changes provide robust utilities for generating, normalizing, and exporting legal unit data, with comprehensive test coverage to ensure stability and backward compatibility.

**Legal ID and Canonicalization Utilities**

* Introduced `ingestion/legal_ids.py` with robust functions for generating deterministic law/unit IDs and canonical IDs, handling Romanian legal numbering (including superscripts and special cases), and normalizing input. This ensures stable and consistent identifiers for all legal units.
* Added comprehensive tests in `tests/test_legal_ids.py` to guarantee ID and canonicalization stability across a variety of input formats and edge cases.

**Legal Unit Construction and Export**

* Added `ingestion/exporters.py` with utilities to build, convert, and export legal units in a canonical, backend-compatible format, including support for legacy data and detailed parser warnings.
* Updated `ParsedLegalUnit.to_legal_unit_dict` to support conditional inclusion of parser warnings for greater flexibility in downstream consumers.

**Normalization and Domain Mapping**

* Introduced `ingestion/normalizer.py` for consistent normalization of legal text, ensuring retrieval-friendly output without altering the original source.
* Added `ingestion/legal_domains.py` to map law IDs to registered legal domains, supporting domain inference and parser warnings for unknown domains.

**Parser and Test Improvements**

* Enhanced article regex in `ingestion/parser_rules.py` to support superscript article numbers, improving parsing accuracy for Romanian legal texts.
* Added comprehensive integration tests in `tests/test_canonical_legalunit_output.py` to validate that exported legal units are compatible with backend schemas and maintain data fidelity across various scenarios, including legacy data and unknown policies.