### PR TITLE
feat(api): add answer repair and refusal handling

### DIFF
--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -250,6 +250,7 @@ class QueryDebugData(BaseModel):
     evidence_pack: dict[str, Any] | None = None
     generation: dict[str, Any] | None = None
     verifier: dict[str, Any] | None = None
+    answer_repair: dict[str, Any] | None = None
     evidence_units_count: int = Field(..., ge=0)
     citations_count: int = Field(..., ge=0)
     graph_nodes_count: int = Field(..., ge=0)

--- a/apps/api/app/services/answer_repair.py
+++ b/apps/api/app/services/answer_repair.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from ..schemas import AnswerPayload, Citation, ClaimResult, EvidenceUnit, VerifierStatus
+
+ANSWER_REFUSED_INSUFFICIENT_EVIDENCE = "answer_refused_insufficient_evidence"
+ANSWER_REFUSED_NO_VERIFIABLE_LEGAL_CLAIMS = (
+    "answer_refused_no_verifiable_legal_claims"
+)
+ANSWER_REPAIRED_UNSUPPORTED_CLAIMS_REMOVED = (
+    "answer_repaired_unsupported_claims_removed"
+)
+ANSWER_REFUSED_UNSUPPORTED_CLAIMS = "answer_refused_unsupported_claims"
+ANSWER_TEMPERED_WEAK_SUPPORT = "answer_tempered_weak_support"
+INVALID_CITATIONS_REMOVED = "invalid_citations_removed"
+
+REFUSAL_INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+REFUSAL_NO_VERIFIABLE_LEGAL_CLAIMS = "no_verifiable_legal_claims"
+REFUSAL_UNSUPPORTED_CLAIMS = "unsupported_claims"
+
+REPAIR_ACTION_NONE = "none"
+REPAIR_ACTION_REMOVED_UNSUPPORTED = "removed_unsupported_claims"
+REPAIR_ACTION_TEMPERED_WEAK_SUPPORT = "tempered_weak_support"
+REPAIR_ACTION_REFUSED_INSUFFICIENT = "refused_insufficient_evidence"
+REPAIR_ACTION_REFUSED_UNSUPPORTED = "refused_unsupported_claims"
+REPAIR_ACTION_REFUSED_NO_CLAIMS = "refused_no_verifiable_claims"
+
+INSUFFICIENT_EVIDENCE_ANSWER = (
+    "Nu pot formula un r\u0103spuns juridic sus\u021binut pe baza "
+    "corpusului disponibil."
+)
+INSUFFICIENT_EVIDENCE_DETAIL = (
+    "EvidencePack-ul disponibil este gol sau insuficient pentru a sus\u021bine "
+    "un r\u0103spuns juridic verificabil."
+)
+NO_VERIFIABLE_CLAIMS_ANSWER = (
+    "Nu pot identifica afirma\u021bii juridice verificabile \u00een "
+    "r\u0103spunsul generat."
+)
+NO_VERIFIABLE_CLAIMS_DETAIL = (
+    "R\u0103spunsul generat nu con\u021bine claim-uri juridice pe care "
+    "CitationVerifier V1 s\u0103 le poat\u0103 valida fa\u021b\u0103 de "
+    "EvidencePack."
+)
+UNSUPPORTED_CLAIMS_REFUSAL = (
+    "Nu pot publica r\u0103spunsul generat deoarece afirma\u021biile "
+    "juridice nu sunt sus\u021binute de EvidencePack."
+)
+UNSUPPORTED_CLAIMS_DETAIL = (
+    "CitationVerifier V1 a marcat toate afirma\u021biile juridice "
+    "publicabile ca unsupported."
+)
+WEAK_SUPPORT_TEMPERING = (
+    "Pe baza corpusului disponibil, suportul pentru unele afirma\u021bii "
+    "este limitat."
+)
+REPAIRED_DETAIL_HEADER = "Afirma\u021bii p\u0103strate dup\u0103 verificare:"
+
+SUPPORTED_STATUSES = {"strongly_supported", "supported"}
+WEAK_STATUS = "weakly_supported"
+UNSUPPORTED_STATUS = "unsupported"
+
+
+class AnswerRepairResult(BaseModel):
+    answer: AnswerPayload
+    citations: list[Citation] = Field(default_factory=list)
+    verifier: VerifierStatus
+    warnings: list[str] = Field(default_factory=list)
+    repair_applied: bool
+    refusal_reason: str | None = None
+    debug: dict[str, Any] | None = None
+
+
+class AnswerRepair:
+    def repair(
+        self,
+        *,
+        answer: AnswerPayload,
+        citations: list[Citation],
+        evidence_units: list[EvidenceUnit],
+        verifier: VerifierStatus,
+        warnings: list[str] | None = None,
+        debug: bool = False,
+    ) -> AnswerRepairResult:
+        existing_warnings = list(warnings or [])
+        valid_citations, removed_citations = self._filter_invalid_citations(
+            citations,
+            evidence_units,
+        )
+        warnings_added: list[str] = []
+        if removed_citations:
+            warnings_added.append(INVALID_CITATIONS_REMOVED)
+
+        if not evidence_units:
+            return self._refusal_result(
+                answer=answer,
+                verifier=verifier,
+                warnings=existing_warnings,
+                warnings_added=[
+                    *warnings_added,
+                    ANSWER_REFUSED_INSUFFICIENT_EVIDENCE,
+                ],
+                action=REPAIR_ACTION_REFUSED_INSUFFICIENT,
+                reason=REFUSAL_INSUFFICIENT_EVIDENCE,
+                short_answer=INSUFFICIENT_EVIDENCE_ANSWER,
+                detailed_answer=INSUFFICIENT_EVIDENCE_DETAIL,
+                removed_citations=removed_citations,
+                kept_claims=[],
+                removed_claims=[],
+                debug=debug,
+            )
+
+        if verifier.claims_total == 0:
+            return self._refusal_result(
+                answer=answer,
+                verifier=verifier,
+                warnings=existing_warnings,
+                warnings_added=[
+                    *warnings_added,
+                    ANSWER_REFUSED_NO_VERIFIABLE_LEGAL_CLAIMS,
+                ],
+                action=REPAIR_ACTION_REFUSED_NO_CLAIMS,
+                reason=REFUSAL_NO_VERIFIABLE_LEGAL_CLAIMS,
+                short_answer=NO_VERIFIABLE_CLAIMS_ANSWER,
+                detailed_answer=NO_VERIFIABLE_CLAIMS_DETAIL,
+                removed_citations=removed_citations,
+                kept_claims=[],
+                removed_claims=verifier.claim_results,
+                debug=debug,
+            )
+
+        invalidated_claims = self._claims_invalidated_by_removed_citations(
+            verifier.claim_results,
+            removed_citations,
+        )
+        unsupported_claims = [
+            claim
+            for claim in verifier.claim_results
+            if claim.status == UNSUPPORTED_STATUS or claim in invalidated_claims
+        ]
+        weak_claims = [
+            claim
+            for claim in verifier.claim_results
+            if claim.status == WEAK_STATUS
+        ]
+        kept_claims = self._publishable_claims(
+            verifier.claim_results,
+            invalidated_claims,
+        )
+
+        if unsupported_claims:
+            if not kept_claims:
+                return self._refusal_result(
+                    answer=answer,
+                    verifier=verifier,
+                    warnings=existing_warnings,
+                    warnings_added=[
+                        *warnings_added,
+                        ANSWER_REFUSED_UNSUPPORTED_CLAIMS,
+                    ],
+                    action=REPAIR_ACTION_REFUSED_UNSUPPORTED,
+                    reason=REFUSAL_UNSUPPORTED_CLAIMS,
+                    short_answer=UNSUPPORTED_CLAIMS_REFUSAL,
+                    detailed_answer=UNSUPPORTED_CLAIMS_DETAIL,
+                    removed_citations=removed_citations or citations,
+                    kept_claims=[],
+                    removed_claims=unsupported_claims,
+                    debug=debug,
+                )
+
+            repaired_answer = self._answer_from_kept_claims(answer, kept_claims)
+            repaired_verifier = self._updated_verifier(
+                verifier,
+                verifier_passed=False,
+                repair_applied=True,
+                refusal_reason=None,
+                warnings_added=[
+                    *warnings_added,
+                    ANSWER_REPAIRED_UNSUPPORTED_CLAIMS_REMOVED,
+                ],
+            )
+            final_warnings = self._dedupe(
+                existing_warnings
+                + warnings_added
+                + [ANSWER_REPAIRED_UNSUPPORTED_CLAIMS_REMOVED]
+            )
+            return AnswerRepairResult(
+                answer=repaired_answer,
+                citations=valid_citations,
+                verifier=repaired_verifier,
+                warnings=final_warnings,
+                repair_applied=True,
+                refusal_reason=None,
+                debug=self._debug_payload(
+                    action=REPAIR_ACTION_REMOVED_UNSUPPORTED,
+                    removed_claims=unsupported_claims,
+                    kept_claims=kept_claims,
+                    removed_citations=removed_citations,
+                    refusal_reason=None,
+                    warnings_added=[
+                        *warnings_added,
+                        ANSWER_REPAIRED_UNSUPPORTED_CLAIMS_REMOVED,
+                    ],
+                )
+                if debug
+                else None,
+            )
+
+        fully_supported = verifier.verifier_passed or (
+            self._all_claims_supported(verifier.claim_results)
+            and not verifier.warnings
+        )
+        if weak_claims or not fully_supported:
+            tempered_answer = self._temper_answer(answer)
+            repaired_verifier = self._updated_verifier(
+                verifier,
+                verifier_passed=False,
+                repair_applied=True,
+                refusal_reason=None,
+                warnings_added=[*warnings_added, ANSWER_TEMPERED_WEAK_SUPPORT],
+            )
+            final_warnings = self._dedupe(
+                existing_warnings + warnings_added + [ANSWER_TEMPERED_WEAK_SUPPORT]
+            )
+            return AnswerRepairResult(
+                answer=tempered_answer,
+                citations=valid_citations,
+                verifier=repaired_verifier,
+                warnings=final_warnings,
+                repair_applied=True,
+                refusal_reason=None,
+                debug=self._debug_payload(
+                    action=REPAIR_ACTION_TEMPERED_WEAK_SUPPORT,
+                    removed_claims=[],
+                    kept_claims=verifier.claim_results,
+                    removed_citations=removed_citations,
+                    refusal_reason=None,
+                    warnings_added=[*warnings_added, ANSWER_TEMPERED_WEAK_SUPPORT],
+                )
+                if debug
+                else None,
+            )
+
+        if removed_citations:
+            repaired_verifier = self._updated_verifier(
+                verifier,
+                verifier_passed=False,
+                repair_applied=True,
+                refusal_reason=None,
+                warnings_added=warnings_added,
+            )
+            final_warnings = self._dedupe(existing_warnings + warnings_added)
+            return AnswerRepairResult(
+                answer=answer,
+                citations=valid_citations,
+                verifier=repaired_verifier,
+                warnings=final_warnings,
+                repair_applied=True,
+                refusal_reason=None,
+                debug=self._debug_payload(
+                    action=REPAIR_ACTION_TEMPERED_WEAK_SUPPORT,
+                    removed_claims=[],
+                    kept_claims=verifier.claim_results,
+                    removed_citations=removed_citations,
+                    refusal_reason=None,
+                    warnings_added=warnings_added,
+                )
+                if debug
+                else None,
+            )
+
+        passed_verifier = self._updated_verifier(
+            verifier,
+            verifier_passed=True,
+            repair_applied=False,
+            refusal_reason=None,
+            warnings_added=[],
+        )
+        return AnswerRepairResult(
+            answer=answer,
+            citations=valid_citations,
+            verifier=passed_verifier,
+            warnings=self._dedupe(existing_warnings),
+            repair_applied=False,
+            refusal_reason=None,
+            debug=self._debug_payload(
+                action=REPAIR_ACTION_NONE,
+                removed_claims=[],
+                kept_claims=verifier.claim_results,
+                removed_citations=[],
+                refusal_reason=None,
+                warnings_added=[],
+            )
+            if debug
+            else None,
+        )
+
+    def _filter_invalid_citations(
+        self,
+        citations: list[Citation],
+        evidence_units: list[EvidenceUnit],
+    ) -> tuple[list[Citation], list[Citation]]:
+        evidence_ids = {unit.id for unit in evidence_units}
+        valid: list[Citation] = []
+        removed: list[Citation] = []
+        for citation in citations:
+            if citation.verified and citation.legal_unit_id in evidence_ids:
+                valid.append(citation)
+            else:
+                removed.append(citation)
+        return valid, removed
+
+    def _claims_invalidated_by_removed_citations(
+        self,
+        claims: list[ClaimResult],
+        removed_citations: list[Citation],
+    ) -> list[ClaimResult]:
+        removed_ids = {citation.citation_id for citation in removed_citations}
+        if not removed_ids:
+            return []
+        return [
+            claim
+            for claim in claims
+            if claim.citation_ids
+            and removed_ids.intersection(claim.citation_ids)
+            and not set(claim.citation_ids).difference(removed_ids)
+        ]
+
+    def _publishable_claims(
+        self,
+        claims: list[ClaimResult],
+        invalidated_claims: list[ClaimResult],
+    ) -> list[ClaimResult]:
+        invalidated_ids = {claim.claim_id for claim in invalidated_claims}
+        return [
+            claim
+            for claim in claims
+            if claim.status in SUPPORTED_STATUSES
+            and claim.claim_id not in invalidated_ids
+        ]
+
+    def _answer_from_kept_claims(
+        self,
+        answer: AnswerPayload,
+        kept_claims: list[ClaimResult],
+    ) -> AnswerPayload:
+        kept_texts = self._dedupe([claim.claim_text for claim in kept_claims])
+        detailed = "\n".join(
+            [REPAIRED_DETAIL_HEADER]
+            + [f"- {claim_text}" for claim_text in kept_texts]
+        )
+        return answer.model_copy(
+            update={
+                "short_answer": kept_texts[0],
+                "detailed_answer": detailed,
+                "refusal_reason": None,
+                "confidence": 0.0,
+            }
+        )
+
+    def _temper_answer(self, answer: AnswerPayload) -> AnswerPayload:
+        if answer.short_answer.startswith(WEAK_SUPPORT_TEMPERING):
+            short_answer = answer.short_answer
+        else:
+            short_answer = f"{WEAK_SUPPORT_TEMPERING} {answer.short_answer}"
+        return answer.model_copy(
+            update={
+                "short_answer": short_answer,
+                "confidence": 0.0,
+            }
+        )
+
+    def _refusal_result(
+        self,
+        *,
+        answer: AnswerPayload,
+        verifier: VerifierStatus,
+        warnings: list[str],
+        warnings_added: list[str],
+        action: str,
+        reason: str,
+        short_answer: str,
+        detailed_answer: str,
+        removed_citations: list[Citation],
+        kept_claims: list[ClaimResult],
+        removed_claims: list[ClaimResult],
+        debug: bool,
+    ) -> AnswerRepairResult:
+        repaired_answer = answer.model_copy(
+            update={
+                "short_answer": short_answer,
+                "detailed_answer": detailed_answer,
+                "confidence": 0.0,
+                "refusal_reason": reason,
+            }
+        )
+        repaired_verifier = self._updated_verifier(
+            verifier,
+            verifier_passed=False,
+            repair_applied=True,
+            refusal_reason=reason,
+            warnings_added=warnings_added,
+        )
+        return AnswerRepairResult(
+            answer=repaired_answer,
+            citations=[],
+            verifier=repaired_verifier,
+            warnings=self._dedupe(warnings + warnings_added),
+            repair_applied=True,
+            refusal_reason=reason,
+            debug=self._debug_payload(
+                action=action,
+                removed_claims=removed_claims,
+                kept_claims=kept_claims,
+                removed_citations=removed_citations,
+                refusal_reason=reason,
+                warnings_added=warnings_added,
+            )
+            if debug
+            else None,
+        )
+
+    def _updated_verifier(
+        self,
+        verifier: VerifierStatus,
+        *,
+        verifier_passed: bool,
+        repair_applied: bool,
+        refusal_reason: str | None,
+        warnings_added: list[str],
+    ) -> VerifierStatus:
+        return verifier.model_copy(
+            update={
+                "verifier_passed": verifier_passed,
+                "repair_applied": repair_applied,
+                "refusal_reason": refusal_reason,
+                "warnings": self._dedupe(verifier.warnings + warnings_added),
+            }
+        )
+
+    def _all_claims_supported(self, claims: list[ClaimResult]) -> bool:
+        return bool(claims) and all(
+            claim.status in SUPPORTED_STATUSES for claim in claims
+        )
+
+    def _debug_payload(
+        self,
+        *,
+        action: str,
+        removed_claims: list[ClaimResult],
+        kept_claims: list[ClaimResult],
+        removed_citations: list[Citation],
+        refusal_reason: str | None,
+        warnings_added: list[str],
+    ) -> dict[str, Any]:
+        return {
+            "repair_action": action,
+            "removed_claims": [claim.claim_text for claim in removed_claims],
+            "kept_claims": [claim.claim_text for claim in kept_claims],
+            "removed_citation_ids": [
+                citation.citation_id for citation in removed_citations
+            ],
+            "removed_unit_ids": [
+                citation.legal_unit_id for citation in removed_citations
+            ],
+            "refusal_reason": refusal_reason,
+            "warnings_added": self._dedupe(warnings_added),
+        }
+
+    def _dedupe(self, values: list[str]) -> list[str]:
+        deduped: list[str] = []
+        for value in values:
+            if value not in deduped:
+                deduped.append(value)
+        return deduped

