### PR TITLE
docs: add updated Handoff 03 transition materials

### DIFF
--- a/docs/parser-architecture.md
+++ b/docs/parser-architecture.md
@@ -1,0 +1,570 @@
+# Arhitectura parserului LexAI
+
+## 1. Overview
+
+Parserul LexAI transformă surse locale sau HTML legal în artefacte JSON canonice, verificabile și pregătite pentru import. LexAI nu este un legal chatbot: parserul nu interpretează juridic legea, nu formulează concluzii și nu folosește un LLM ca sursă de adevăr juridic.
+
+Fluxul curent este:
+
+```text
+raw/local input
+  -> HTML cleaner
+  -> structural parser / legacy units
+  -> LegalUnit canonic
+  -> LegalEdge contains
+  -> ReferenceCandidate
+  -> LegalChunk
+  -> embeddings_input.jsonl
+  -> corpus_manifest.json
+  -> validation_report.json
+```
+
+`LegalUnit.raw_text` este singura sursă citabilă. `LegalChunk.retrieval_text` este derivat pentru retrieval și nu trebuie citat ca text de lege. `ReferenceCandidate` nu este `LegalEdge`; referințele ambigue sau nerezolvate rămân candidate/unresolved.
+
+Principiul de bază este: unknown stays unknown. Parserul nu inventează `source_url`, `source_id`, `status`, date, concepte juridice, referințe rezolvate sau concluzii juridice.
+
+## 2. Ownership boundary
+
+Parser / Handoff 06 deține:
+
+- producerea bundle-urilor canonice file-based;
+- extracția LegalUnit;
+- strategia de ID-uri deterministe;
+- ierarhia act -> articol -> alineat -> literă;
+- HTML cleaner-ul;
+- extracția de ReferenceCandidate;
+- generarea LegalChunk și embeddings input;
+- manifestul și validation report-ul.
+
+Backend Platform / Handoff 04 deține:
+
+- importul bundle-ului în PostgreSQL;
+- schema DB, migrations și eventual Alembic;
+- `legal_units` APIs;
+- Explore APIs și graph APIs;
+- search și raw retrieval;
+- pgvector și importul vectorilor.
+
+AI/RAG / Handoff 03 deține:
+
+- consumul RetrievalCandidate;
+- graph expansion peste unități și edges;
+- LegalRanker;
+- EvidencePackCompiler;
+- GenerationAdapter;
+- CitationVerifier.
+
+Handoff 03 poate consuma LegalUnits reale, dar nu trebuie să trateze LLM-ul ca sursă de drept. Evidence și citările trebuie să se bazeze pe `LegalUnit.raw_text`.
+
+## 3. File/folder map
+
+`ingestion/contracts/__init__.py`
+: Definește contractele ingestion-side: `ParserActMetadata`, `ParsedLegalUnit`, `ParsedLegalEdge`, `LegalChunk`, `ReferenceCandidate`, `CorpusManifest`, `ValidationReport`, `EmbeddingInputRecord`.
+
+`ingestion/legal_ids.py`
+: Conține strategia deterministă de ID-uri pentru law/art/alin/lit/pct și canonical IDs. Normalizează forme precum `41^1` și `41¹`.
+
+`ingestion/legal_domains.py`
+: Registry conservator pentru domenii juridice cunoscute, de exemplu `ro.codul_muncii -> munca`.
+
+`ingestion/normalizer.py`
+: Normalizează text derivat pentru matching/retrieval. Nu înlocuiește `raw_text`.
+
+`ingestion/html_cleaner.py`
+: Curăță HTML local: elimină script/style/nav/header/footer/search/menu/cookie-like noise și păstrează markerii juridici.
+
+`ingestion/reference_extractor.py`
+: Extractor rule-based pentru referințe legislative românești. Produce `ReferenceCandidate`, nu `LegalEdge`.
+
+`ingestion/chunks.py`
+: Generează `LegalChunk`, `retrieval_context`, `retrieval_text` și `EmbeddingInputRecord`.
+
+`ingestion/exporters.py`
+: Convertește legacy units în LegalUnits canonice, construiește contains edges, reference candidates, chunks, manifest și validation report.
+
+`ingestion/validators.py`
+: Conține validări legacy. Validarea canonică robustă este construită în `ingestion/exporters.py`.
+
+`ingestion/bundle_loader.py`
+: Loader file-based pentru bundle canonic. Încarcă artefactele, verifică fișierele obligatorii și construiește indexuri unit/chunk/adjacency.
+
+`ingestion/local_retriever.py`
+: Retriever local de dezvoltare/test. Scorarea folosește `LegalChunk.retrieval_text`, dar evidence text vine din `LegalUnit.raw_text`.
+
+`scripts/export_canonical_bundle.py`
+: CLI local pentru export din legacy units în bundle canonic. Scrie artefactele P8 și iese non-zero dacă `import_blocking_passed=false`.
+
+`tests/fixtures/corpus/*`
+: Fixture-uri canonice Codul Muncii și mini Codul Muncii. Sunt folosite pentru integrarea parserului cu Handoff 03 și pentru readiness checks.
+
+`docs/ingestion-canonical-bundle.md`
+: Document scurt despre bundle-ul canonic și consumul lui de Handoff 03/04.
+
+## 4. Canonical data flow
+
+```text
+Raw HTML / local fixture
+  -> clean_html_to_lines
+  -> structural parser / legacy units
+  -> ParsedLegalUnit
+  -> LegalUnit dict
+  -> contains LegalEdges
+  -> ReferenceCandidate extraction
+  -> LegalChunk generation
+  -> EmbeddingInputRecord JSONL
+  -> CorpusManifest
+  -> ValidationReport
+```
+
+Transformări:
+
+- HTML cleaner-ul extrage linii curate, fără navigație evidentă.
+- Parserul structural sau legacy produce unități inițiale.
+- Exporterul canonic convertește unitățile în `ParsedLegalUnit`.
+- `ParsedLegalUnit.to_legal_unit_dict()` produce forma compatibilă cu backend `LegalUnit`.
+- Parent-child produce `LegalEdge` de tip `contains`.
+- `reference_extractor` citește lexical `raw_text` și produce candidați nerezolvați.
+- `chunks.py` produce retrieval context determinist și `retrieval_text`.
+- Manifestul conține metadate, counts și hash-uri.
+- Validation report-ul decide dacă bundle-ul este import-ready.
+
+## 5. LegalUnit
+
+`LegalUnit` este unitatea juridică citabilă. Este puntea dintre parser, raw retrieval, evidence pack și citări. Un `EvidenceUnit` extinde `LegalUnit`, deci parserul trebuie să producă LegalUnits complete, nu dict-uri parțiale.
+
+Câmpuri importante:
+
+- `id`: ID stabil și citabil.
+- `canonical_id`: ID intern compact, fără prefixul `ro.`.
+- `law_id`: actul normativ.
+- `law_title`: titlul actului.
+- `hierarchy_path`: traseu complet pentru UI/RAG.
+- `article_number`, `paragraph_number`, `letter_number`: localizare juridică.
+- `raw_text`: textul juridic citabil.
+- `normalized_text`: text derivat pentru matching, nu sursă citabilă.
+- `legal_domain`: domeniu din registry sau `unknown`.
+- `legal_concepts`: listă conservatoare, default `[]`.
+- `parent_id`: unitatea părinte.
+- `parser_warnings`: lipsuri sau decizii explicite de tip unknown/null.
+
+Exemplu scurt:
+
+```json
+{
+  "id": "ro.codul_muncii.art_41.alin_4",
+  "canonical_id": "codul_muncii:art_41:alin_4",
+  "law_id": "ro.codul_muncii",
+  "law_title": "Codul muncii",
+  "status": "unknown",
+  "hierarchy_path": [
+    "Legislatia Romaniei",
+    "Munca",
+    "Codul muncii",
+    "Art. 41",
+    "Alin. (4)"
+  ],
+  "article_number": "41",
+  "paragraph_number": "4",
+  "raw_text": "(4) Orice modificare a unuia dintre elementele prevazute la alin. (3), in timpul executarii contractului individual de munca, impune incheierea unui act aditional la contract...",
+  "normalized_text": "(4) Orice modificare a unuia dintre elementele prevazute la alin. (3)...",
+  "legal_domain": "munca",
+  "legal_concepts": [],
+  "parent_id": "ro.codul_muncii.art_41",
+  "source_url": null,
+  "parser_warnings": [
+    "source_url_unknown",
+    "status_unknown"
+  ]
+}
+```
+
+`raw_text` nu trebuie alterat semantic. Curățarea și normalizarea derivată trebuie să păstreze textul juridic citabil intact.
+
+## 6. ID strategy
+
+ID-urile sunt deterministe. `LegalUnit.id` nu folosește UUID.
+
+Exemple:
+
+- `ro.codul_muncii`
+- `ro.codul_muncii.art_41`
+- `ro.codul_muncii.art_41.alin_4`
+- `ro.codul_muncii.art_17.alin_3.lit_k`
+- `ro.codul_muncii.art_41_1`
+
+Exemplu `canonical_id`:
+
+- `codul_muncii:art_41:alin_4`
+
+Normalizarea tratează forme precum:
+
+- `Art. 41^1 -> art_41_1`
+- `Art. 41¹ -> art_41_1`
+
+Această strategie permite import DB, graph traversal, retrieval și evidence/citation pe aceeași cheie juridică stabilă.
+
+## 7. HTML cleaner
+
+`ingestion/html_cleaner.py` elimină conservator:
+
+- `script`, `style`, `noscript`, `svg`;
+- `nav`;
+- `header`/`footer` când sunt clar navigaționale;
+- breadcrumbs, search boxes, buttons, menus și cookie banners detectabile.
+
+Păstrează:
+
+- titlul actului;
+- titluri/capitole/secțiuni;
+- `Art.`, `Articolul`;
+- alineate `(1)`;
+- litere `k)`;
+- puncte;
+- diacritice.
+
+Cleaner-ul produce warnings precum `legal_container_not_found`, `used_body_fallback`, `removed_navigation_blocks` sau `possible_navigation_residue`. Nu interpretează legea și nu rescrie semantic textul legal.
+
+## 8. Reference extraction
+
+`ingestion/reference_extractor.py` detectează lexical:
+
+- `art. 41`, `art 41`, `articolul 41`;
+- `Art. 41^1`, `Art. 41¹`;
+- `alin. (3)`, `alineatul (3)`;
+- `lit. k)`, `litera k)`;
+- `pct. 2`, `punctul 2`;
+- `teza a II-a`;
+- `Legea nr. 53/2003`;
+- `O.U.G. nr. 195/2002`, `OUG nr. 195/2002`;
+- `O.G. nr. 2/2001`, `OG nr. 2/2001`;
+- `H.G. nr. 1/2016`, `HG nr. 1/2016`;
+- coduri numite, de exemplu `Codul muncii`, `Codul civil`;
+- referințe locale precum `prezentul cod`.
+
+Produce `ReferenceCandidate`. Nu produce `LegalEdge` de tip `references`. Rezolvarea completă este deferred.
+
+Exemple:
+
+```json
+{
+  "source_unit_id": "ro.codul_muncii.art_41.alin_4",
+  "raw_reference": "alin. (3)",
+  "reference_type": "paragraph",
+  "target_law_hint": "same_act",
+  "target_article": null,
+  "target_paragraph": "3",
+  "resolved_target_id": null,
+  "resolution_status": "unresolved_needs_context"
+}
+```
+
+```json
+{
+  "source_unit_id": "ro.demo.art_1",
+  "raw_reference": "art. 17 alin. (3) lit. k)",
+  "reference_type": "compound",
+  "target_law_hint": "same_act",
+  "target_article": "17",
+  "target_paragraph": "3",
+  "target_letter": "k",
+  "resolved_target_id": null,
+  "resolution_status": "candidate_only"
+}
+```
+
+```json
+{
+  "source_unit_id": "ro.demo.art_1",
+  "raw_reference": "Legea nr. 53/2003",
+  "reference_type": "law",
+  "target_law_hint": "ro.lege_53_2003",
+  "resolved_target_id": null,
+  "resolution_status": "candidate_only"
+}
+```
+
+```json
+{
+  "source_unit_id": "ro.codul_muncii.art_41",
+  "raw_reference": "prezentul cod",
+  "reference_type": "same_act",
+  "target_law_hint": "same_act",
+  "resolved_target_id": null,
+  "resolution_status": "unresolved_needs_context"
+}
+```
+
+## 9. LegalEdges
+
+În stadiul curent se produc doar `contains` edges sigure. Acestea conectează:
+
+```text
+act -> articol -> alineat -> literă
+```
+
+Exemplu:
+
+```json
+{
+  "id": "edge.contains.ro.codul_muncii.art_41.ro.codul_muncii.art_41.alin_4",
+  "source_id": "ro.codul_muncii.art_41",
+  "target_id": "ro.codul_muncii.art_41.alin_4",
+  "type": "contains",
+  "weight": 1.0,
+  "confidence": 1.0
+}
+```
+
+`references` edges nu se creează din candidați ambigui. Handoff 03 și Handoff 04 pot folosi `contains` pentru graph expansion, children/parents și UI Explore.
+
+## 10. LegalChunk + contextual retrieval
+
+`LegalChunk` este derivat din `LegalUnit`. Nu este sursă juridică citabilă.
+
+Reguli:
+
+- `text` și `raw_text` vin din `LegalUnit.raw_text`;
+- `retrieval_context` este determinist;
+- contextul se bazează pe hierarchy, law title, legal domain, metadata părinte și reference candidates nerezolvate;
+- `retrieval_text = retrieval_context + "\n\n" + raw_text`;
+- `embeddings_input.jsonl` folosește `retrieval_text`;
+- metadata marchează contextul ca non-citable.
+
+Mecanismul este inspirat de contextual retrieval, dar implementat determinist pentru LexAI, fără LLM.
+
+Exemplu:
+
+```json
+{
+  "chunk_id": "chunk.ro.codul_muncii.art_41.alin_4.0",
+  "legal_unit_id": "ro.codul_muncii.art_41.alin_4",
+  "text": "(4) Orice modificare a unuia dintre elementele prevazute la alin. (3)...",
+  "retrieval_context": "Unitate din Codul muncii, domeniul munca.\nLocalizare: Art. 41, Alin. (4).\nContext ierarhic: Legislatia Romaniei > Munca > Codul muncii > Art. 41 > Alin. (4).\nUnitate parinte: Art. 41.\nReferinte extrase nerezolvate: alin. (3).",
+  "retrieval_text": "Unitate din Codul muncii, domeniul munca...\n\n(4) Orice modificare...",
+  "context_generation_method": "deterministic_v1",
+  "context_confidence": 0.75,
+  "metadata": {
+    "retrieval_context_is_citable": false,
+    "text_source": "LegalUnit.raw_text"
+  }
+}
+```
+
+## 11. Canonical bundle output
+
+`legal_units.json`
+: Conține LegalUnits canonice. Consumatori: Handoff 03 evidence/retrieval, Handoff 04 import DB. Este sursa citabilă prin `raw_text`.
+
+`legal_edges.json`
+: Conține `contains` edges. Consumatori: Handoff 03 graph expansion, Handoff 04 graph APIs. Nu conține reference edges fragile.
+
+`reference_candidates.json`
+: Conține referințe detectate lexical și nerezolvate sau candidate-only. Consumatori: Handoff 04/P7+ pentru rezolvare ulterioară. Nu este sursă citabilă și nu este graph edge.
+
+`legal_chunks.json`
+: Conține chunks pentru retrieval/vector. Consumatori: Handoff 03 retrieval adapters, Handoff 04 staging pentru chunks. `retrieval_text` nu este citabil.
+
+`embeddings_input.jsonl`
+: JSONL determinist pentru job viitor de embeddings. Consumatori: Handoff 04/embedding job ulterior. Nu conține vectori reali.
+
+`corpus_manifest.json`
+: Conține parser version, generated_at, counts, input files, hashes, warnings. Consumatori: import/readiness checks.
+
+`validation_report.json`
+: Conține metrici, warnings, blocking errors, `import_blocking_passed`, `demo_path_passed`. Decide import readiness.
+
+## 12. Storage boundary
+
+Parser storage:
+
+- bundle-uri canonice file-based;
+- output local în `ingestion/output/<bundle_name>/`;
+- fixture-uri mici versionate în `tests/fixtures/corpus/`;
+- manifest, hash-uri și validation report.
+
+Nu este responsabilitatea parserului:
+
+- PostgreSQL;
+- pgvector;
+- Alembic;
+- runtime API persistence;
+- import DB real.
+
+## 13. Validation gates
+
+Validation report-ul include:
+
+- `corpus_quality`: scor ponderat, nu cosmetizat;
+- `import_blocking_passed`: true/false pentru import readiness;
+- `demo_path_passed`: true/false/null pentru demo Codul Muncii;
+- `blocking_errors`;
+- `warnings`;
+- `quality_metrics`.
+
+Metrici importante:
+
+- `unit_completeness`;
+- `hierarchy_integrity`;
+- `edge_endpoint_integrity`;
+- `duplicate_free_score`;
+- `source_url_coverage`;
+- `text_cleanliness`;
+- `reference_resolution_rate`;
+- `chunk_coverage_rate`;
+- `embedding_input_hash_integrity`.
+
+Exemple de blocking:
+
+- duplicate LegalUnit IDs;
+- invalid edge endpoint;
+- empty `raw_text` pentru unități citabile;
+- `resolved_target_id` non-null dar inexistent;
+- embedding hash greșit;
+- chunk cu `legal_unit_id` invalid;
+- `retrieval_text` gol;
+- context cu interpretări juridice hardcodate.
+
+`source_url=null` poate fi warning non-blocking pentru fixture-uri locale, dacă manifestul și validation report-ul explică sursa demo locală.
+
+## 14. Local bundle loader and local retriever
+
+`ingestion.bundle_loader`:
+
+- încarcă bundle-ul canonic file-based;
+- verifică required files;
+- suportă fișiere standard și fixture-uri prefixate;
+- construiește indexuri unit/chunk;
+- construiește adjacency pentru `contains`.
+
+`ingestion.local_retriever`:
+
+- folosește `LegalChunk.retrieval_text` pentru scoring lexical determinist;
+- aplică token overlap, domain boost și exact citation boost simplu;
+- returnează candidate compatibil cu `RetrievalCandidate`;
+- păstrează evidence text din `LegalUnit.raw_text`;
+- este dev/test adapter, nu production DB retriever.
+
+## 15. Integration with Handoff 03
+
+Handoff 03 primește LegalUnits reale prin fixture-uri:
+
+- fake raw retriever încarcă `tests/fixtures/corpus/codul_muncii_legal_units.json`;
+- `GraphExpansionPolicy` folosește `codul_muncii_legal_edges.json`;
+- `LegalRanker` rankează LegalUnits reale;
+- `EvidencePackCompiler` produce `EvidenceUnit` flat cu `raw_text`;
+- generator/verifier sunt încă mock/unverified.
+
+Demo query:
+
+```text
+Poate angajatorul să-mi scadă salariul fără act adițional?
+```
+
+Unit IDs relevante:
+
+- `ro.codul_muncii.art_41`
+- `ro.codul_muncii.art_41.alin_3`
+- `ro.codul_muncii.art_41.alin_4`
+- `ro.codul_muncii.art_17.alin_3.lit_k`
+
+Testul principal este `tests/test_handoff03_fixture_integration.py`.
+
+## 16. Integration with Handoff 04
+
+Platform owner trebuie să implementeze runtime/import real peste bundle-ul canonic:
+
+- `POST /api/ingest/json`;
+- tabel `legal_units`;
+- tabel `legal_edges`;
+- staging pentru chunks/embeddings;
+- `GET /api/legal-units/{id}`;
+- `GET /api/legal-units/{id}/neighbors`;
+- `POST /api/retrieve/raw`;
+- Explore APIs;
+- pgvector import ulterior din `embeddings_input.jsonl`.
+
+În repo, aceste rute/servicii runtime nu sunt complet implementate încă. Unele fișiere există ca schelet gol, de exemplu `apps/api/app/routes/retrieve_raw.py`, `apps/api/app/routes/explore.py`, `apps/api/app/services/import_service.py`, `apps/api/app/services/raw_retriever.py`, `apps/api/app/services/graph_store.py`.
+
+## 17. How to run
+
+Pipeline direct din URL `legislatie.just.ro` catre bundle canonic:
+
+```powershell
+py -3.13 scripts/run_parser_pipeline.py `
+  --url "https://legislatie.just.ro/Public/DetaliiDocument/123456" `
+  --out-dir ingestion/output/legislatie_codul_muncii `
+  --law-id ro.codul_muncii `
+  --law-title "Codul muncii" `
+  --write-debug
+```
+
+Scriptul valideaza domeniul URL-ului, descarca HTML-ul, ruleaza cleaner-ul HTML,
+trimite liniile in `StructuralParser`, apoi exporta bundle-ul canonic complet:
+`legal_units.json`, `legal_edges.json`, `reference_candidates.json`,
+`legal_chunks.json`, `embeddings_input.jsonl`, `corpus_manifest.json` si
+`validation_report.json`. Parametrii `--law-id` si `--law-title` sunt recomandati
+pentru ID-uri stabile; daca lipsesc, scriptul incearca inferenta conservatoare din
+titlul HTML sau din document id-ul URL-ului.
+
+Export bundle canonic din legacy units:
+
+```powershell
+py -3.13 scripts/export_canonical_bundle.py `
+  --input tests/fixtures/corpus/codul_muncii_legacy_units.json `
+  --out-dir ingestion/output/codul_muncii_canonical `
+  --law-id ro.codul_muncii `
+  --law-title "Codul muncii" `
+  --generated-at 2026-04-25T00:00:00+00:00
+```
+
+Workflow-ul curent este local/test-first. Nu există încă un CLI complet pentru crawling oficial end-to-end în formă canonică production-ready.
+
+Clarificare P11: acum exista un CLI pentru un singur URL `legislatie.just.ro`;
+inca nu exista un crawler production-ready pentru corpusuri oficiale mari.
+
+Teste relevante:
+
+```powershell
+py -3.13 -m pytest tests/test_bundle_loader.py
+py -3.13 -m pytest tests/test_run_parser_pipeline.py
+py -3.13 -m pytest tests/test_local_retriever.py
+py -3.13 -m pytest tests/test_parser_integration_readiness.py
+py -3.13 -m pytest tests/test_handoff03_fixture_integration.py
+py -3.13 -m pytest tests/test_legal_chunks.py
+py -3.13 -m pytest tests/test_canonical_bundle_export.py
+py -3.13 -m pytest tests/test_validation.py
+py -3.13 -m pytest
+```
+
+## 18. Current status
+
+- Ultima verificare dupa pipeline URL: `244 passed, 1 warning`.
+- Codul Muncii este integration-ready file-based.
+- Ultima verificare locală: `240 passed, 1 existing warning`.
+- Runtime API/DB integration nu este completă.
+- Nu există embeddings reale.
+- Nu există reference resolution complet.
+- Nu există DB import real.
+- `validation_report.import_blocking_passed=true` pentru fixture-ul Codul Muncii.
+- `validation_report.demo_path_passed=true` pentru fixture-ul Codul Muncii.
+
+## 19. Known limitations
+
+- Corpus demo limitat.
+- Nu există ingestie completă din sursă oficială pentru corpus mare.
+- Referințele rămân unresolved/candidate-only.
+- Nu există runtime DB import.
+- Nu există pgvector import.
+- Nu există embeddings reale.
+- Nu există GenerationAdapter final.
+- Nu există CitationVerifier final.
+- Artefactele legacy root-level `legal_units.json` și `legal_edges.json` pot induce confuzie față de bundle-ul canonic.
+- `apps/api/app/schemas/legal.py` păstrează o schemă legacy diferită de `apps/api/app/schemas/query.py::LegalUnit`.
+
+## 20. Next recommended steps
+
+1. Handoff 04: import canonic din bundle și implementare `/api/retrieve/raw`.
+2. Handoff 04: endpoint-uri pentru `legal_units`, neighbors și Explore APIs peste DB.
+3. Handoff 03: GenerationAdapter și CitationVerifier peste EvidencePack real.
+4. Parser continuation: adăugare 1-2 acte demo prin același workflow canonic.
+5. Cleanup: clarificarea sau mutarea artefactelor legacy root-level.

