### PR TITLE
feat(ingestion): extract legislative reference candidates

### DIFF
--- a/ingestion/contracts/__init__.py
+++ b/ingestion/contracts/__init__.py
@@ -41,6 +41,9 @@ ReferenceResolutionStatus = Literal[
     "resolved_medium_confidence",
     "candidate_ambiguous",
     "external_unresolved",
+    "unresolved_ambiguous",
+    "unresolved_needs_context",
+    "candidate_only",
     "unresolved",
 ]
 
@@ -209,8 +212,9 @@ class ReferenceCandidate(IngestionContract):
     target_paragraph: str | None = None
     target_letter: str | None = None
     target_point: str | None = None
+    target_thesis: str | None = None
     resolved_target_id: str | None = None
-    resolution_status: ReferenceResolutionStatus = "unresolved"
+    resolution_status: ReferenceResolutionStatus = "candidate_only"
     resolution_confidence: float = Field(default=0.0, ge=0.0, le=1.0)
     resolver_notes: list[str] = Field(default_factory=list)
 

--- a/ingestion/exporters.py
+++ b/ingestion/exporters.py
@@ -19,6 +19,7 @@ from ingestion.legal_ids import (
     make_unit_id,
 )
 from ingestion.normalizer import normalize_legal_text
+from ingestion.reference_extractor import extract_references_from_units
 
 
 CITABLE_LEVELS = {"articol", "alineat", "litera", "punct"}