--- a/apps/api/app/services/query_orchestrator.py
+++ b/apps/api/app/services/query_orchestrator.py
@@ -11,6 +11,7 @@ from ..schemas import (
     QueryRequest,
     QueryResponse,
 )
+from .answer_repair import AnswerRepair
 from .citation_verifier import CitationVerifier
 from .evidence_pack_compiler import EvidencePackCompiler
 from .generation_adapter import (
@@ -39,6 +40,7 @@ class QueryOrchestrator:
         evidence_pack_compiler: EvidencePackCompiler | None = None,
         generation_adapter: GenerationAdapter | None = None,
         citation_verifier: CitationVerifier | None = None,
+        answer_repair: AnswerRepair | None = None,
     ) -> None:
         self.evidence_service = evidence_service or MockEvidenceService()
         self.query_understanding = query_understanding or QueryUnderstanding()
@@ -52,6 +54,7 @@ class QueryOrchestrator:
         )
         self.generation_adapter = generation_adapter or GenerationAdapter()
         self.citation_verifier = citation_verifier or CitationVerifier()
+        self.answer_repair = answer_repair or AnswerRepair()
 
     async def run(self, request: QueryRequest) -> QueryResponse:
         query_id = self._query_id(request)
@@ -103,6 +106,25 @@ class QueryOrchestrator:
             citations,
             verification.verified_citation_ids,
         )