--- a/scripts/run_parser_pipeline.py
+++ b/scripts/run_parser_pipeline.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from ingestion.exporters import export_canonical_bundle
+from ingestion.html_cleaner import clean_html_to_lines
+from ingestion.legal_ids import make_law_id
+from ingestion.parser.html_parser import extract_metadata
+from ingestion.parser.html_scraper import scrape_html_source
+from ingestion.structural_parser import StructuralParser
+
+
+DEFAULT_OUTPUT_DIR = Path("ingestion/output/legislatie_just_ro_bundle")
+LEGISLATIE_HOST = "legislatie.just.ro"
+
+
+@dataclass(frozen=True)
+class ParserPipelineResult:
+    artifact_paths: dict[str, Path]
+    law_id: str
+    law_title: str
+    legacy_units_count: int
+    cleaner_warnings: list[str]
+    import_blocking_passed: bool
+
+
+def run_pipeline(
+    *,
+    url: str,
+    out_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    law_id: str | None = None,
+    law_title: str | None = None,
+    source_id: str | None = None,
+    status: str = "unknown",
+    parser_version: str = "0.1.0",
+    generated_at: str | None = None,
+    write_debug: bool = False,
+) -> ParserPipelineResult:
+    """
+    Fetch a legislatie.just.ro page and export a canonical parser bundle.
+
+    This is a file-based integration pipeline: it does not write to DB, does
+    not generate vectors, and does not treat retrieval text as citable law.
+    """
+    _validate_legislatie_url(url)
+
+    html = scrape_html_source(url)
+    if not html:
+        raise RuntimeError(f"Could not fetch HTML from {url}")
+
+    page_metadata = extract_metadata(html)
+    clean_result = clean_html_to_lines(html)
+    if not clean_result.lines:
+        raise RuntimeError("HTML cleaner produced no legal text lines")
+
+    resolved_law_title, title_warning = _resolve_law_title(
+        explicit_title=law_title,
+        page_metadata=page_metadata,
+        cleaned_lines=clean_result.lines,
+    )
+    resolved_law_id, id_warning = _resolve_law_id(
+        explicit_law_id=law_id,
+        law_title=resolved_law_title,
+        url=url,
+    )
+
+    structural_parser = StructuralParser(corpus_id=resolved_law_id)
+    legacy_units, _legacy_edges = structural_parser.parse(clean_result.lines)
+    if not legacy_units:
+        raise RuntimeError("Structural parser produced no legal units")
+
+    output_dir = Path(out_dir)
+    generated_at_value = generated_at or datetime.now(timezone.utc).isoformat()
+    additional_warnings = [f"html_cleaner:{warning}" for warning in clean_result.warnings]
+    if title_warning:
+        additional_warnings.append(title_warning)
+    if id_warning:
+        additional_warnings.append(id_warning)
+
+    metadata = {
+        "law_id": resolved_law_id,
+        "law_title": resolved_law_title,
+        "source_id": source_id,
+        "source_url": url,
+        "status": status,
+    }
+    source_descriptor = {
+        "law_id": resolved_law_id,
+        "law_title": resolved_law_title,
+        "source_type": "legislatie.just.ro_url",
+        "source_url": url,
+        "source_id": source_id,
+    }
+    artifact_paths = export_canonical_bundle(
+        legacy_units,
+        metadata,
+        output_dir,
+        parser_version=parser_version,
+        generated_at=generated_at_value,
+        input_files=[url],
+        source_descriptors=[source_descriptor],
+        additional_warnings=additional_warnings,
+    )
+
+    if write_debug:
+        _write_debug_files(
+            output_dir,
+            clean_lines=clean_result.lines,
+            cleaner_report={
+                "warnings": clean_result.warnings,
+                "removed_blocks_count": clean_result.removed_blocks_count,
+                "selected_container": clean_result.selected_container,
+                "text_hash": clean_result.text_hash,
+            },
+            legacy_units=legacy_units,
+        )
+
+    validation_report = _load_json(artifact_paths["validation_report"])
+    return ParserPipelineResult(
+        artifact_paths=artifact_paths,
+        law_id=resolved_law_id,
+        law_title=resolved_law_title,
+        legacy_units_count=len(legacy_units),
+        cleaner_warnings=clean_result.warnings,
+        import_blocking_passed=bool(validation_report.get("import_blocking_passed")),
+    )
+
+
+def _validate_legislatie_url(url: str) -> None:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("URL must use http or https")
+    if host != LEGISLATIE_HOST and not host.endswith(f".{LEGISLATIE_HOST}"):
+        raise ValueError("URL must point to legislatie.just.ro")
+
+
+def _resolve_law_title(
+    *,
+    explicit_title: str | None,
+    page_metadata: dict,
+    cleaned_lines: list[str] | None = None,
+) -> tuple[str, str | None]:
+    if explicit_title and explicit_title.strip():
+        return explicit_title.strip(), None
+
+    title = _clean_html_title(str(page_metadata.get("title") or "").strip())
+    if title and not _is_generic_html_title(title):
+        return title, "law_title_inferred_from_html_title"
+
+    for line in (cleaned_lines or [])[:20]:
+        candidate = _clean_html_title(line.strip())
+        if _looks_like_act_title(candidate):
+            return candidate, "law_title_inferred_from_cleaned_text"
+
+    return "unknown", "law_title_unknown"
+
+
+def _resolve_law_id(
+    *,
+    explicit_law_id: str | None,
+    law_title: str,
+    url: str,
+) -> tuple[str, str | None]:
+    if explicit_law_id and explicit_law_id.strip():
+        return explicit_law_id.strip(), None
+
+    if law_title and law_title != "unknown":
+        return _make_law_id_from_title(law_title), "law_id_inferred_from_law_title"
+
+    document_id = _extract_legislatie_document_id(url)
+    if document_id:
+        return f"ro.legislatie_document_{document_id}", "law_id_inferred_from_url_document_id"
+
+    return "ro.legislatie_unknown", "law_id_unknown_fallback"
+
+
+def _extract_legislatie_document_id(url: str) -> str | None:
+    path = urlparse(url).path
+    match = re.search(r"/(?:detaliidocument|detaliidocumentafis)/(\d+)", path, re.IGNORECASE)
+    return match.group(1) if match else None
+
+
+def _make_law_id_from_title(title: str) -> str:
+    normalized = _ascii_lower(title)
+    match = re.search(
+        r"\b(lege|legea|oug|o\.u\.g\.|og|o\.g\.|hg|h\.g\.)\s+"
+        r"(?:nr\.?\s*)?(\d+)"
+        r"(?:\s*/\s*(\d{4})|\s+din\s+.*?\b((?:19|20)\d{2})\b)",
+        normalized,
+    )
+    if match:
+        prefix = _numbered_act_prefix(match.group(1))
+        year = match.group(3) or match.group(4)
+        return f"ro.{prefix}_{match.group(2)}_{year}"
+    return make_law_id(title)
+
+
+def _numbered_act_prefix(raw_prefix: str) -> str:
+    compact = raw_prefix.replace(".", "")
+    if compact in {"lege", "legea"}:
+        return "lege"
+    return compact
+
+
+def _clean_html_title(title: str) -> str:
+    title = re.sub(r"\s*[-|]\s*portal legislativ\s*$", "", title, flags=re.IGNORECASE)
+    title = re.sub(r"\s+", " ", title).strip()
+    return title
+
+
+def _is_generic_html_title(title: str) -> bool:
+    normalized = _ascii_lower(title)
+    return normalized in {
+        "portal legislativ",
+        "legislatie just",
+        "legislatie.just.ro",
+    }
+
+
+def _looks_like_act_title(text: str) -> bool:
+    if not text:
+        return False
+    normalized = _ascii_lower(text)
+    return bool(
+        re.match(
+            r"^(codul|constitutia|legea?\s+nr\.?|oug|o\.u\.g\.|og|o\.g\.|hg|h\.g\.|"
+            r"ordonanta|hotararea)",
+            normalized,
+        )
+    )
+
+
+def _ascii_lower(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text)
+    without_marks = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return without_marks.lower()
+
+
+def _write_debug_files(
+    output_dir: Path,
+    *,
+    clean_lines: list[str],
+    cleaner_report: dict,
+    legacy_units: list[dict],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "cleaned_lines.txt").write_text(
+        "\n".join(clean_lines) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "cleaner_report.json").write_text(
+        json.dumps(cleaner_report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "legacy_units.json").write_text(
+        json.dumps(legacy_units, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the canonical LexAI parser pipeline for a legislatie.just.ro URL",
+    )
+    parser.add_argument("url", nargs="?", help="Source URL from legislatie.just.ro")
+    parser.add_argument("--url", dest="url_option", default=None, help="Source URL from legislatie.just.ro")
+    parser.add_argument(
+        "--out-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Output directory for the canonical bundle",
+    )
+    parser.add_argument("--law-id", default=None, help="Optional canonical law id")
+    parser.add_argument("--law-title", default=None, help="Optional legal act title")
+    parser.add_argument("--source-id", default=None, help="Optional upstream source id")
+    parser.add_argument(
+        "--status",
+        default="unknown",
+        choices=["active", "historical", "repealed", "unknown"],
+    )
+    parser.add_argument("--parser-version", default="0.1.0")
+    parser.add_argument("--generated-at", default=None)
+    parser.add_argument(
+        "--write-debug",
+        action="store_true",
+        help="Write cleaned lines, cleaner report, and legacy units next to the bundle",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    url = args.url_option or args.url
+    if not url:
+        parser.error("a legislatie.just.ro URL is required")
+    try:
+        result = run_pipeline(
+            url=url,
+            out_dir=args.out_dir,
+            law_id=args.law_id,
+            law_title=args.law_title,
+            source_id=args.source_id,
+            status=args.status,
+            parser_version=args.parser_version,
+            generated_at=args.generated_at,
+            write_debug=args.write_debug,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(f"[parser-pipeline] {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"law_id: {result.law_id}")
+    print(f"law_title: {result.law_title}")
+    print(f"legacy_units_count: {result.legacy_units_count}")
+    if result.cleaner_warnings:
+        print(f"cleaner_warnings: {', '.join(result.cleaner_warnings)}")
+    for artifact, path in result.artifact_paths.items():
+        print(f"{artifact}: {path}")
+
+    if not result.import_blocking_passed:
+        print(
+            "import_blocking_passed=false; canonical bundle is not import-ready",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_run_parser_pipeline.py
+++ b/tests/test_run_parser_pipeline.py
@@ -1,0 +1,143 @@
+import importlib
+import json
+
+
+pipeline = importlib.import_module("scripts.run_parser_pipeline")
+
+
+SAMPLE_LEGISLATIE_HTML = """
+<html>
+  <head><title>Codul muncii</title></head>
+  <body>
+    <nav>Meniu Cautare Acasa Tipareste</nav>
+    <main id="textdocumentleg">
+      <h1>Codul muncii</h1>
+      <p>Art. 17</p>
+      <p>(3) Persoana selectata va fi informata cu privire la:</p>
+      <p>k) salariul de baza, alte elemente constitutive ale veniturilor salariale.</p>
+      <p>Art. 41</p>
+      <p>(1) Contractul individual de munca poate fi modificat numai prin acordul partilor.</p>
+      <p>(3) Modificarea contractului individual de munca se refera la durata contractului,
+      locul muncii, felul muncii, conditiile de munca, salariul si timpul de munca.</p>
+      <p>(4) Modificarea contractului individual de munca se face prin act aditional,
+      in conditiile prevazute la alin. (3).</p>
+    </main>
+    <script>window.noise = true;</script>
+    <footer>Footer legislatie</footer>
+  </body>
+</html>
+"""
+
+
+def test_run_pipeline_from_legislatie_url_exports_canonical_bundle(tmp_path, monkeypatch):
+    url = "https://legislatie.just.ro/Public/DetaliiDocument/123456"
+    monkeypatch.setattr(pipeline, "scrape_html_source", lambda requested_url: SAMPLE_LEGISLATIE_HTML)
+
+    result = pipeline.run_pipeline(
+        url=url,
+        out_dir=tmp_path,
+        law_id="ro.codul_muncii",
+        law_title="Codul muncii",
+        generated_at="2026-04-25T00:00:00+00:00",
+        write_debug=True,
+    )
+
+    assert result.import_blocking_passed is True
+    assert result.law_id == "ro.codul_muncii"
+    assert result.legacy_units_count >= 7
+    assert set(result.artifact_paths) == {
+        "legal_units",
+        "legal_edges",
+        "legal_chunks",
+        "embeddings_input",
+        "corpus_manifest",
+        "validation_report",
+        "reference_candidates",
+    }
+    for path in result.artifact_paths.values():
+        assert path.exists()
+
+    legal_units = json.loads(result.artifact_paths["legal_units"].read_text(encoding="utf-8"))
+    units_by_id = {unit["id"]: unit for unit in legal_units}
+    assert "ro.codul_muncii.art_41" in units_by_id
+    assert "ro.codul_muncii.art_41.alin_4" in units_by_id
+    assert "ro.codul_muncii.art_17.alin_3.lit_k" in units_by_id
+    assert units_by_id["ro.codul_muncii.art_41.alin_4"]["source_url"] == url
+    assert (
+        units_by_id["ro.codul_muncii.art_41.alin_4"]["raw_text"]
+        == "(4) Modificarea contractului individual de munca se face prin act aditional,\n"
+        "in conditiile prevazute la alin. (3)."
+    )
+
+    legal_edges = json.loads(result.artifact_paths["legal_edges"].read_text(encoding="utf-8"))
+    assert all(edge["type"] == "contains" for edge in legal_edges)
+    assert {
+        (edge["source_id"], edge["target_id"])
+        for edge in legal_edges
+    } >= {
+        ("ro.codul_muncii", "ro.codul_muncii.art_41"),
+        ("ro.codul_muncii.art_41", "ro.codul_muncii.art_41.alin_4"),
+        ("ro.codul_muncii.art_17.alin_3", "ro.codul_muncii.art_17.alin_3.lit_k"),
+    }
+
+    legal_chunks = json.loads(result.artifact_paths["legal_chunks"].read_text(encoding="utf-8"))
+    chunk_by_unit = {chunk["legal_unit_id"]: chunk for chunk in legal_chunks}
+    assert chunk_by_unit["ro.codul_muncii.art_41.alin_4"]["text"] == units_by_id[
+        "ro.codul_muncii.art_41.alin_4"
+    ]["raw_text"]
+    assert "act aditional" in chunk_by_unit["ro.codul_muncii.art_41.alin_4"]["retrieval_text"]
+
+    embeddings_lines = result.artifact_paths["embeddings_input"].read_text(encoding="utf-8").splitlines()
+    assert embeddings_lines
+    first_embedding_record = json.loads(embeddings_lines[0])
+    assert {"record_id", "chunk_id", "legal_unit_id", "text_hash"} <= set(first_embedding_record)
+
+    manifest = json.loads(result.artifact_paths["corpus_manifest"].read_text(encoding="utf-8"))
+    assert manifest["input_files"] == [url]
+    assert manifest["sources"][0]["source_type"] == "legislatie.just.ro_url"
+    assert manifest["contextual_retrieval_enabled"] is True
+
+    validation_report = json.loads(result.artifact_paths["validation_report"].read_text(encoding="utf-8"))
+    assert validation_report["import_blocking_passed"] is True
+    assert validation_report["chunks_count"] == len(legal_chunks)
+
+    assert (tmp_path / "cleaned_lines.txt").exists()
+    assert (tmp_path / "cleaner_report.json").exists()
+    assert (tmp_path / "legacy_units.json").exists()
+
+
+def test_run_pipeline_rejects_non_legislatie_url(tmp_path, monkeypatch):
+    monkeypatch.setattr(pipeline, "scrape_html_source", lambda requested_url: SAMPLE_LEGISLATIE_HTML)
+
+    try:
+        pipeline.run_pipeline(
+            url="https://example.com/Public/DetaliiDocument/123456",
+            out_dir=tmp_path,
+            law_id="ro.codul_muncii",
+            law_title="Codul muncii",
+        )
+    except ValueError as exc:
+        assert "legislatie.just.ro" in str(exc)
+    else:
+        raise AssertionError("Expected non-legislatie URL to be rejected")
+
+
+def test_run_pipeline_can_infer_title_and_law_id_from_html(tmp_path, monkeypatch):
+    url = "https://legislatie.just.ro/Public/DetaliiDocument/123456"
+    monkeypatch.setattr(pipeline, "scrape_html_source", lambda requested_url: SAMPLE_LEGISLATIE_HTML)
+
+    result = pipeline.run_pipeline(
+        url=url,
+        out_dir=tmp_path,
+        generated_at="2026-04-25T00:00:00+00:00",
+    )
+
+    assert result.law_title == "Codul muncii"
+    assert result.law_id == "ro.codul_muncii"
+
+
+def test_run_pipeline_normalizes_numbered_legislatie_title():
+    assert (
+        pipeline._make_law_id_from_title("LEGE nr. 53 din 24 ianuarie 2003 - Portal Legislativ")
+        == "ro.lege_53_2003"
+    )


### PR DESCRIPTION
This pull request introduces a new parser pipeline script for processing legal documents from legislatie.just.ro and adds a comprehensive test suite to ensure its correctness. The main changes include implementing a robust file-based integration pipeline for fetching, cleaning, parsing, and exporting canonical bundles of legal data, as well as providing extensive tests for various pipeline scenarios.

**Key changes:**

**New parser pipeline implementation:**

* Added `scripts/run_parser_pipeline.py`, a script that fetches a legislatie.just.ro page, cleans and parses the HTML, infers or validates metadata (such as law ID and title), and exports a canonical bundle of legal units and related artifacts. The script includes robust error handling, metadata inference logic, and an optional debug output mode.
* The pipeline includes helper functions for URL validation, law title and ID inference, and debug artifact writing. It is designed to be run as a command-line tool with configurable arguments.

**Testing and validation:**

* Added `tests/test_run_parser_pipeline.py` with tests that verify the pipeline's ability to process sample HTML, export all expected artifacts, correctly infer law IDs and titles, handle invalid URLs, and normalize law titles. The tests use monkeypatching to simulate HTML fetching and validate the structure and content of the output artifacts.

**Metadata inference and normalization:**

* Implemented logic to infer law titles and IDs from HTML content or URLs, including normalization for numbered legal acts (e.g., "LEGE nr. 53 din 24 ianuarie 2003" → "ro.lege_53_2003"). [[1]](diffhunk://#diff-b330825601cb1814d1d4730ef4e8681ec3255d4a8b6d715a387c4d14b021b90cR1-R346) [[2]](diffhunk://#diff-cba6e56239661e736477c82d39b6f068a5f3685ee10d2ef5edb7ca1f6a383921R1-R143)

**Debugging and artifact management:**

* The pipeline can optionally write debug files containing cleaned lines, cleaner reports, and parsed legacy units to assist with troubleshooting and validation. [[1]](diffhunk://#diff-b330825601cb1814d1d4730ef4e8681ec3255d4a8b6d715a387c4d14b021b90cR1-R346) [[2]](diffhunk://#diff-cba6e56239661e736477c82d39b6f068a5f3685ee10d2ef5edb7ca1f6a383921R1-R143)