@@ -194,7 +195,12 @@ def build_canonical_bundle(
     metadata = _metadata_dict(act_metadata)
     legal_units = _canonical_units_from_legacy(legacy_units, metadata)
     legal_edges = _build_contains_edges(legal_units, parser_version=parser_version)
-    exported_reference_candidates = _export_reference_candidates(reference_candidates or [])
+    extracted_reference_candidates = (
+        list(reference_candidates)
+        if reference_candidates is not None
+        else extract_references_from_units(legal_units)
+    )
+    exported_reference_candidates = _export_reference_candidates(extracted_reference_candidates)
     validation_report = build_canonical_validation_report(
         legal_units,
         legal_edges,
@@ -544,13 +550,26 @@ def _export_reference_candidates(
                 "target_paragraph": candidate.get("target_paragraph"),
                 "target_letter": candidate.get("target_letter"),
                 "target_point": candidate.get("target_point"),
+                "target_thesis": candidate.get("target_thesis"),
                 "resolved_target_id": candidate.get("resolved_target_id") or candidate.get("target_id"),
-                "resolution_status": candidate.get("resolution_status") or candidate.get("status") or "unresolved",
+                "resolution_status": candidate.get("resolution_status") or candidate.get("status") or "candidate_only",
                 "resolution_confidence": candidate.get("resolution_confidence") or candidate.get("confidence") or 0.0,
                 "resolver_notes": candidate.get("resolver_notes") or [],
             }
         )
-    return sorted(exported, key=lambda item: (item["source_unit_id"], item["raw_reference"]))
+    return sorted(
+        exported,
+        key=lambda item: (
+            item["source_unit_id"],
+            item["raw_reference"],
+            item["reference_type"],
+            item.get("target_article") or "",
+            item.get("target_paragraph") or "",
+            item.get("target_letter") or "",
+            item.get("target_point") or "",
+            item.get("target_thesis") or "",
+        ),
+    )
 
 
 def _canonical_bundle_warnings(
@@ -568,11 +587,15 @@ def _canonical_bundle_warnings(
     empty_concepts = sum(1 for unit in legal_units if not unit.get("legal_concepts"))
     if empty_concepts >= max(1, len(legal_units) // 2):
         warnings.add("legal_concepts_empty_for_most_units_by_v1_policy")
-    if not reference_candidates or any(
+    unresolved_references = any(
         candidate.get("resolution_status")
         not in {"resolved_high_confidence", "resolved_medium_confidence"}
         for candidate in reference_candidates
-    ):
+    )
+    if reference_candidates and unresolved_references:
+        warnings.add("reference_candidates_extracted_unresolved")
+        warnings.add("reference_resolution_deferred_to_p7")
+    if not reference_candidates:
         warnings.add("reference_candidates_not_implemented_or_not_all_resolved")
     if any(unit.get("legal_domain") == "unknown" for unit in legal_units):
         warnings.add("legal_domain_unknown")

--- a/ingestion/reference_extractor.py
+++ b/ingestion/reference_extractor.py
@@ -1,105 +1,431 @@
-"""
-reference_extractor.py
-----------------------
-Parses raw_text of a LegalUnit and returns a list of ReferenceCandidate dicts.
-
-Supports:
-  - REF_ART_RE   – standalone article references: "art. 17"
-  - REF_ALIN_RE  – paragraph references: "alin. (2)"
-  - REF_LOCAL_RE – local-act hints: "prezenta lege", "prezentul cod"
-  - Combined pattern: "art. 17 alin. (1)"
-
-Does NOT handle cross-act resolution (delegated to reference_resolver.py).
-"""
+from __future__ import annotations
 
 import re
-from typing import List, Dict, Any
+import unicodedata
+from typing import Any, Mapping
 
-# ---------------------------------------------------------------------------
-# Compiled regexes
-# ---------------------------------------------------------------------------
+from ingestion.contracts import ReferenceCandidate
+from ingestion.legal_ids import make_law_id, normalize_number
 
-# Matches: art. 17  |  art. 17^1
+
+ARTICLE_NUMBER = r"\d+(?:\^\d+|[\u2070\u00b9\u00b2\u00b3\u2074-\u2079]+)?"
+LETTER = r"[a-zA-Z]"
+ROMAN = r"[IVXLCDM]+"
+
 REF_ART_RE = re.compile(
-    r'art\.\s*(\d+(?:\^\d+)?)',
-    re.IGNORECASE
+    rf"\b(?:art\.?|articolul)\s*({ARTICLE_NUMBER})",
+    re.IGNORECASE,
 )
-
-# Matches: alin. (1)  |  alin.(2)
 REF_ALIN_RE = re.compile(
-    r'alin\.\s*\((\d+)\)',
-    re.IGNORECASE
+    r"\b(?:alin\.?|alineatul)\s*\(?(\d+)\)?",
+    re.IGNORECASE,
 )
-
-# Matches local-act self-references
 REF_LOCAL_RE = re.compile(
-    r'(prezenta\s+lege|prezentul\s+(?:cod|regulament|ordin))',
-    re.IGNORECASE
+    r"\b("
+    r"prezentul\s+cod|"
+    r"prezenta\s+lege|"
+    r"prezentul\s+act\s+normativ|"
+    r"prezenta\s+ordonan(?:t|ț|ţ)(?:a|ă)|"
+    r"prezenta\s+hot(?:a|ă)r(?:a|â)re"
+    r")\b",
+    re.IGNORECASE,
 )
 
-# Combined: "art. 17 alin. (1) lit. a)"  – the most common citation pattern
-REF_COMBINED_RE = re.compile(
-    r'art\.\s*(\d+(?:\^\d+)?)(?:\s+alin\.\s*\((\d+)\))?(?:\s+lit\.\s*([a-z])\))?',
-    re.IGNORECASE
+REF_COMPOUND_RE = re.compile(
+    rf"\b(?:art\.?|articolul)\s*(?P<article>{ARTICLE_NUMBER})"
+    r"(?:\s*,?\s*(?:alin\.?|alineatul)\s*\(?(?P<paragraph>\d+)\)?)?"
+    rf"(?:\s*,?\s*(?:lit\.?|litera)\s*(?P<letter>{LETTER})\))?"
+    r"(?:\s*,?\s*(?:pct\.?|punctul)\s*(?P<point>\d+))?"
+    rf"(?:\s*,?\s*(?P<thesis>teza\s+a\s+(?P<thesis_value>{ROMAN})-a))?",
+    re.IGNORECASE,
+)
+REF_LETTER_RE = re.compile(
+    rf"\b(?:lit\.?|litera)\s*({LETTER})\)",
+    re.IGNORECASE,
+)
+REF_POINT_RE = re.compile(
+    r"\b(?:pct\.?|punctul)\s*(\d+)\b",
+    re.IGNORECASE,
+)
+REF_THESIS_RE = re.compile(
+    rf"\bteza\s+a\s+({ROMAN})-a\b",
+    re.IGNORECASE,
+)
+REF_NUMBERED_ACT_RE = re.compile(
+    r"\b(?P<label>"
+    r"Legea|"
+    r"O\.?\s*U\.?\s*G\.?|"
+    r"O\.?\s*G\.?|"
+    r"H\.?\s*G\.?"
+    r")\s+(?:nr\.?\s*)?(?P<number>\d+)\s*/\s*(?P<year>\d{4})\b",
+    re.IGNORECASE,
+)
+REF_CODE_RE = re.compile(
+    r"\b("
+    r"Codul\s+de\s+procedur(?:a|ă)\s+civil(?:a|ă)|"
+    r"Codul\s+de\s+procedur(?:a|ă)\s+penal(?:a|ă)|"
+    r"Codul\s+muncii|"
+    r"Codul\s+civil|"
+    r"Codul\s+fiscal|"
+    r"Codul\s+penal"
+    r")\b",
+    re.IGNORECASE,
 )
 
-# Hint for external law references – e.g. "din Codul Civil", "din Legea 53/2003"
-# When detected we mark the candidate as external
-REF_EXTERNAL_HINT_RE = re.compile(
-    r'din\s+(Legea|Codul|Ordonanța|OUG|OG|HG)\s+',
-    re.IGNORECASE
-)
+
+def extract_references(unit: Mapping[str, Any]) -> list[dict[str, Any]]:
+    source_unit_id = str(unit.get("id") or "")
+    raw_text = str(unit.get("raw_text") or "")
+    if not raw_text.strip():
+        return []
+    return extract_references_from_text(raw_text, source_unit_id=source_unit_id)
 
 
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
+def extract_references_from_units(units: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    for unit in units:
+        candidates.extend(extract_references(unit))
+    return sorted(candidates, key=_candidate_sort_key)
 
-def extract_references(unit: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """
-    Given a LegalUnit dict, scan its raw_text and return a list of
-    ReferenceCandidate dicts.
 
-    Each candidate has:
-        source_unit_id  – ID of the unit that contains the citation
-        raw_reference   – the matched substring (for debugging)
-        target_article  – str | None  (e.g. "17" or "41^1")
-        target_paragraph – str | None (e.g. "1")
-        target_law_hint  – "same_act" | "external" | None
-    """
-    source_id = unit.get("id", "")
-    raw_text  = unit.get("raw_text", "")
-    candidates: List[Dict[str, Any]] = []
+def extract_references_from_text(
+    raw_text: str,
+    *,
+    source_unit_id: str,
+) -> list[dict[str, Any]]:
+    candidates: list[tuple[int, dict[str, Any]]] = []
+    structural_spans: list[tuple[int, int]] = []
 
-    for match in REF_COMBINED_RE.finditer(raw_text):
-        art_val  = match.group(1)          # always present when REF_COMBINED_RE fires
-        alin_val = match.group(2) or None  # may be absent
-        lit_val  = match.group(3) or None  # may be absent
+    for match in REF_COMPOUND_RE.finditer(raw_text):
+        if _is_self_article_heading(raw_text, match, source_unit_id):
+            continue
+        candidate = _compound_candidate(raw_text, match, source_unit_id)
+        candidates.append((match.start(), candidate))
+        structural_spans.append(match.span())
 
-        raw_ref = match.group(0)
+        sibling_letter = _sibling_letter_candidate(raw_text, match, source_unit_id)
+        if sibling_letter is not None:
+            candidates.append((match.start(), sibling_letter))
 
-        # Determine law hint: look at the surrounding context (up to 60 chars after)
-        start, end = match.span()
-        context_after = raw_text[end:end + 80]
+    for match in REF_ALIN_RE.finditer(raw_text):
+        if _overlaps(match.span(), structural_spans):
+            continue
+        candidates.append(
+            (
+                match.start(),
+                _candidate(
+                    source_unit_id=source_unit_id,
+                    raw_reference=match.group(0),
+                    reference_type="paragraph",
+                    target_law_hint=_law_hint_near(raw_text, match) or "same_act",
+                    target_paragraph=normalize_number(match.group(1)),
+                    resolution_status="unresolved_needs_context",
+                    resolver_notes=["paragraph_reference_without_article"],
+                ),
+            )
+        )
 
-        is_local    = bool(REF_LOCAL_RE.search(raw_text[max(0, start - 60):end + 60]))
-        is_external = bool(REF_EXTERNAL_HINT_RE.search(context_after))
+    for regex, reference_type, field_name in (
+        (REF_LETTER_RE, "letter", "target_letter"),
+        (REF_POINT_RE, "point", "target_point"),
+        (REF_THESIS_RE, "thesis", "target_thesis"),
+    ):
+        for match in regex.finditer(raw_text):
+            if _overlaps(match.span(), structural_spans):
+                continue
+            value = _normalize_field(reference_type, match.group(1))
+            candidates.append(
+                (
+                    match.start(),
+                    _candidate(
+                        source_unit_id=source_unit_id,
+                        raw_reference=match.group(0),
+                        reference_type=reference_type,
+                        target_law_hint=_law_hint_near(raw_text, match) or "same_act",
+                        resolution_status="unresolved_needs_context",
+                        resolver_notes=[f"{reference_type}_reference_without_article"],
+                        **{field_name: value},
+                    ),
+                )
+            )
 
-        if is_external:
-            law_hint = "external"
-        elif is_local:
-            law_hint = "same_act"
-        else:
-            # Default for intra-act references when no explicit hint
-            law_hint = "same_act"
+    for match in REF_NUMBERED_ACT_RE.finditer(raw_text):
+        if _is_whole_text_reference(raw_text, match):
+            continue
+        candidates.append(
+            (
+                match.start(),
+                _candidate(
+                    source_unit_id=source_unit_id,
+                    raw_reference=match.group(0),
+                    reference_type=_numbered_reference_type(match.group("label")),
+                    target_law_hint=_numbered_law_hint(
+                        match.group("label"),
+                        match.group("number"),
+                        match.group("year"),
+                    ),
+                    resolver_notes=["act_reference_candidate_only"],
+                ),
+            )
+        )
 
-        candidates.append({
-            "source_unit_id":   source_id,
-            "raw_reference":    raw_ref,
-            "target_article":   art_val,
-            "target_paragraph": alin_val,
-            "target_letter":    lit_val,
-            "target_law_hint":  law_hint,
-        })
+    for match in REF_CODE_RE.finditer(raw_text):
+        if _is_whole_text_reference(raw_text, match):
+            continue
+        candidates.append(
+            (
+                match.start(),
+                _candidate(
+                    source_unit_id=source_unit_id,
+                    raw_reference=match.group(0),
+                    reference_type="code",
+                    target_law_hint=_code_law_hint(match.group(0)),
+                    resolver_notes=["code_reference_candidate_only"],
+                ),
+            )
+        )
 
-    return candidates
+    for match in REF_LOCAL_RE.finditer(raw_text):
+        candidates.append(
+            (
+                match.start(),
+                _candidate(
+                    source_unit_id=source_unit_id,
+                    raw_reference=match.group(0),
+                    reference_type="same_act",
+                    target_law_hint="same_act",
+                    resolution_status="unresolved_needs_context",
+                    resolver_notes=["same_act_reference_requires_context"],
+                ),
+            )
+        )
+
+    return _dedupe_in_text_order(candidates)
+
+
+def _compound_candidate(
+    raw_text: str,
+    match: re.Match[str],
+    source_unit_id: str,
+) -> dict[str, Any]:
+    has_child = any(
+        match.group(name)
+        for name in ("paragraph", "letter", "point", "thesis_value")
+    )
+    return _candidate(
+        source_unit_id=source_unit_id,
+        raw_reference=match.group(0),
+        reference_type="compound" if has_child else "article",
+        target_law_hint=_law_hint_near(raw_text, match) or "same_act",
+        target_article=normalize_number(match.group("article")),
+        target_paragraph=normalize_number(match.group("paragraph"))
+        if match.group("paragraph")
+        else None,
+        target_letter=normalize_number(match.group("letter"))
+        if match.group("letter")
+        else None,
+        target_point=normalize_number(match.group("point"))
+        if match.group("point")
+        else None,
+        target_thesis=_normalize_thesis(match.group("thesis_value")),
+        resolver_notes=["compound_reference_candidate_only"]
+        if has_child
+        else ["article_reference_candidate_only"],
+    )
+
+
+def _sibling_letter_candidate(
+    raw_text: str,
+    match: re.Match[str],
+    source_unit_id: str,
+) -> dict[str, Any] | None:
+    if not match.group("letter"):
+        return None
+    tail = raw_text[match.end() : match.end() + 12]
+    tail_match = re.match(r"\s*(?:și|si)\s*([a-zA-Z])\)", tail, re.IGNORECASE)
+    if not tail_match:
+        return None
+    return _candidate(
+        source_unit_id=source_unit_id,
+        raw_reference=f"{match.group(0)}{tail_match.group(0)}",
+        reference_type="compound",
+        target_law_hint=_law_hint_near(raw_text, match) or "same_act",
+        target_article=normalize_number(match.group("article")),
+        target_paragraph=normalize_number(match.group("paragraph"))
+        if match.group("paragraph")
+        else None,
+        target_letter=normalize_number(tail_match.group(1)),
+        target_point=normalize_number(match.group("point"))
+        if match.group("point")
+        else None,
+        target_thesis=_normalize_thesis(match.group("thesis_value")),
+        resolver_notes=["compound_sibling_letter_reference_candidate_only"],
+    )
+
+
+def _candidate(
+    *,
+    source_unit_id: str,
+    raw_reference: str,
+    reference_type: str,
+    target_law_hint: str | None = None,
+    target_article: str | None = None,
+    target_paragraph: str | None = None,
+    target_letter: str | None = None,
+    target_point: str | None = None,
+    target_thesis: str | None = None,
+    resolution_status: str = "candidate_only",
+    resolver_notes: list[str] | None = None,
+) -> dict[str, Any]:
+    return ReferenceCandidate(
+        source_unit_id=source_unit_id,
+        raw_reference=raw_reference,
+        reference_type=reference_type,
+        target_law_hint=target_law_hint,
+        target_article=target_article,
+        target_paragraph=target_paragraph,
+        target_letter=target_letter,
+        target_point=target_point,
+        target_thesis=target_thesis,
+        resolved_target_id=None,
+        resolution_status=resolution_status,
+        resolution_confidence=0.0,
+        resolver_notes=resolver_notes or ["reference_resolution_deferred_to_p7"],
+    ).model_dump()
+
+
+def _law_hint_near(raw_text: str, match: re.Match[str]) -> str | None:
+    context = raw_text[max(0, match.start() - 80) : min(len(raw_text), match.end() + 120)]
+    same_act = REF_LOCAL_RE.search(context)
+    if same_act:
+        return "same_act"
+    code = REF_CODE_RE.search(context)
+    if code:
+        return _code_law_hint(code.group(0))
+    numbered = REF_NUMBERED_ACT_RE.search(context)
+    if numbered:
+        return _numbered_law_hint(
+            numbered.group("label"),
+            numbered.group("number"),
+            numbered.group("year"),
+        )
+    return None
+
+
+def _numbered_reference_type(label: str) -> str:
+    normalized = _normalize_ascii(label)
+    if "u" in normalized and normalized.replace(" ", "").replace(".", "") == "oug":
+        return "oug"
+    compact = normalized.replace(" ", "").replace(".", "")
+    if compact == "og":
+        return "og"
+    if compact == "hg":
+        return "hg"
+    return "law"
+
+
+def _numbered_law_hint(label: str, number: str, year: str) -> str:
+    prefix = _numbered_reference_type(label)
+    if prefix == "law":
+        prefix = "lege"
+    return f"ro.{prefix}_{normalize_number(number)}_{normalize_number(year)}"
+
+
+def _code_law_hint(raw_reference: str) -> str:
+    normalized = _normalize_ascii(raw_reference)
+    mapping = {
+        "codul muncii": "ro.codul_muncii",
+        "codul civil": "ro.codul_civil",
+        "codul fiscal": "ro.codul_fiscal",
+        "codul penal": "ro.codul_penal",
+        "codul de procedura civila": "ro.codul_de_procedura_civila",
+        "codul de procedura penala": "ro.codul_de_procedura_penala",
+    }
+    return mapping.get(normalized, make_law_id(raw_reference))
+
+
+def _normalize_field(reference_type: str, value: str) -> str:
+    if reference_type == "thesis":
+        return _normalize_thesis(value) or value.upper()
+    return normalize_number(value)
+
+
+def _normalize_thesis(value: str | None) -> str | None:
+    if not value:
+        return None
+    return value.upper()
+
+
+def _is_self_article_heading(
+    raw_text: str,
+    match: re.Match[str],
+    source_unit_id: str,
+) -> bool:
+    line_start = raw_text.rfind("\n", 0, match.start()) + 1
+    prefix = raw_text[line_start : match.start()]
+    if prefix.strip():
+        return False
+    article = normalize_number(match.group("article"))
+    return source_unit_id.endswith(f".art_{article}") or f".art_{article}." in source_unit_id
+
+
+def _is_whole_text_reference(raw_text: str, match: re.Match[str]) -> bool:
+    return raw_text.strip() == match.group(0).strip()
+
+
+def _overlaps(span: tuple[int, int], spans: list[tuple[int, int]]) -> bool:
+    start, end = span
+    return any(start < existing_end and end > existing_start for existing_start, existing_end in spans)
+
+
+def _dedupe_in_text_order(candidates: list[tuple[int, dict[str, Any]]]) -> list[dict[str, Any]]:
+    seen: set[tuple[Any, ...]] = set()
+    deduped: list[tuple[int, dict[str, Any]]] = []
+    for index, candidate in candidates:
+        key = _candidate_dedupe_key(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((index, candidate))
+    return [
+        candidate
+        for _, candidate in sorted(
+            deduped,
+            key=lambda item: (item[0], _candidate_sort_key(item[1])),
+        )
+    ]
+
+
+def _candidate_dedupe_key(candidate: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        candidate.get("source_unit_id"),
+        candidate.get("raw_reference"),
+        candidate.get("reference_type"),
+        candidate.get("target_law_hint"),
+        candidate.get("target_article"),
+        candidate.get("target_paragraph"),
+        candidate.get("target_letter"),
+        candidate.get("target_point"),
+        candidate.get("target_thesis"),
+    )
+
+
+def _candidate_sort_key(candidate: Mapping[str, Any]) -> tuple[Any, ...]:
+    return (
+        candidate.get("source_unit_id") or "",
+        candidate.get("raw_reference") or "",
+        candidate.get("reference_type") or "",
+        candidate.get("target_article") or "",
+        candidate.get("target_paragraph") or "",
+        candidate.get("target_letter") or "",
+        candidate.get("target_point") or "",
+        candidate.get("target_thesis") or "",
+    )
+
+
+def _normalize_ascii(value: str) -> str:
+    normalized = unicodedata.normalize("NFD", value.casefold())
+    stripped = "".join(
+        char for char in normalized if unicodedata.category(char) != "Mn"
+    )
+    return " ".join(stripped.replace(".", " ").split())

--- a/tests/fixtures/corpus/codul_muncii_corpus_manifest.json
+++ b/tests/fixtures/corpus/codul_muncii_corpus_manifest.json
@@ -5,7 +5,7 @@
   "source_count": 1,
   "units_count": 9,
   "edges_count": 8,
-  "reference_candidates_count": 0,
+  "reference_candidates_count": 4,
   "input_files": [
     "tests/fixtures/corpus/codul_muncii_legacy_units.json"
   ],
@@ -24,14 +24,15 @@
     "validation_report": "validation_report.json",
     "reference_candidates": "reference_candidates.json"
   },
-  "content_hash": "9cdfbbfca145b6309cb517f6aa7c11f07643367463925f0b78ee10035f5aa381",
-  "bundle_hash": "be6605eac452ecf86035f5982360e99d4feead735363fa11948b3713434c919d",
+  "content_hash": "f9e3fe70c0278e4aaf759df506769823fb98258ef673d0b28b2e544f255838c1",
+  "bundle_hash": "913c958a7abcee70c6a559dffda44aa04ce6735b5cc065771ec063202f3c4b93",
   "warnings": [
     "effective_date_unknown",
     "legal_concepts_empty_for_most_units_by_v1_policy",
     "local_fixture_demo_sample_not_official_complete_text",
     "publication_date_unknown",
-    "reference_candidates_not_implemented_or_not_all_resolved",
+    "reference_candidates_extracted_unresolved",
+    "reference_resolution_deferred_to_p7",
     "source_url_unknown",
     "status_unknown",
     "unknown_fields_left_null_by_policy",

--- a/tests/fixtures/corpus/codul_muncii_reference_candidates.json
+++ b/tests/fixtures/corpus/codul_muncii_reference_candidates.json
@@ -1,1 +1,70 @@
-[]
+[
+  {
+    "source_unit_id": "ro.codul_muncii.art_41",
+    "raw_reference": "alin. (3)",
+    "reference_type": "paragraph",
+    "target_law_hint": "same_act",
+    "target_article": null,
+    "target_paragraph": "3",
+    "target_letter": null,
+    "target_point": null,
+    "target_thesis": null,
+    "resolved_target_id": null,
+    "resolution_status": "unresolved_needs_context",
+    "resolution_confidence": 0.0,
+    "resolver_notes": [
+      "paragraph_reference_without_article"
+    ]
+  },
+  {
+    "source_unit_id": "ro.codul_muncii.art_41",
+    "raw_reference": "prezentul cod",
+    "reference_type": "same_act",
+    "target_law_hint": "same_act",
+    "target_article": null,
+    "target_paragraph": null,
+    "target_letter": null,
+    "target_point": null,
+    "target_thesis": null,
+    "resolved_target_id": null,
+    "resolution_status": "unresolved_needs_context",
+    "resolution_confidence": 0.0,
+    "resolver_notes": [
+      "same_act_reference_requires_context"
+    ]
+  },
+  {
+    "source_unit_id": "ro.codul_muncii.art_41.alin_2",
+    "raw_reference": "prezentul cod",
+    "reference_type": "same_act",
+    "target_law_hint": "same_act",
+    "target_article": null,
+    "target_paragraph": null,
+    "target_letter": null,
+    "target_point": null,
+    "target_thesis": null,
+    "resolved_target_id": null,
+    "resolution_status": "unresolved_needs_context",
+    "resolution_confidence": 0.0,
+    "resolver_notes": [
+      "same_act_reference_requires_context"
+    ]
+  },
+  {
+    "source_unit_id": "ro.codul_muncii.art_41.alin_4",
+    "raw_reference": "alin. (3)",
+    "reference_type": "paragraph",
+    "target_law_hint": "same_act",
+    "target_article": null,
+    "target_paragraph": "3",
+    "target_letter": null,
+    "target_point": null,
+    "target_thesis": null,
+    "resolved_target_id": null,
+    "resolution_status": "unresolved_needs_context",
+    "resolution_confidence": 0.0,
+    "resolver_notes": [
+      "paragraph_reference_without_article"
+    ]
+  }
+]

--- a/tests/fixtures/corpus/codul_muncii_validation_report.json
+++ b/tests/fixtures/corpus/codul_muncii_validation_report.json
@@ -6,7 +6,7 @@
   "units_count": 9,
   "edges_count": 8,
   "chunks_count": 0,
-  "reference_candidates_count": 0,
+  "reference_candidates_count": 4,
   "quality_metrics": {
     "unit_completeness": 1.0,
     "hierarchy_integrity": 1.0,
@@ -22,7 +22,8 @@
     "legal_concepts_empty_for_most_units_by_v1_policy",
     "local_fixture_demo_sample_not_official_complete_text",
     "publication_date_unknown",
-    "reference_candidates_not_implemented_or_not_all_resolved",
+    "reference_candidates_extracted_unresolved",
+    "reference_resolution_deferred_to_p7",
     "source_url_unknown",
     "status_unknown",
     "unknown_fields_left_null_by_policy",

--- a/tests/fixtures/corpus/reference_extraction_legacy_units.json
+++ b/tests/fixtures/corpus/reference_extraction_legacy_units.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "ro.codul_muncii.art_100",
+    "type": "articol",
+    "raw_text": "Se aplică art. 41 alin. (3), art. 17 alin. (3) lit. k), Legea nr. 53/2003, O.U.G. nr. 195/2002, Codul civil și prezentul cod.",
+    "hierarchy_path": ["100"],
+    "corpus_id": "ro.codul_muncii"
+  },
+  {
+    "id": "ro.codul_muncii.art_101",
+    "type": "articol",
+    "raw_text": "Sunt menționate OUG nr. 195/2002, O.G. nr. 2/2001, HG nr. 1/2016, Codul fiscal și prezenta lege.",
+    "hierarchy_path": ["101"],
+    "corpus_id": "ro.codul_muncii"
+  }
+]

--- a/tests/test_canonical_bundle_export.py
+++ b/tests/test_canonical_bundle_export.py
@@ -49,6 +49,7 @@ ACT_METADATA = {
     "status": "unknown",
 }
 FIXTURE_DIR = Path("tests/fixtures/corpus/mini_codul_muncii")
+REFERENCE_FIXTURE_PATH = Path("tests/fixtures/corpus/reference_extraction_legacy_units.json")
 
 
 def test_canonical_bundle_generation_writes_required_files(tmp_path):
@@ -147,6 +148,36 @@ def test_reference_candidates_file_exists_even_when_empty(tmp_path):
     candidates = json.loads((tmp_path / "reference_candidates.json").read_text(encoding="utf-8"))
 
     assert candidates == []
+
+
+def test_reference_candidates_are_exported_without_reference_edges():
+    legacy_units = json.loads(REFERENCE_FIXTURE_PATH.read_text(encoding="utf-8"))
+    bundle = build_canonical_bundle(legacy_units, ACT_METADATA)
+    candidates = bundle["reference_candidates"]
+
+    raw_refs = {candidate["raw_reference"] for candidate in candidates}
+    assert "art. 41 alin. (3)" in raw_refs
+    assert "art. 17 alin. (3) lit. k)" in raw_refs
+    assert "Legea nr. 53/2003" in raw_refs
+    assert "O.U.G. nr. 195/2002" in raw_refs
+    assert "Codul civil" in raw_refs
+    assert "prezentul cod" in raw_refs
+    assert candidates == sorted(
+        candidates,
+        key=lambda item: (
+            item["source_unit_id"],
+            item["raw_reference"],
+            item["reference_type"],
+            item.get("target_article") or "",
+            item.get("target_paragraph") or "",
+            item.get("target_letter") or "",
+        ),
+    )
+    assert {edge["type"] for edge in bundle["legal_edges"]} == {"contains"}
+    assert bundle["validation_report"]["reference_candidates_count"] == len(candidates)
+    assert bundle["validation_report"]["quality_metrics"]["reference_resolution_rate"] == 0.0
+    assert "reference_candidates_extracted_unresolved" in bundle["validation_report"]["warnings"]
+    assert "reference_resolution_deferred_to_p7" in bundle["validation_report"]["warnings"]
 
 
 def test_validation_report_includes_v1_unknown_policy_warnings():

--- a/tests/test_codul_muncii_demo_path.py
+++ b/tests/test_codul_muncii_demo_path.py
@@ -206,7 +206,7 @@ def test_validation_report_marks_demo_fixture_unknowns_and_no_reference_edges():
 
     assert report["units_count"] == 9
     assert report["edges_count"] == 8
-    assert report["reference_candidates_count"] == 0
+    assert report["reference_candidates_count"] == len(_load_json(REFERENCE_CANDIDATES_PATH))
     assert report["quality_metrics"]["source_url_coverage"] == 0.0
     assert report["quality_metrics"]["reference_resolution_rate"] == 0.0
     assert report["import_blocking_passed"] is True
@@ -218,7 +218,12 @@ def test_validation_report_marks_demo_fixture_unknowns_and_no_reference_edges():
     assert "version_start_unknown" in warnings
     assert "version_end_unknown" in warnings
     assert "legal_concepts_empty_for_most_units_by_v1_policy" in warnings
-    assert _load_json(REFERENCE_CANDIDATES_PATH) == []
+    assert "reference_candidates_extracted_unresolved" in warnings
+    assert "reference_resolution_deferred_to_p7" in warnings
+    reference_candidates = _load_json(REFERENCE_CANDIDATES_PATH)
+    assert any(candidate["raw_reference"] == "alin. (3)" for candidate in reference_candidates)
+    assert any(candidate["raw_reference"] == "prezentul cod" for candidate in reference_candidates)
+    assert all(candidate["resolved_target_id"] is None for candidate in reference_candidates)
     assert {edge["type"] for edge in _edges()} == {"contains"}
 
 

--- a/tests/test_reference_extractor.py
+++ b/tests/test_reference_extractor.py
@@ -1,0 +1,151 @@
+from ingestion.reference_extractor import extract_references
+
+
+SOURCE_UNIT_ID = "ro.codul_muncii.art_100"
+
+
+def _extract(text: str):
+    return extract_references({"id": SOURCE_UNIT_ID, "raw_text": text})
+
+
+def _by_raw(candidates: list[dict], raw_reference: str) -> dict:
+    return next(
+        candidate
+        for candidate in candidates
+        if candidate["raw_reference"] == raw_reference
+    )
+
+
+def test_detects_article_reference():
+    candidate = _by_raw(_extract("Conform art. 41, regula se aplică."), "art. 41")
+
+    assert candidate["reference_type"] == "article"
+    assert candidate["target_article"] == "41"
+    assert candidate["target_law_hint"] == "same_act"
+    assert candidate["resolved_target_id"] is None
+    assert candidate["resolution_status"] == "candidate_only"
+
+
+def test_detects_superscript_and_caret_articles_with_same_normalization():
+    candidates = _extract("A se vedea Art. 41^1 și Art. 41\u00b9.")
+
+    assert _by_raw(candidates, "Art. 41^1")["target_article"] == "41_1"
+    assert _by_raw(candidates, "Art. 41\u00b9")["target_article"] == "41_1"
+
+
+def test_detects_paragraph_letter_point_and_thesis_references():
+    candidates = _extract("Potrivit alin. (3), lit. k), pct. 2 și teza a II-a.")
+
+    paragraph = _by_raw(candidates, "alin. (3)")
+    letter = _by_raw(candidates, "lit. k)")
+    point = _by_raw(candidates, "pct. 2")
+    thesis = _by_raw(candidates, "teza a II-a")
+
+    assert paragraph["reference_type"] == "paragraph"
+    assert paragraph["target_paragraph"] == "3"
+    assert paragraph["resolution_status"] == "unresolved_needs_context"
+    assert letter["target_letter"] == "k"
+    assert point["target_point"] == "2"
+    assert thesis["target_thesis"] == "II"
+
+
+def test_detects_compound_article_paragraph_letter_without_independent_letter():
+    candidates = _extract("Se aplică art. 17 alin. (3) lit. k).")
+
+    assert candidates == [
+        {
+            "source_unit_id": SOURCE_UNIT_ID,
+            "raw_reference": "art. 17 alin. (3) lit. k)",
+            "reference_type": "compound",
+            "target_law_hint": "same_act",
+            "target_article": "17",
+            "target_paragraph": "3",
+            "target_letter": "k",
+            "target_point": None,
+            "target_thesis": None,
+            "resolved_target_id": None,
+            "resolution_status": "candidate_only",
+            "resolution_confidence": 0.0,
+            "resolver_notes": ["compound_reference_candidate_only"],
+        }
+    ]
+
+
+def test_detects_numbered_laws_and_ordinances():
+    candidates = _extract(
+        "Conform Legea nr. 53/2003, O.U.G. nr. 195/2002, "
+        "OUG nr. 195/2002, O.G. nr. 2/2001, OG nr. 2/2001, "
+        "H.G. nr. 1/2016 și HG nr. 1/2016."
+    )
+
+    assert _by_raw(candidates, "Legea nr. 53/2003")["target_law_hint"] == "ro.lege_53_2003"
+    assert _by_raw(candidates, "O.U.G. nr. 195/2002")["reference_type"] == "oug"
+    assert _by_raw(candidates, "O.U.G. nr. 195/2002")["target_law_hint"] == "ro.oug_195_2002"
+    assert _by_raw(candidates, "OUG nr. 195/2002")["target_law_hint"] == "ro.oug_195_2002"
+    assert _by_raw(candidates, "O.G. nr. 2/2001")["target_law_hint"] == "ro.og_2_2001"
+    assert _by_raw(candidates, "OG nr. 2/2001")["target_law_hint"] == "ro.og_2_2001"
+    assert _by_raw(candidates, "H.G. nr. 1/2016")["target_law_hint"] == "ro.hg_1_2016"
+    assert _by_raw(candidates, "HG nr. 1/2016")["target_law_hint"] == "ro.hg_1_2016"
+
+
+def test_detects_named_codes_with_diacritics_and_without():
+    candidates = _extract(
+        "Codul muncii, Codul civil, Codul fiscal, Codul penal, "
+        "Codul de procedură civilă și Codul de procedura penala."
+    )
+
+    assert _by_raw(candidates, "Codul muncii")["target_law_hint"] == "ro.codul_muncii"
+    assert _by_raw(candidates, "Codul civil")["target_law_hint"] == "ro.codul_civil"
+    assert _by_raw(candidates, "Codul fiscal")["target_law_hint"] == "ro.codul_fiscal"
+    assert _by_raw(candidates, "Codul penal")["target_law_hint"] == "ro.codul_penal"
+    assert (
+        _by_raw(candidates, "Codul de procedură civilă")["target_law_hint"]
+        == "ro.codul_de_procedura_civila"
+    )
+    assert (
+        _by_raw(candidates, "Codul de procedura penala")["target_law_hint"]
+        == "ro.codul_de_procedura_penala"
+    )
+
+
+def test_detects_same_act_references():
+    candidates = _extract(
+        "prezentul cod, prezenta lege, prezentul act normativ, "
+        "prezenta ordonanță, prezenta ordonanta, prezenta hotărâre și prezenta hotarare"
+    )
+
+    raw_refs = {candidate["raw_reference"] for candidate in candidates}
+    assert "prezentul cod" in raw_refs
+    assert "prezenta lege" in raw_refs
+    assert "prezentul act normativ" in raw_refs
+    assert "prezenta ordonanță" in raw_refs
+    assert "prezenta ordonanta" in raw_refs
+    assert "prezenta hotărâre" in raw_refs
+    assert "prezenta hotarare" in raw_refs
+    assert {candidate["target_law_hint"] for candidate in candidates} == {"same_act"}
+
+
+def test_dedupes_exact_same_reference_in_same_unit():
+    candidates = _extract("Vezi art. 41 și art. 41.")
+
+    assert [candidate["raw_reference"] for candidate in candidates] == ["art. 41"]
+
+
+def test_does_not_match_obvious_numbers_without_reference_labels():
+    candidates = _extract("Termenul este de 20 de zile, suma este 100 lei, procentul este 5%.")
+
+    assert candidates == []
+
+
+def test_preserves_raw_reference_and_output_is_deterministic():
+    text = "Conform art. 41 alin. (3), Legea nr. 53/2003 și prezentul cod."
+
+    first = _extract(text)
+    second = _extract(text)
+
+    assert first == second
+    assert [candidate["raw_reference"] for candidate in first] == [
+        "art. 41 alin. (3)",
+        "Legea nr. 53/2003",
+        "prezentul cod",
+    ]

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -41,8 +41,7 @@ class TestExtractor:
     def test_combined_article_and_paragraph(self):
         """The flagship acceptance criterion: art. 17 alin. (1) is extracted."""
         candidates = extract_references(SOURCE_UNIT)
-        assert len(candidates) == 1
-        cand = candidates[0]
+        cand = next(c for c in candidates if c["raw_reference"] == "art. 17 alin. (1)")
         assert cand["target_article"]   == "17"
         assert cand["target_paragraph"] == "1"
         assert cand["source_unit_id"]   == "ro.codul_muncii.art_41"
@@ -50,7 +49,11 @@ class TestExtractor:
     def test_local_law_hint_detected(self):
         """'prezenta lege' marks the candidate as same_act."""
         candidates = extract_references(SOURCE_UNIT)
-        assert candidates[0]["target_law_hint"] == "same_act"
+        assert any(
+            candidate["raw_reference"] == "prezenta lege"
+            and candidate["target_law_hint"] == "same_act"
+            for candidate in candidates
+        )
 
     def test_standalone_article_no_paragraph(self):
         unit = {
@@ -78,8 +81,16 @@ class TestExtractor:
             "raw_text": "conform art. 1249 din Codul Civil.",
         }
         candidates = extract_references(unit)
-        assert len(candidates) == 1
-        assert candidates[0]["target_law_hint"] == "external"
+        assert any(
+            candidate["raw_reference"] == "art. 1249"
+            and candidate["target_law_hint"] == "ro.codul_civil"
+            for candidate in candidates
+        )
+        assert any(
+            candidate["raw_reference"] == "Codul Civil"
+            and candidate["target_law_hint"] == "ro.codul_civil"
+            for candidate in candidates
+        )
 
     def test_ref_art_re_standalone(self):
         matches = REF_ART_RE.findall("Vezi art. 100 şi art. 200^1.")


### PR DESCRIPTION
This pull request introduces comprehensive improvements to how legal reference candidates are extracted, represented, exported, and tested across the codebase. The main focus is on enabling extraction and export of unresolved reference candidates (even when not all are resolved), enhancing the data model to capture more granular reference details, updating the export logic and sorting, and expanding the test suite to cover a wide range of reference extraction scenarios.

Key changes include:

### Reference Extraction and Export Logic

* Reference candidates are now extracted from legal units and exported even when unresolved, with new statuses (`candidate_only`, `unresolved_ambiguous`, `unresolved_needs_context`) and support for additional fields such as `target_thesis`. The export logic and sorting have been updated to reflect these changes, and new warnings are added when unresolved references are present. [[1]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R22) [[2]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661L197-R203) [[3]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R553-R572) [[4]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661L571-R598) [[5]](diffhunk://#diff-5fe14c39a3e4e2d361dd5ca1fe49b6d5421861c49d624343c04738275de85502R44-R46) [[6]](diffhunk://#diff-5fe14c39a3e4e2d361dd5ca1fe49b6d5421861c49d624343c04738275de85502R215-R217)

### Data Model Enhancements

* The `ReferenceCandidate` contract and related status enums are extended to support new resolution statuses and the `target_thesis` field, improving the expressiveness and accuracy of extracted references. [[1]](diffhunk://#diff-5fe14c39a3e4e2d361dd5ca1fe49b6d5421861c49d624343c04738275de85502R44-R46) [[2]](diffhunk://#diff-5fe14c39a3e4e2d361dd5ca1fe49b6d5421861c49d624343c04738275de85502R215-R217)

### Test Suite Expansion

* Extensive new tests have been added for the reference extraction logic, covering detection of articles, paragraphs, letters, points, theses, compound references, numbered laws, named codes, same-act references, deduplication, and edge cases. Existing tests are updated to align with the new extraction and export behavior. [[1]](diffhunk://#diff-55453433ba8e68de8c7dc7936dcff8af0796e7c2e445febcadf48de6e7b70fa3R1-R151) [[2]](diffhunk://#diff-52b8f2e623489bd3570119271e0622f9b5adc44eb98461662905000fa7972ce1L44-R56) [[3]](diffhunk://#diff-52b8f2e623489bd3570119271e0622f9b5adc44eb98461662905000fa7972ce1L81-R93) [[4]](diffhunk://#diff-546bf4b8e44cee6e89b68b19dab46c9d76fe4a8efc85642ef1a0af0b4d4282e9R52) [[5]](diffhunk://#diff-546bf4b8e44cee6e89b68b19dab46c9d76fe4a8efc85642ef1a0af0b4d4282e9R153-R182) [[6]](diffhunk://#diff-61a02100b2d7b380c7f13c7fcb17c1759a059303cafe93a67b3f9b95de47f1cdL209-R209) [[7]](diffhunk://#diff-61a02100b2d7b380c7f13c7fcb17c1759a059303cafe93a67b3f9b95de47f1cdL221-R226)

### Fixture and Manifest Updates

* Test fixtures and corpus manifests are updated to include extracted reference candidates and expected warning messages, ensuring consistency with the new extraction and export logic. [[1]](diffhunk://#diff-f00e6a4c10f0c0d297e68b00946b3c52f4a8db2e744b4b76df37fa67ff53cdb7L8-R8) [[2]](diffhunk://#diff-f00e6a4c10f0c0d297e68b00946b3c52f4a8db2e744b4b76df37fa67ff53cdb7L27-R35) [[3]](diffhunk://#diff-71192c884b09af459cefbba4ab13e6b2f7c59457e03428f66b3deb844e2450fcL9-R9) [[4]](diffhunk://#diff-71192c884b09af459cefbba4ab13e6b2f7c59457e03428f66b3deb844e2450fcL25-R26) [[5]](diffhunk://#diff-007a71e9eaa3e4ce7522683317640f514447ff55e9bf34d4f2439d884b2334eeR1-R16) [[6]](diffhunk://#diff-f5271fa2344718b3e93b8a75156339bfe55e27ac9bcb472293fc782b75ab3be7L1-R70)

---

**Most important changes:**

#### Reference extraction and export

* Reference candidates are now extracted from units and exported even when unresolved, with new statuses and fields (e.g., `target_thesis`), and the export sorting has been updated for determinism. Warnings are added when unresolved references are present. [[1]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R22) [[2]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661L197-R203) [[3]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R553-R572) [[4]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661L571-R598) [[5]](diffhunk://#diff-5fe14c39a3e4e2d361dd5ca1fe49b6d5421861c49d624343c04738275de85502R44-R46) [[6]](diffhunk://#diff-5fe14c39a3e4e2d361dd5ca1fe49b6d5421861c49d624343c04738275de85502R215-R217)

#### Data model changes

* The `ReferenceCandidate` contract and status enums are extended to support `candidate_only`, `unresolved_ambiguous`, `unresolved_needs_context`, and the `target_thesis` field. [[1]](diffhunk://#diff-5fe14c39a3e4e2d361dd5ca1fe49b6d5421861c49d624343c04738275de85502R44-R46) [[2]](diffhunk://#diff-5fe14c39a3e4e2d361dd5ca1fe49b6d5421861c49d624343c04738275de85502R215-R217)

#### Test coverage

* New and updated tests cover a wide range of reference extraction scenarios, including articles, paragraphs, letters, points, theses, compound and same-act references, deduplication, and validation of warning messages and export sorting. [[1]](diffhunk://#diff-55453433ba8e68de8c7dc7936dcff8af0796e7c2e445febcadf48de6e7b70fa3R1-R151) [[2]](diffhunk://#diff-52b8f2e623489bd3570119271e0622f9b5adc44eb98461662905000fa7972ce1L44-R56) [[3]](diffhunk://#diff-52b8f2e623489bd3570119271e0622f9b5adc44eb98461662905000fa7972ce1L81-R93) [[4]](diffhunk://#diff-546bf4b8e44cee6e89b68b19dab46c9d76fe4a8efc85642ef1a0af0b4d4282e9R52) [[5]](diffhunk://#diff-546bf4b8e44cee6e89b68b19dab46c9d76fe4a8efc85642ef1a0af0b4d4282e9R153-R182) [[6]](diffhunk://#diff-61a02100b2d7b380c7f13c7fcb17c1759a059303cafe93a67b3f9b95de47f1cdL209-R209) [[7]](diffhunk://#diff-61a02100b2d7b380c7f13c7fcb17c1759a059303cafe93a67b3f9b95de47f1cdL221-R226)

#### Fixture and manifest updates

* Test fixtures and manifests are updated to include extracted reference candidates, updated candidate counts, hashes, and new warning messages, ensuring test and export consistency. [[1]](diffhunk://#diff-f00e6a4c10f0c0d297e68b00946b3c52f4a8db2e744b4b76df37fa67ff53cdb7L8-R8) [[2]](diffhunk://#diff-f00e6a4c10f0c0d297e68b00946b3c52f4a8db2e744b4b76df37fa67ff53cdb7L27-R35) [[3]](diffhunk://#diff-71192c884b09af459cefbba4ab13e6b2f7c59457e03428f66b3deb844e2450fcL9-R9) [[4]](diffhunk://#diff-71192c884b09af459cefbba4ab13e6b2f7c59457e03428f66b3deb844e2450fcL25-R26) [[5]](diffhunk://#diff-007a71e9eaa3e4ce7522683317640f514447ff55e9bf34d4f2439d884b2334eeR1-R16) [[6]](diffhunk://#diff-f5271fa2344718b3e93b8a75156339bfe55e27ac9bcb472293fc782b75ab3be7L1-R70)

#### Sorting and determinism

* Exported reference candidates are now deterministically sorted by a tuple of identifying fields, ensuring stable output for tests and downstream consumers. [[1]](diffhunk://#diff-68ceee3bd0bb77d1aba15a1c5dd140fdb8a2d71cba5452a420d6537401116661R553-R572) [[2]](diffhunk://#diff-546bf4b8e44cee6e89b68b19dab46c9d76fe4a8efc85642ef1a0af0b4d4282e9R153-R182)