### PR TITLE
feat(ingestion): add HTML cleaner fidelity checks

### DIFF
--- a/ingestion/exporters.py
+++ b/ingestion/exporters.py
@@ -10,6 +10,7 @@ from typing import Any, Mapping
 from pydantic import BaseModel
 
 from ingestion.contracts import ParserActMetadata, ParsedLegalUnit
+from ingestion.html_cleaner import navigation_residue_count, text_cleanliness_score
 from ingestion.legal_domains import get_registered_legal_domain
 from ingestion.legal_ids import (
     make_canonical_id,
@@ -348,6 +349,9 @@ def build_canonical_validation_report(
         sum(1 for unit in legal_units if _has_minimum_legal_unit_fields(unit)),
         units_count,
     )
+    text_cleanliness = text_cleanliness_score(
+        [str(unit.get("raw_text") or "") for unit in legal_units]
+    )
     reference_resolution_rate = (
         _safe_rate(
             sum(
@@ -368,6 +372,7 @@ def build_canonical_validation_report(
         "source_url_coverage": source_url_coverage,
         "raw_text_non_empty_rate": raw_text_non_empty_rate,
         "stable_id_rate": stable_id_rate,
+        "text_cleanliness": text_cleanliness,
         "reference_resolution_rate": reference_resolution_rate,
     }
     warnings = _canonical_bundle_warnings(
@@ -571,6 +576,8 @@ def _canonical_bundle_warnings(
         warnings.add("reference_candidates_not_implemented_or_not_all_resolved")
     if any(unit.get("legal_domain") == "unknown" for unit in legal_units):
         warnings.add("legal_domain_unknown")
+    if any(navigation_residue_count(str(unit.get("raw_text") or "")) for unit in legal_units):
+        warnings.add("possible_navigation_residue")
     return sorted(warnings)
 
 

--- a/ingestion/html_cleaner.py
+++ b/ingestion/html_cleaner.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import re
+import unicodedata
+
+from bs4 import BeautifulSoup, Tag
+
+
+NON_TEXT_TAGS = {
+    "head",
+    "iframe",
+    "link",
+    "meta",
+    "noscript",
+    "object",
+    "script",
+    "style",
+    "svg",
+}
+ALWAYS_DROP_TAGS = {
+    "button",
+    "form",
+    "input",
+    "nav",
+    "option",
+    "select",
+    "textarea",
+}
+INLINE_TAGS = {
+    "a",
+    "abbr",
+    "b",
+    "cite",
+    "em",
+    "i",
+    "label",
+    "small",
+    "span",
+    "strong",
+    "sub",
+    "sup",
+    "u",
+}
+CONTENT_SELECTOR_PATTERNS = (
+    "textdocumentleg",
+    "documentleg",
+    "legal-content",
+    "legal_content",
+    "main-content",
+    "main_content",
+    "content",
+    "document",
+    "act-content",
+)
+CONTAINER_TAGS = {"article", "div", "main", "section", "td"}
+NAVIGATION_ATTRIBUTE_RE = re.compile(
+    r"(?:^|[-_\s])("
+    r"breadcrumb|cautare|cookie|footer|header|menu|meniu|nav|"
+    r"pagination|print|search|share|sidebar|social|toolbar"
+    r")(?:$|[-_\s])",
+    re.IGNORECASE,
+)
+LEGAL_MARKER_RE = re.compile(
+    r"\b(?:Art\.|Articolul|TITLUL|CAPITOLUL|SEC(?:T|Ț)IUNEA)\b|"
+    r"^\s*\(\d+\)|^\s*[a-z]\)",
+    re.IGNORECASE | re.MULTILINE,
+)
+NAVIGATION_RESIDUE_TERMS = (
+    "acasa",
+    "cauta",
+    "cautare",
+    "cookie",
+    "meniu",
+    "tipareste",
+)
+
+
+@dataclass(frozen=True)
+class HtmlCleanConfig:
+    preserve_line_breaks: bool = True
+    collapse_spaces: bool = True
+    drop_empty_lines: bool = True
+
+
+@dataclass(frozen=True)
+class CleanTextResult:
+    lines: list[str]
+    warnings: list[str]
+    removed_blocks_count: int
+    selected_container: str | None
+    text_hash: str | None
+
+
+def clean_html_to_lines(
+    html: str | None,
+    *,
+    config: HtmlCleanConfig | None = None,
+) -> CleanTextResult:
+    config = config or HtmlCleanConfig()
+    if not html:
+        return CleanTextResult(
+            lines=[],
+            warnings=["empty_html"],
+            removed_blocks_count=0,
+            selected_container=None,
+            text_hash=None,
+        )
+
+    soup = BeautifulSoup(html, "html.parser")
+    warnings: set[str] = set()
+    removed_blocks_count = _remove_noise_blocks(soup)
+    if removed_blocks_count:
+        warnings.add("removed_navigation_blocks")
+
+    selected, selected_container = _select_legal_container(soup)
+    if selected is None:
+        selected = soup.find("body") or soup
+        selected_container = "body" if soup.find("body") else None
+        warnings.update({"legal_container_not_found", "used_body_fallback"})
+
+    _unwrap_inline_tags(selected)
+    lines = _extract_lines(selected, config=config)
+    if navigation_residue_count("\n".join(lines)):
+        warnings.add("possible_navigation_residue")
+
+    return CleanTextResult(
+        lines=lines,
+        warnings=sorted(warnings),
+        removed_blocks_count=removed_blocks_count,
+        selected_container=selected_container,
+        text_hash=_text_hash(lines),
+    )
+
+
+def navigation_residue_count(text: str) -> int:
+    normalized = _normalize_for_detection(text)
+    return sum(
+        len(re.findall(rf"\b{re.escape(term)}\b", normalized))
+        for term in NAVIGATION_RESIDUE_TERMS
+    )
+
+
+def text_cleanliness_score(texts: list[str]) -> float:
+    if not texts:
+        return 1.0
+    dirty_count = sum(1 for text in texts if navigation_residue_count(text))
+    return round((len(texts) - dirty_count) / len(texts), 4)
+
+
+def _remove_noise_blocks(soup: BeautifulSoup) -> int:
+    removed = 0
+    for tag in list(soup.find_all(NON_TEXT_TAGS | ALWAYS_DROP_TAGS)):
+        tag.decompose()
+        removed += 1
+
+    for tag in list(soup.find_all(True)):
+        if not isinstance(tag, Tag):
+            continue
+        if tag.name in {"header", "footer"} and _is_navigation_like(tag):
+            tag.decompose()
+            removed += 1
+            continue
+        if _has_navigation_attributes(tag):
+            tag.decompose()
+            removed += 1
+    return removed
+
+
+def _select_legal_container(soup: BeautifulSoup) -> tuple[Tag | None, str | None]:
+    candidates: list[tuple[int, Tag, str]] = []
+    for tag in soup.find_all(True):
+        if not isinstance(tag, Tag):
+            continue
+        if tag.name not in CONTAINER_TAGS:
+            continue
+        label = _container_label(tag)
+        score = _container_score(tag)
+        if score > 0:
+            candidates.append((score, tag, label))
+    if not candidates:
+        return None, None
+    candidates.sort(key=lambda item: (-item[0], _tag_depth(item[1]), item[2]))
+    _, tag, label = candidates[0]
+    return tag, label
+
+
+def _container_score(tag: Tag) -> int:
+    attrs = _attribute_text(tag)
+    text = tag.get_text("\n", strip=True)
+    normalized_attrs = attrs.casefold()
+    has_content_selector = any(
+        pattern in normalized_attrs for pattern in CONTENT_SELECTOR_PATTERNS
+    )
+    if tag.name in {"html", "body"} and not has_content_selector:
+        return 0
+    score = 0
+    if has_content_selector:
+        score += 10
+    if tag.name == "main":
+        score += 6
+    if tag.name == "article":
+        score += 6
+    if LEGAL_MARKER_RE.search(text):
+        score += 5
+    if len(text) > 400:
+        score += 2
+    if _is_navigation_like(tag):
+        score -= 20
+    return score
+
+
+def _container_label(tag: Tag) -> str:
+    if tag.get("id"):
+        return f"#{tag.get('id')}"
+    classes = tag.get("class") or []
+    if classes:
+        return f".{'.'.join(str(item) for item in classes)}"
+    return tag.name or "unknown"
+
+
+def _has_navigation_attributes(tag: Tag) -> bool:
+    if tag.name in {"body", "main", "article"}:
+        return False
+    return bool(NAVIGATION_ATTRIBUTE_RE.search(_attribute_text(tag)))
+
+
+def _is_navigation_like(tag: Tag) -> bool:
+    attr_text = _attribute_text(tag)
+    if NAVIGATION_ATTRIBUTE_RE.search(attr_text):
+        return True
+    text = _normalize_for_detection(tag.get_text(" ", strip=True))
+    if not text:
+        return False
+    markers = sum(1 for term in NAVIGATION_RESIDUE_TERMS if term in text)
+    return markers >= 2 and not LEGAL_MARKER_RE.search(tag.get_text("\n", strip=True))
+
+
+def _attribute_text(tag: Tag) -> str:
+    values: list[str] = [tag.name or ""]
+    for key in ("id", "class", "role", "aria-label", "title"):
+        value = tag.get(key)
+        if isinstance(value, list):
+            values.extend(str(item) for item in value)
+        elif value is not None:
+            values.append(str(value))
+    return " ".join(values)
+
+
+def _unwrap_inline_tags(container: Tag) -> None:
+    for tag in list(container.find_all(INLINE_TAGS)):
+        tag.unwrap()
+
+
+def _extract_lines(container: Tag, *, config: HtmlCleanConfig) -> list[str]:
+    separator = "\n" if config.preserve_line_breaks else " "
+    raw_text = container.get_text(separator=separator, strip=False)
+    lines: list[str] = []
+    for raw_line in raw_text.splitlines():
+        line = raw_line.strip()
+        if config.collapse_spaces:
+            line = re.sub(r"[ \t\f\v]+", " ", line)
+        if config.drop_empty_lines and not line:
+            continue
+        lines.append(line)
+    return lines
+
+
+def _text_hash(lines: list[str]) -> str | None:
+    if not lines:
+        return None
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+def _tag_depth(tag: Tag) -> int:
+    depth = 0
+    parent = tag.parent
+    while isinstance(parent, Tag):
+        depth += 1
+        parent = parent.parent
+    return depth
+
+
+def _normalize_for_detection(text: str) -> str:
+    normalized = unicodedata.normalize("NFD", text.casefold())
+    stripped = "".join(
+        char for char in normalized if unicodedata.category(char) != "Mn"
+    )
+    return " ".join(stripped.split())

--- a/ingestion/validators.py
+++ b/ingestion/validators.py
@@ -8,6 +8,8 @@ Phase 3: build_validation_report – full quality report for a processed corpus.
 import json
 from typing import Any
 
+from ingestion.html_cleaner import text_cleanliness_score
+
 
 # ---------------------------------------------------------------------------
 # Phase 1 – Blocking duplicate ID check
@@ -79,6 +81,9 @@ def build_validation_report(
     report["ReferenceResolutionRate"] = (
         round(resolved_count / total_candidates, 4) if total_candidates > 0 else 0.0
     )
+    report["text_cleanliness"] = text_cleanliness_score(
+        [str(unit.get("raw_text") or "") for unit in units]
+    )
 
     # --- Orphan detection (warning) ---
     target_ids = {e["target_id"] for e in contains_edges}
@@ -96,6 +101,8 @@ def build_validation_report(
         )
     if duplicates:
         warnings.append(f"BLOCKING: {len(duplicates)} duplicate ID(s) found.")
+    if report["text_cleanliness"] < 1.0:
+        warnings.append("Possible navigation residue detected in raw_text.")
 
     report["warnings"] = warnings
 

--- a/tests/fixtures/corpus/codul_muncii_corpus_manifest.json
+++ b/tests/fixtures/corpus/codul_muncii_corpus_manifest.json
@@ -24,8 +24,8 @@
     "validation_report": "validation_report.json",
     "reference_candidates": "reference_candidates.json"
   },
-  "content_hash": "97c9e08b32baa402f3b981a2035426fb5bf4387f446604e8b116283e98946c99",
-  "bundle_hash": "ec120f8736b32f85b8c95bb00bf8bd129578e3a290592dc28d5ded95d01ad51e",
+  "content_hash": "9cdfbbfca145b6309cb517f6aa7c11f07643367463925f0b78ee10035f5aa381",
+  "bundle_hash": "be6605eac452ecf86035f5982360e99d4feead735363fa11948b3713434c919d",
   "warnings": [
     "effective_date_unknown",
     "legal_concepts_empty_for_most_units_by_v1_policy",

--- a/tests/fixtures/corpus/codul_muncii_validation_report.json
+++ b/tests/fixtures/corpus/codul_muncii_validation_report.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "parser_version": "0.1.0",
-  "corpus_quality": 0.7143,
+  "corpus_quality": 0.75,
   "import_blocking_passed": true,
   "units_count": 9,
   "edges_count": 8,
@@ -14,6 +14,7 @@
     "source_url_coverage": 0.0,
     "raw_text_non_empty_rate": 1.0,
     "stable_id_rate": 1.0,
+    "text_cleanliness": 1.0,
     "reference_resolution_rate": 0.0
   },
   "warnings": [

--- a/tests/fixtures/corpus/mini_codul_muncii/expected/corpus_manifest.json
+++ b/tests/fixtures/corpus/mini_codul_muncii/expected/corpus_manifest.json
@@ -24,8 +24,8 @@
     "validation_report": "validation_report.json",
     "reference_candidates": "reference_candidates.json"
   },
-  "content_hash": "13f9c179978794a0c02c58c8414036dbbc0d28864fee0e45daedb46f216a2d81",
-  "bundle_hash": "93507501ccc0e4b165fc01d04a62c45d4585ec0c5400c967af61d78a68dace44",
+  "content_hash": "9204cdf8e1021ffd27924f2a66e06dab9e7f06831d93e53ad76c77e7904db423",
+  "bundle_hash": "e0ecec7019ecfd85e147bc46b3db446ef98468a70021cbbd8d446bf05d8a4885",
   "warnings": [
     "legal_concepts_empty_for_most_units_by_v1_policy",
     "reference_candidates_not_implemented_or_not_all_resolved",

--- a/tests/fixtures/corpus/mini_codul_muncii/expected/validation_report.json
+++ b/tests/fixtures/corpus/mini_codul_muncii/expected/validation_report.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "parser_version": "0.1.0",
-  "corpus_quality": 0.7143,
+  "corpus_quality": 0.75,
   "import_blocking_passed": true,
   "units_count": 6,
   "edges_count": 5,
@@ -14,6 +14,7 @@
     "source_url_coverage": 0.0,
     "raw_text_non_empty_rate": 1.0,
     "stable_id_rate": 1.0,
+    "text_cleanliness": 1.0,
     "reference_resolution_rate": 0.0
   },
   "warnings": [

--- a/tests/fixtures/html/codul_muncii_fragment.expected_lines.json
+++ b/tests/fixtures/html/codul_muncii_fragment.expected_lines.json
@@ -1,0 +1,13 @@
+[
+  "Codul muncii",
+  "Art. 41",
+  "(1) Contractul individual de muncă poate fi modificat numai prin acordul părților.",
+  "(2) Cu titlu de excepție, modificarea unilaterală a contractului individual de muncă este posibilă numai în cazurile și în condițiile prevăzute de prezentul cod.",
+  "(3) Modificarea contractului individual de muncă se referă la oricare dintre următoarele elemente: durata contractului; locul muncii; felul muncii; condițiile de muncă; salariul; timpul de muncă și timpul de odihnă.",
+  "(4) Orice modificare a unuia dintre elementele prevăzute la alin. (3), în timpul executării contractului individual de muncă, impune încheierea unui act adițional la contract.",
+  "Art. 17",
+  "(3) Persoana selectată în vederea angajării ori salariatul, după caz, va fi informată cu privire la cel puțin următoarele elemente:",
+  "k) salariul de bază, alte elemente constitutive ale veniturilor salariale, precum și periodicitatea plății salariului la care salariatul are dreptul.",
+  "Art. 41¹",
+  "(1) Text păstrat pentru articol suplimentar."
+]

--- a/tests/fixtures/html/codul_muncii_fragment.html
+++ b/tests/fixtures/html/codul_muncii_fragment.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ro">
+  <head>
+    <title>Codul muncii</title>
+    <style>
+      .menu { display: block; }
+    </style>
+    <script>
+      window.fakeNavigation = "Meniu Căutare";
+    </script>
+  </head>
+  <body>
+    <header class="site-header nav">Meniu Căutare Acasă</header>
+    <nav class="main-menu">Acasă Meniu Tipărește</nav>
+    <div id="textdocumentleg">
+      <h1>Codul muncii</h1>
+      <h2>Art. 41</h2>
+      <p>(1) Contractul individual de muncă poate fi modificat numai prin acordul părților.</p>
+      <p>(2) Cu titlu de excepție, modificarea unilaterală a contractului individual de muncă este posibilă numai în cazurile și în condițiile prevăzute de prezentul cod.</p>
+      <p>(3) Modificarea contractului individual de muncă se referă la oricare dintre următoarele elemente: durata contractului; locul muncii; felul muncii; condițiile de muncă; salariul; timpul de muncă și timpul de odihnă.</p>
+      <p>(4) Orice modificare a unuia dintre elementele prevăzute la alin. (3), în timpul executării contractului individual de muncă, impune încheierea unui act adițional la contract.</p>
+      <h2>Art. 17</h2>
+      <p>(3) Persoana selectată în vederea angajării ori salariatul, după caz, va fi informată cu privire la cel puțin următoarele elemente:</p>
+      <p>k) salariul de bază, alte elemente constitutive ale veniturilor salariale, precum și periodicitatea plății salariului la care salariatul are dreptul.</p>
+      <h2>Art. 41¹</h2>
+      <p>(1) Text păstrat pentru articol suplimentar.</p>
+    </div>
+    <footer class="page-footer">Tipărește Contact Meniu</footer>
+  </body>
+</html>

--- a/tests/fixtures/html/noisy_legislatie_page.expected_lines.json
+++ b/tests/fixtures/html/noisy_legislatie_page.expected_lines.json
@@ -1,0 +1,10 @@
+[
+  "Codul muncii",
+  "Art. 41",
+  "(1) Contractul individual de muncă poate fi modificat numai prin acordul părților.",
+  "(2) Cu titlu de excepție, modificarea unilaterală a contractului individual de muncă este posibilă numai în cazurile și în condițiile prevăzute de prezentul cod.",
+  "(3) Modificarea contractului individual de muncă se referă la salariul și timpul de muncă.",
+  "(4) Orice modificare impune încheierea unui act adițional la contract.",
+  "Art. 41^1",
+  "(1) Text local pentru articol suplimentar."
+]

--- a/tests/fixtures/html/noisy_legislatie_page.html
+++ b/tests/fixtures/html/noisy_legislatie_page.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="ro">
+  <head>
+    <title>Pagină locală de test</title>
+    <style>
+      body { font-family: sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div class="top-menu">Meniu Acasă Căutare Tipărește</div>
+    <form class="search-box">
+      <label>Căutare</label>
+      <input value="Codul muncii">
+      <button>Trimite</button>
+    </form>
+    <script>
+      console.log("navigation");
+    </script>
+    <p>Codul muncii</p>
+    <p>Art. 41</p>
+    <p>(1) Contractul individual de muncă poate fi modificat numai prin acordul părților.</p>
+    <p>(2) Cu titlu de excepție, modificarea unilaterală a contractului individual de muncă este posibilă numai în cazurile și în condițiile prevăzute de prezentul cod.</p>
+    <p>(3) Modificarea contractului individual de muncă se referă la salariul și timpul de muncă.</p>
+    <p>(4) Orice modificare impune încheierea unui act adițional la contract.</p>
+    <p>Art. 41^1</p>
+    <p>(1) Text local pentru articol suplimentar.</p>
+    <footer class="footer-nav">Footer Contact Meniu Tipărește</footer>
+  </body>
+</html>

--- a/tests/test_canonical_bundle_export.py
+++ b/tests/test_canonical_bundle_export.py
@@ -159,8 +159,9 @@ def test_validation_report_includes_v1_unknown_policy_warnings():
     assert report["quality_metrics"]["duplicate_free_score"] == 1.0
     assert report["quality_metrics"]["hierarchy_integrity"] == 1.0
     assert report["quality_metrics"]["source_url_coverage"] == 0.0
+    assert report["quality_metrics"]["text_cleanliness"] == 1.0
     assert report["quality_metrics"]["reference_resolution_rate"] == 0.0
-    assert report["corpus_quality"] == 0.7143
+    assert report["corpus_quality"] == 0.75
     assert report["import_blocking_passed"] is True
     assert "unknown_fields_left_null_by_policy" in warnings
     assert "source_url_unknown" in warnings

--- a/tests/test_html_cleaner.py
+++ b/tests/test_html_cleaner.py
@@ -1,0 +1,105 @@
+import json
+from pathlib import Path
+
+from ingestion.html_cleaner import clean_html_to_lines
+from ingestion.structural_parser import StructuralParser
+
+
+FIXTURE_DIR = Path("tests/fixtures/html")
+NAVIGATION_TERMS = ("Meniu", "Căutare", "Acasă", "Tipărește")
+
+
+def _fixture_text(name: str) -> str:
+    return (FIXTURE_DIR / f"{name}.html").read_text(encoding="utf-8")
+
+
+def _expected_lines(name: str) -> list[str]:
+    return json.loads(
+        (FIXTURE_DIR / f"{name}.expected_lines.json").read_text(encoding="utf-8")
+    )
+
+
+def test_cleaner_removes_script_style_nav_footer_and_matches_golden_lines():
+    result = clean_html_to_lines(_fixture_text("codul_muncii_fragment"))
+    joined = "\n".join(result.lines)
+
+    assert result.lines == _expected_lines("codul_muncii_fragment")
+    assert result.selected_container == "#textdocumentleg"
+    assert result.removed_blocks_count >= 4
+    assert "removed_navigation_blocks" in result.warnings
+    assert "window.fakeNavigation" not in joined
+    assert "display: block" not in joined
+    assert "Contact" not in joined
+    for term in NAVIGATION_TERMS:
+        assert term not in joined
+
+
+def test_cleaner_preserves_legal_diacritics_and_numbering():
+    result = clean_html_to_lines(_fixture_text("codul_muncii_fragment"))
+
+    assert "(1) Contractul individual de muncă poate fi modificat numai prin acordul părților." in result.lines
+    assert "(4) Orice modificare a unuia dintre elementele prevăzute la alin. (3), în timpul executării contractului individual de muncă, impune încheierea unui act adițional la contract." in result.lines
+    assert "k) salariul de bază, alte elemente constitutive ale veniturilor salariale, precum și periodicitatea plății salariului la care salariatul are dreptul." in result.lines
+    assert "Art. 41" in result.lines
+    assert "Art. 41¹" in result.lines
+
+
+def test_cleaner_body_fallback_is_explicit_and_still_clean():
+    result = clean_html_to_lines(_fixture_text("noisy_legislatie_page"))
+    joined = "\n".join(result.lines)
+
+    assert result.lines == _expected_lines("noisy_legislatie_page")
+    assert result.selected_container == "body"
+    assert "legal_container_not_found" in result.warnings
+    assert "used_body_fallback" in result.warnings
+    assert "removed_navigation_blocks" in result.warnings
+    assert "possible_navigation_residue" not in result.warnings
+    for term in NAVIGATION_TERMS:
+        assert term not in joined
+    assert "Art. 41^1" in result.lines
+
+
+def test_cleaner_output_is_deterministic():
+    first = clean_html_to_lines(_fixture_text("codul_muncii_fragment"))
+    second = clean_html_to_lines(_fixture_text("codul_muncii_fragment"))
+
+    assert first == second
+    assert first.text_hash == second.text_hash
+    assert first.text_hash is not None
+
+
+def test_cleaner_does_not_empty_simple_legal_html():
+    html = """
+    <html>
+      <body>
+        <p>Articolul 1</p>
+        <p>(1) Dreptul la muncă este garantat.</p>
+      </body>
+    </html>
+    """
+
+    result = clean_html_to_lines(html)
+
+    assert result.lines == ["Articolul 1", "(1) Dreptul la muncă este garantat."]
+    assert "legal_container_not_found" in result.warnings
+    assert "used_body_fallback" in result.warnings
+
+
+def test_cleaned_lines_remain_structural_parser_compatible():
+    result = clean_html_to_lines(_fixture_text("codul_muncii_fragment"))
+    parser = StructuralParser("ro.codul_muncii")
+
+    units, edges = parser.parse(result.lines)
+    unit_ids = {unit["id"] for unit in units}
+    edge_pairs = {(edge["source_id"], edge["target_id"]) for edge in edges}
+
+    assert "ro.codul_muncii.art_41" in unit_ids
+    assert "ro.codul_muncii.art_41.alin_1" in unit_ids
+    assert "ro.codul_muncii.art_41.alin_4" in unit_ids
+    assert "ro.codul_muncii.art_17.alin_3.lit_k" in unit_ids
+    assert "ro.codul_muncii.art_41_1" in unit_ids
+    assert ("ro.codul_muncii.art_41", "ro.codul_muncii.art_41.alin_1") in edge_pairs
+    assert (
+        "ro.codul_muncii.art_17.alin_3",
+        "ro.codul_muncii.art_17.alin_3.lit_k",
+    ) in edge_pairs

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -103,10 +103,21 @@ class TestBuildValidationReport:
         report = build_validation_report(CLEAN_UNITS, CONTAINS_EDGES, REF_CANDIDATES_MIXED)
         assert report["total_units"] == len(CLEAN_UNITS)
         assert report["total_contains_edges"] == len(CONTAINS_EDGES)
+        assert report["text_cleanliness"] == 1.0
 
     def test_warnings_present_for_orphans(self):
         report = build_validation_report(CLEAN_UNITS, CONTAINS_EDGES, [])
         assert any("orphan" in w.lower() for w in report["warnings"])
+
+    def test_text_cleanliness_penalizes_navigation_residue(self):
+        noisy_units = CLEAN_UNITS + [
+            {"id": "ro.test.art_3", "type": "articol", "raw_text": "Meniu Cautare Acasa"},
+        ]
+
+        report = build_validation_report(noisy_units, CONTAINS_EDGES, [])
+
+        assert report["text_cleanliness"] < 1.0
+        assert any("navigation residue" in warning.lower() for warning in report["warnings"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces a new HTML cleaning utility to improve the quality assessment of legal document ingestion by detecting and scoring the presence of navigation residue (extraneous navigation-related text) in raw legal texts. It adds a `text_cleanliness` metric to validation reports, issues warnings when navigation residue is detected, and updates test fixtures and manifests accordingly.

The most important changes are:

**HTML Cleaning Utility and Metrics:**
* Added a new module `ingestion/html_cleaner.py` that provides functions to detect navigation residue in text, score the cleanliness of text, and clean HTML fragments by removing navigation and non-content elements. This includes the `navigation_residue_count`, `text_cleanliness_score`, and `clean_html_to_lines` functions.
* Integrated `text_cleanliness_score` into both `ingestion/exporters.py` and `ingestion/validators.py` to compute a cleanliness metric for each set of legal units. This metric is now included in the output of validation reports. [[1]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R13) [[2]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R352-R354) [[3]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R375) [[4]](diffhunk://#diff-b68e18ad6d00aff6b3c762d72d0bc31533fa5b95e3fd5c81653845baaabc2ae7R11-R12) [[5]](diffhunk://#diff-b68e18ad6d00aff6b3c762d72d0bc31533fa5b95e3fd5c81653845baaabc2ae7R84-R86)

**Warning System Enhancements:**
* The validation and canonical bundle report logic now issues warnings if navigation residue is detected in any legal unit's raw text, using the new detection utility. [[1]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R579-R580) [[2]](diffhunk://#diff-b68e18ad6d00aff6b3c762d72d0bc31533fa5b95e3fd5c81653845baaabc2ae7R104-R105)

**Test and Fixture Updates:**
* Updated test fixtures (`validation_report.json`, `corpus_manifest.json`, etc.) and expected outputs to account for the new `text_cleanliness` metric and its effect on overall corpus quality scores. [[1]](diffhunk://#diff-71192c884b09af459cefbba4ab13e6b2f7c59457e03428f66b3deb844e2450fcL4-R4) [[2]](diffhunk://#diff-71192c884b09af459cefbba4ab13e6b2f7c59457e03428f66b3deb844e2450fcR17) [[3]](diffhunk://#diff-c2622b46d05aacf3eb3f49acd1794382a155afbffae831ba475c0f601800e98dL4-R4) [[4]](diffhunk://#diff-c2622b46d05aacf3eb3f49acd1794382a155afbffae831ba475c0f601800e98dR17) [[5]](diffhunk://#diff-f00e6a4c10f0c0d297e68b00946b3c52f4a8db2e744b4b76df37fa67ff53cdb7L27-R28) [[6]](diffhunk://#diff-7243af0082678b9c501859ba1f3c88aa8024c837996523746deed7a6096b7453L27-R28)
* Added new HTML and expected output fixtures to test the HTML cleaning logic and ensure navigation content is properly removed. [[1]](diffhunk://#diff-3642242c0052c96585ecbef567b398ea6644d330aac213069a1665477d9cf946R1-R30) [[2]](diffhunk://#diff-fc860a2659ee17bfb3245c5d54ddc376c00c77bcf636df06b13571c0e5f1b39aR1-R13) [[3]](diffhunk://#diff-fdf221593a6839e96eeb44b29570af0cbda2aa357449d2d85c1c04735f1b2e82R1-R29) [[4]](diffhunk://#diff-b8cf467adede010c4582deb49584ae59228ca2380b331a445415dfd6a595eb6eR1-R10)
* Updated tests to assert the presence and correctness of the new `text_cleanliness` metric and its impact on quality scores and warnings.