+        pre_repair_warnings = self._dedupe(
+            raw_retrieval.warnings
+            + graph_expansion.warnings
+            + legal_ranker.warnings
+            + compiled_evidence.warnings
+            + self._generation_warnings(draft_answer, verifier_ran=True)
+            + verification.warnings
+        )
+        repair = self.answer_repair.repair(
+            answer=answer,
+            citations=citations,
+            evidence_units=compiled_evidence.evidence_units,
+            verifier=verification.verifier,
+            warnings=pre_repair_warnings,
+            debug=request.debug,
+        )
+        answer = repair.answer
+        citations = repair.citations
+        verifier = repair.verifier
         graph = GraphPayload(
             nodes=compiled_evidence.graph_nodes,
             edges=compiled_evidence.graph_edges,
@@ -120,12 +142,13 @@ class QueryOrchestrator:
                 evidence_pack=compiled_evidence.debug,
                 generation=self._generation_debug(draft_answer, verifier_ran=True),
                 verifier=verification.debug,
+                answer_repair=repair.debug,
                 evidence_units_count=len(compiled_evidence.evidence_units),
                 citations_count=len(citations),
                 graph_nodes_count=len(graph.nodes),
                 graph_edges_count=len(graph.edges),
                 notes=[
-                    "GenerationAdapter and CitationVerifier V1 ran over compiled EvidencePack.",
+                    "GenerationAdapter, CitationVerifier V1, and AnswerRepair V1 ran over compiled EvidencePack.",
                 ],
             )
 
@@ -135,17 +158,10 @@ class QueryOrchestrator:
             answer=answer,
             citations=citations,
             evidence_units=compiled_evidence.evidence_units,
-            verifier=verification.verifier,
+            verifier=verifier,
             graph=graph,
             debug=debug,
-            warnings=self._dedupe(
-                raw_retrieval.warnings
-                + graph_expansion.warnings
-                + legal_ranker.warnings
-                + compiled_evidence.warnings
-                + self._generation_warnings(draft_answer, verifier_ran=True)
-                + verification.warnings
-            ),
+            warnings=repair.warnings,
         )
 
     def _generate_answer(

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -28,10 +28,12 @@ def test_post_api_query_returns_unverified_fallback_without_retrieval():
     assert payload["question"] == VALID_QUERY["question"]
     assert payload["answer"]["confidence"] == 0.0
     assert payload["answer"]["not_legal_advice"] is True
-    assert payload["answer"]["refusal_reason"] == "generation_insufficient_evidence"
+    assert payload["answer"]["refusal_reason"] == "insufficient_evidence"
     assert payload["citations"] == []
     assert payload["evidence_units"] == []
     assert payload["verifier"]["verifier_passed"] is False
+    assert payload["verifier"]["repair_applied"] is True
+    assert payload["verifier"]["refusal_reason"] == "insufficient_evidence"
     assert payload["verifier"]["citations_checked"] == 0
     assert "verifier_insufficient_evidence" in payload["verifier"]["warnings"]
     assert payload["graph"]["nodes"] == []
@@ -39,6 +41,7 @@ def test_post_api_query_returns_unverified_fallback_without_retrieval():
     assert "evidence_pack_no_ranked_candidates" in payload["warnings"]
     assert "generation_insufficient_evidence" in payload["warnings"]
     assert "verifier_insufficient_evidence" in payload["warnings"]
+    assert "answer_refused_insufficient_evidence" in payload["warnings"]
 
 
 def test_post_api_query_uses_snake_case_fields():
@@ -102,6 +105,9 @@ def test_post_api_query_debug_true_includes_debug_payload():
     assert verifier["claim_extraction"]["claims_total"] == 0
     assert verifier["citation_checks"] == []
     assert "verifier_insufficient_evidence" in verifier["warnings"]
+    answer_repair = debug["answer_repair"]
+    assert answer_repair["repair_action"] == "refused_insufficient_evidence"
+    assert answer_repair["refusal_reason"] == "insufficient_evidence"
 
 
 def test_post_api_query_debug_false_returns_null_debug():
@@ -116,6 +122,7 @@ def test_post_api_query_debug_false_returns_null_debug():
     assert "evidence_pack_no_ranked_candidates" in payload["warnings"]
     assert "generation_insufficient_evidence" in payload["warnings"]
     assert "verifier_insufficient_evidence" in payload["warnings"]
+    assert "answer_refused_insufficient_evidence" in payload["warnings"]
 
 
 def test_post_api_query_debug_true_includes_exact_citations():
@@ -144,8 +151,10 @@ def test_post_api_query_debug_true_includes_exact_citations():
     assert filters["paragraph_number"] == "1"
     assert filters["law_id"] == "ro.codul_muncii"
     assert payload["answer"]["confidence"] == 0.0
-    assert payload["answer"]["refusal_reason"] == "generation_insufficient_evidence"
+    assert payload["answer"]["refusal_reason"] == "insufficient_evidence"
     assert payload["verifier"]["verifier_passed"] is False
+    assert payload["verifier"]["repair_applied"] is True
+    assert payload["verifier"]["refusal_reason"] == "insufficient_evidence"
     assert "verifier_insufficient_evidence" in payload["verifier"]["warnings"]
     assert "raw_retrieval_not_configured" in payload["warnings"]
     assert "graph_expansion_no_seed_candidates" in payload["warnings"]
@@ -226,12 +235,17 @@ async def test_query_orchestrator_populates_evidence_units_with_fake_candidates(
     assert response.debug.evidence_pack["fallback_used"] is False
     assert response.debug.evidence_pack["selected_evidence_count"] == 1
     assert response.debug.generation["evidence_unit_count_used"] == 1
-    assert response.citations
-    assert response.citations[0].legal_unit_id == "ro.codul_muncii.art_41"
+    assert response.citations == []
+    assert response.answer.refusal_reason == "unsupported_claims"
     assert response.answer.confidence == 0.0
     assert response.verifier.citations_checked == 1
     assert response.verifier.claims_total > 0
+    assert response.verifier.verifier_passed is False
+    assert response.verifier.repair_applied is True
+    assert "answer_refused_unsupported_claims" in response.warnings
     assert response.debug.verifier["claim_extraction"]["claims_total"] > 0
+    assert response.debug.answer_repair["repair_action"] == "refused_unsupported_claims"
+    assert response.debug.answer_repair["removed_citation_ids"] == ["citation:1"]
 
 
 def test_handoff04_graph_endpoints_are_not_registered():
@@ -268,7 +282,9 @@ def test_post_api_query_real_verifier_failure_is_explicit():
     payload = response.json()
     warnings = " ".join(payload["warnings"] + payload["verifier"]["warnings"])
     assert "verifier_insufficient_evidence" in warnings
+    assert "answer_refused_insufficient_evidence" in warnings
     assert "citation_verifier_failed" not in warnings
     assert "CitationVerifier has not run yet" not in warnings
     assert "generation_unverified_citation_verifier_not_run" not in warnings
     assert payload["verifier"]["verifier_passed"] is False
+    assert payload["verifier"]["repair_applied"] is True

--- a/tests/test_answer_repair.py
+++ b/tests/test_answer_repair.py
@@ -1,0 +1,256 @@
+from apps.api.app.schemas import AnswerPayload, Citation, ClaimResult, EvidenceUnit, VerifierStatus
+from apps.api.app.services.answer_repair import (
+    ANSWER_REFUSED_INSUFFICIENT_EVIDENCE,
+    ANSWER_REFUSED_NO_VERIFIABLE_LEGAL_CLAIMS,
+    ANSWER_REFUSED_UNSUPPORTED_CLAIMS,
+    ANSWER_REPAIRED_UNSUPPORTED_CLAIMS_REMOVED,
+    ANSWER_TEMPERED_WEAK_SUPPORT,
+    INSUFFICIENT_EVIDENCE_ANSWER,
+    INVALID_CITATIONS_REMOVED,
+    REFUSAL_INSUFFICIENT_EVIDENCE,
+    REFUSAL_NO_VERIFIABLE_LEGAL_CLAIMS,
+    REFUSAL_UNSUPPORTED_CLAIMS,
+    WEAK_SUPPORT_TEMPERING,
+    AnswerRepair,
+)
+
+
+def evidence_unit(unit_id: str = "ro.codul_muncii.art_41") -> EvidenceUnit:
+    raw_text = "Contractul individual de munca poate fi modificat numai prin acordul partilor."
+    return EvidenceUnit(
+        id=unit_id,
+        law_id="ro.codul_muncii",
+        law_title="Codul muncii",
+        status="active",
+        hierarchy_path=["Codul muncii", "Art. 41"],
+        article_number="41",
+        raw_text=raw_text,
+        normalized_text=None,
+        legal_domain="munca",
+        legal_concepts=[],
+        source_url=None,
+        evidence_id=f"evidence:{unit_id}",
+        excerpt=raw_text,
+        rank=1,
+        relevance_score=0.9,
+        retrieval_method="test",
+        retrieval_score=0.9,
+        rerank_score=0.9,
+        support_role="direct_basis",
+    )
+
+
+def citation(
+    *,
+    citation_id: str = "citation:1",
+    unit_id: str = "ro.codul_muncii.art_41",
+    verified: bool = True,
+) -> Citation:
+    return Citation(
+        citation_id=citation_id,
+        evidence_id=f"evidence:{unit_id}",
+        legal_unit_id=unit_id,
+        label="Codul muncii, art. 41",
+        quote="Contractul individual de munca poate fi modificat numai prin acordul partilor.",
+        verified=verified,
+    )
+
+
+def answer(
+    short_answer: str = "Contractul individual de munca poate fi modificat numai prin acordul partilor.",
+) -> AnswerPayload:
+    return AnswerPayload(
+        short_answer=short_answer,
+        detailed_answer=None,
+        confidence=0.0,
+        not_legal_advice=True,
+    )
+
+
+def claim(
+    *,
+    claim_id: str = "claim:1",
+    text: str = "Contractul individual de munca poate fi modificat numai prin acordul partilor.",
+    status: str = "supported",
+    citation_ids: list[str] | None = None,
+) -> ClaimResult:
+    support_score = {
+        "strongly_supported": 0.85,
+        "supported": 0.7,
+        "weakly_supported": 0.5,
+        "unsupported": 0.2,
+    }[status]
+    return ClaimResult(
+        claim_id=claim_id,
+        claim_text=text,
+        status=status,
+        citation_ids=citation_ids or ["citation:1"],
+        confidence=support_score,
+        support_score=support_score,
+        supporting_unit_ids=["ro.codul_muncii.art_41"] if status != "unsupported" else [],
+    )
+
+
+def verifier(
+    claims: list[ClaimResult],
+    *,
+    passed: bool | None = None,
+    warnings: list[str] | None = None,
+) -> VerifierStatus:
+    supported = [
+        item
+        for item in claims
+        if item.status in {"strongly_supported", "supported"}
+    ]
+    weak = [item for item in claims if item.status == "weakly_supported"]
+    unsupported = [item for item in claims if item.status == "unsupported"]
+    return VerifierStatus(
+        groundedness_score=len(supported) / len(claims) if claims else 0.0,
+        claims_total=len(claims),
+        claims_supported=len(supported),
+        claims_weakly_supported=len(weak),
+        claims_unsupported=len(unsupported),
+        citations_checked=1,
+        verifier_passed=(
+            passed
+            if passed is not None
+            else bool(claims) and not weak and not unsupported
+        ),
+        claim_results=claims,
+        warnings=warnings or [],
+    )
+
+
+def test_answer_repair_empty_evidence_refuses():
+    result = AnswerRepair().repair(
+        answer=answer(),
+        citations=[],
+        evidence_units=[],
+        verifier=verifier([], passed=False),
+        debug=True,
+    )
+
+    assert result.answer.short_answer == INSUFFICIENT_EVIDENCE_ANSWER
+    assert result.answer.refusal_reason == REFUSAL_INSUFFICIENT_EVIDENCE
+    assert result.citations == []
+    assert result.repair_applied is True
+    assert result.verifier.repair_applied is True
+    assert result.verifier.refusal_reason == REFUSAL_INSUFFICIENT_EVIDENCE
+    assert ANSWER_REFUSED_INSUFFICIENT_EVIDENCE in result.warnings
+    assert result.debug["repair_action"] == "refused_insufficient_evidence"
+
+
+def test_answer_repair_no_legal_claims_refuses():
+    result = AnswerRepair().repair(
+        answer=answer("Acesta este doar text operational."),
+        citations=[],
+        evidence_units=[evidence_unit()],
+        verifier=verifier([], passed=False),
+    )
+
+    assert result.answer.refusal_reason == REFUSAL_NO_VERIFIABLE_LEGAL_CLAIMS
+    assert result.verifier.verifier_passed is False
+    assert result.repair_applied is True
+    assert ANSWER_REFUSED_NO_VERIFIABLE_LEGAL_CLAIMS in result.warnings
+
+
+def test_answer_repair_removes_unsupported_claim():
+    supported = claim(claim_id="claim:1")
+    unsupported = claim(
+        claim_id="claim:2",
+        text="Angajatorul poate concedia salariatul fara preaviz.",
+        status="unsupported",
+        citation_ids=["citation:1"],
+    )
+
+    result = AnswerRepair().repair(
+        answer=answer(
+            "Contractul individual de munca poate fi modificat numai prin acordul partilor. "
+            "Angajatorul poate concedia salariatul fara preaviz."
+        ),
+        citations=[citation()],
+        evidence_units=[evidence_unit()],
+        verifier=verifier([supported, unsupported], passed=False),
+        debug=True,
+    )
+
+    rendered = f"{result.answer.short_answer}\n{result.answer.detailed_answer}"
+    assert supported.claim_text in rendered
+    assert unsupported.claim_text not in rendered
+    assert result.repair_applied is True
+    assert result.verifier.verifier_passed is False
+    assert ANSWER_REPAIRED_UNSUPPORTED_CLAIMS_REMOVED in result.warnings
+    assert result.debug["removed_claims"] == [unsupported.claim_text]
+
+
+def test_answer_repair_refuses_when_all_claims_unsupported():
+    unsupported = claim(
+        text="Angajatorul poate concedia salariatul fara preaviz.",
+        status="unsupported",
+    )
+
+    result = AnswerRepair().repair(
+        answer=answer(unsupported.claim_text),
+        citations=[citation()],
+        evidence_units=[evidence_unit()],
+        verifier=verifier([unsupported], passed=False),
+    )
+
+    assert result.answer.refusal_reason == REFUSAL_UNSUPPORTED_CLAIMS
+    assert result.citations == []
+    assert result.verifier.verifier_passed is False
+    assert ANSWER_REFUSED_UNSUPPORTED_CLAIMS in result.warnings
+
+
+def test_answer_repair_tempers_weak_support():
+    weak = claim(status="weakly_supported")
+
+    result = AnswerRepair().repair(
+        answer=answer(),
+        citations=[citation()],
+        evidence_units=[evidence_unit()],
+        verifier=verifier([weak], passed=False),
+    )
+
+    assert result.answer.short_answer.startswith(WEAK_SUPPORT_TEMPERING)
+    assert result.repair_applied is True
+    assert result.verifier.verifier_passed is False
+    assert ANSWER_TEMPERED_WEAK_SUPPORT in result.warnings
+
+
+def test_answer_repair_leaves_fully_supported_answer_unchanged():
+    original = answer()
+    result = AnswerRepair().repair(
+        answer=original,
+        citations=[citation()],
+        evidence_units=[evidence_unit()],
+        verifier=verifier([claim()], passed=True),
+    )
+
+    assert result.answer.short_answer == original.short_answer
+    assert result.repair_applied is False
+    assert result.verifier.verifier_passed is True
+    assert ANSWER_TEMPERED_WEAK_SUPPORT not in result.warnings
+    assert ANSWER_REPAIRED_UNSUPPORTED_CLAIMS_REMOVED not in result.warnings
+
+
+def test_answer_repair_removes_invalid_citations():
+    valid = citation(citation_id="citation:1", verified=True)
+    invalid = citation(
+        citation_id="citation:bad",
+        unit_id="ro.codul_muncii.art_missing",
+        verified=False,
+    )
+    result = AnswerRepair().repair(
+        answer=answer(),
+        citations=[valid, invalid],
+        evidence_units=[evidence_unit()],
+        verifier=verifier([claim(citation_ids=["citation:1"])], passed=False),
+        debug=True,
+    )
+
+    assert [item.citation_id for item in result.citations] == ["citation:1"]
+    assert result.repair_applied is True
+    assert result.verifier.verifier_passed is False
+    assert INVALID_CITATIONS_REMOVED in result.warnings
+    assert result.debug["removed_citation_ids"] == ["citation:bad"]

--- a/tests/test_handoff03_fixture_integration.py
+++ b/tests/test_handoff03_fixture_integration.py
@@ -197,6 +197,8 @@ async def test_query_orchestrator_returns_real_evidence_units_for_demo_fixture()
     assert response.answer.confidence == 0.0
     assert response.verifier.citations_checked == len(response.citations)
     assert response.verifier.claims_total > 0
+    assert response.verifier.verifier_passed is True
+    assert response.verifier.repair_applied is False
     assert response.verifier.groundedness_score > 0.0
     assert "mock" not in " ".join(response.verifier.warnings).lower()
     assert response.debug.retrieval["candidate_count"] >= 4
@@ -205,6 +207,7 @@ async def test_query_orchestrator_returns_real_evidence_units_for_demo_fixture()
     assert response.debug.citations_count == len(response.citations)
     assert response.debug.generation["generation_mode"] == "deterministic_extractive_v1"
     assert response.debug.verifier["claim_extraction"]["claims_total"] > 0
+    assert response.debug.answer_repair["repair_action"] == "none"
     assert response.debug.legal_ranker["ranked_candidate_count"] >= 4
     assert response.debug.graph_expansion["fallback_used"] is False
     assert "CitationVerifier has not run yet" not in " ".join(response.warnings)

--- a/tests/test_query_orchestrator.py
+++ b/tests/test_query_orchestrator.py
@@ -56,7 +56,12 @@ async def test_query_orchestrator_generates_grounded_draft_with_debug():
         assert citation.verified is True
     assert response.verifier.citations_checked == len(response.citations)
     assert response.verifier.claims_total > 0
+    assert response.verifier.verifier_passed is True
+    assert response.verifier.repair_applied is False
     warnings = " ".join(response.warnings + response.verifier.warnings)
+    assert "answer_refused" not in warnings
+    assert "answer_repaired" not in warnings
+    assert "answer_tempered" not in warnings
     assert "CitationVerifier has not run yet" not in warnings
     assert "generation_unverified_citation_verifier_not_run" not in warnings
     assert "nu a fost verificat final de CitationVerifier" not in response.answer.short_answer
@@ -65,6 +70,8 @@ async def test_query_orchestrator_generates_grounded_draft_with_debug():
     assert response.debug.generation["evidence_unit_count_used"] == len(response.citations)
     assert set(response.debug.generation["citation_unit_ids"]) == citation_ids
     assert response.debug.verifier["claim_extraction"]["claims_total"] > 0
+    assert response.debug.answer_repair["repair_action"] == "none"
+    assert response.debug.answer_repair["warnings_added"] == []
 
 
 @pytest.mark.anyio
@@ -84,3 +91,4 @@ async def test_query_orchestrator_omits_generation_debug_when_debug_false():
     assert response.answer.confidence == 0.0
     assert response.verifier.citations_checked == len(response.citations)
     assert response.verifier.claims_total > 0
+    assert response.verifier.repair_applied is False


### PR DESCRIPTION
This pull request introduces an answer repair mechanism into the query orchestration pipeline, ensuring that generated answers and their associated citations are consistent with verifier results and evidence. It adds an `AnswerRepair` service that can refuse, temper, or repair answers based on the verification outcomes and evidence, and updates both the API and tests to reflect these changes. The debug information is also enhanced to provide detailed insights into any answer repair actions taken.

**Major changes:**

**Answer Repair Integration:**
- Added the `AnswerRepair` service to the `QueryOrchestrator`, which post-processes answers, citations, and verifier results to enforce consistency and handle unsupported, weakly supported, or unverifiable claims. The orchestrator now calls this repair step after verification and before returning results. [[1]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R14) [[2]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R43) [[3]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R57) [[4]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R109-R127) [[5]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3L138-R164)

**API & Schema Updates:**
- Extended the `QueryDebugData` schema to include an `answer_repair` field, allowing debug payloads to capture details of any answer repair actions. The orchestrator's debug output and notes are updated accordingly. [[1]](diffhunk://#diff-f14d76d4a4582f33ea6ddb2e237372a3e64bba18a9eab0c980af1af918190d63R253) [[2]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R145-R151)

**Test Enhancements:**
- Updated and expanded tests to check for answer repair behavior, including refusal reasons, repair actions, and warnings. New assertions verify that answers are appropriately refused or repaired, and that debug payloads reflect these changes. [[1]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L31-R44) [[2]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R108-R110) [[3]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R125) [[4]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L147-R157) [[5]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3L229-R248) [[6]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R285-R290) [[7]](diffhunk://#diff-57006dacd1db3c106f85c556524c4f65f0d0baaa9c2ad82e10bf751e4f5784c1R200-R201) [[8]](diffhunk://#diff-57006dacd1db3c106f85c556524c4f65f0d0baaa9c2ad82e10bf751e4f5784c1R210) [[9]](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330R59-R64) [[10]](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330R73-R74)

**Unit Tests for Answer Repair:**
- Added a comprehensive new test suite for the `AnswerRepair` logic, covering scenarios such as empty evidence, no legal claims, unsupported claims, weak support, and invalid citations.

These changes collectively improve the reliability and transparency of the answer generation pipeline by ensuring that only well-supported answers are returned, and that all repair actions are traceable in both the API response and debug output.
[Copilot is generating a summary...]