### PR TITLE
fix(api): require raw legal text for evidence packs

### DIFF
--- a/apps/api/app/services/evidence_pack_compiler.py
+++ b/apps/api/app/services/evidence_pack_compiler.py
@@ -19,6 +19,7 @@ from ..schemas import (
 EVIDENCE_PACK_NO_RANKED_CANDIDATES = "evidence_pack_no_ranked_candidates"
 EVIDENCE_PACK_PARTIAL = "evidence_pack_partial"
 EVIDENCE_PACK_MISSING_UNIT_TEXT = "evidence_pack_missing_unit_text"
+EVIDENCE_PACK_MISSING_UNIT_RAW_TEXT = "evidence_pack_missing_unit_raw_text"
 EVIDENCE_PACK_MISSING_UNIT_METADATA = "evidence_pack_missing_unit_metadata"
 
 SUPPORT_ROLES = (
@@ -199,13 +200,13 @@ class EvidencePackCompiler:
         warnings: list[str],
     ) -> list[_EvidenceCandidate]:
         pool: list[_EvidenceCandidate] = []
-        missing_text = False
+        missing_raw_text = False
         missing_metadata = False
         for ranked in ranked_candidates[: self.candidate_pool_size]:
             unit = ranked.unit or {}
             text = self._candidate_text(unit)
             if not unit or not text:
-                missing_text = True
+                missing_raw_text = True
                 continue
             if not self._has_required_metadata(unit):
                 missing_metadata = True
@@ -219,7 +220,8 @@ class EvidencePackCompiler:
                     why_selected=self._base_selection_reasons(ranked),
                 )
             )
-        if missing_text:
+        if missing_raw_text:
+            warnings.append(EVIDENCE_PACK_MISSING_UNIT_RAW_TEXT)
             warnings.append(EVIDENCE_PACK_MISSING_UNIT_TEXT)
         if missing_metadata:
             warnings.append(EVIDENCE_PACK_MISSING_UNIT_METADATA)
@@ -539,10 +541,9 @@ class EvidencePackCompiler:
         }
 
     def _candidate_text(self, unit: dict[str, Any]) -> str:
-        for key in ("raw_text", "normalized_text", "text"):
-            value = unit.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+        value = unit.get("raw_text")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
         return ""
 
     def _has_required_metadata(self, unit: dict[str, Any]) -> bool:

--- a/apps/api/app/services/query_orchestrator.py
+++ b/apps/api/app/services/query_orchestrator.py
@@ -26,7 +26,7 @@ from .graph_expansion_policy import GraphExpansionPolicy
 from .legal_ranker import LegalRanker
 from .mock_evidence import MockEvidenceService
 from .query_understanding import QueryUnderstanding
-from .raw_retriever_client import RawRetrieverClient
+from .raw_retriever_client import RAW_RETRIEVAL_NOT_CONFIGURED, RawRetrieverClient
 
 
 class QueryOrchestrator:
@@ -134,7 +134,7 @@ class QueryOrchestrator:
             debug = QueryDebugData(
                 orchestrator=self.__class__.__name__,
                 evidence_service=self.evidence_service.__class__.__name__,
-                retrieval_mode="mock_static_fixture",
+                retrieval_mode=self._retrieval_mode(raw_retrieval),
                 query_understanding=query_plan,
                 retrieval=raw_retrieval.debug,
                 graph_expansion=graph_expansion.debug,
@@ -322,6 +322,11 @@ class QueryOrchestrator:
             if value not in deduped:
                 deduped.append(value)
         return deduped
+
+    def _retrieval_mode(self, raw_retrieval) -> str:
+        if RAW_RETRIEVAL_NOT_CONFIGURED in raw_retrieval.warnings:
+            return "fallback_unconfigured"
+        return f"raw_retriever_client:{self.raw_retriever_client.__class__.__name__}"
 
     def _query_id(self, request: QueryRequest) -> str:
         stable_input = "|".join(

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -62,6 +62,7 @@ def test_post_api_query_debug_true_includes_debug_payload():
     debug = response.json()["debug"]
     assert debug["orchestrator"] == "QueryOrchestrator"
     assert debug["evidence_service"] == "MockEvidenceService"
+    assert debug["retrieval_mode"] == "fallback_unconfigured"
     assert debug["evidence_units_count"] == 0
     assert debug["query_understanding"]["legal_domain"] == "muncă"
     assert debug["query_understanding"]["domain_confidence"] >= 0.70
@@ -233,6 +234,7 @@ async def test_query_orchestrator_populates_evidence_units_with_fake_candidates(
     assert evidence_payload["score_breakdown"]
     assert response.graph.nodes
     assert response.debug.evidence_pack["fallback_used"] is False
+    assert response.debug.retrieval_mode == "raw_retriever_client:FakeRawRetrieverClient"
     assert response.debug.evidence_pack["selected_evidence_count"] == 1
     assert response.debug.generation["evidence_unit_count_used"] == 1
     assert response.citations == []

--- a/tests/test_evidence_pack_compiler.py
+++ b/tests/test_evidence_pack_compiler.py
@@ -4,6 +4,7 @@ from apps.api.app.schemas import (
     RankerFeatureBreakdown,
 )
 from apps.api.app.services.evidence_pack_compiler import (
+    EVIDENCE_PACK_MISSING_UNIT_RAW_TEXT,
     EVIDENCE_PACK_NO_RANKED_CANDIDATES,
     EvidencePackCompiler,
 )
@@ -53,6 +54,37 @@ def ranked(
     )
 
 
+def ranked_with_unit(unit_id: str, unit_payload: dict) -> RankedCandidate:
+    return RankedCandidate(
+        unit_id=unit_id,
+        rank=1,
+        rerank_score=0.8,
+        retrieval_score=0.7,
+        unit=unit_payload,
+        score_breakdown=RankerFeatureBreakdown(
+            bm25_score=0.8,
+            dense_score=0.8,
+            domain_match=1.0,
+            graph_proximity=0.0,
+        ),
+        why_ranked=["raw_text_safety_test"],
+        source="raw_retrieval",
+    )
+
+
+def citable_metadata(unit_id: str) -> dict:
+    return {
+        "id": unit_id,
+        "law_id": "ro.codul_muncii",
+        "law_title": "Codul muncii",
+        "legal_domain": "munca",
+        "status": "active",
+        "hierarchy_path": ["Codul muncii", unit_id],
+        "article_number": "41",
+        "type": "articol",
+    }
+
+
 def test_no_ranked_candidates_returns_safe_fallback():
     result = EvidencePackCompiler().compile(
         ranked_candidates=[],
@@ -66,6 +98,59 @@ def test_no_ranked_candidates_returns_safe_fallback():
     assert result.debug["fallback_used"] is True
     assert result.debug["input_ranked_candidate_count"] == 0
     assert result.debug["selected_evidence_count"] == 0
+
+
+def test_evidence_pack_requires_raw_text_for_citable_evidence():
+    unit_payload = {
+        **citable_metadata("ro.codul_muncii.art_no_raw"),
+        "normalized_text": "NU TREBUIE CITAT",
+        "text": "NU TREBUIE CITAT",
+    }
+
+    result = EvidencePackCompiler().compile(
+        ranked_candidates=[ranked_with_unit(unit_payload["id"], unit_payload)],
+        debug=True,
+    )
+
+    assert result.evidence_units == []
+    assert EVIDENCE_PACK_MISSING_UNIT_RAW_TEXT in result.warnings
+    assert "NU TREBUIE CITAT" not in str(result.model_dump(mode="json"))
+
+
+def test_evidence_pack_does_not_promote_normalized_text_to_raw_text():
+    unit_payload = {
+        **citable_metadata("ro.codul_muncii.art_empty_raw"),
+        "raw_text": "",
+        "normalized_text": "NU TREBUIE CITAT",
+    }
+
+    result = EvidencePackCompiler().compile(
+        ranked_candidates=[ranked_with_unit(unit_payload["id"], unit_payload)],
+        debug=True,
+    )
+
+    assert result.evidence_units == []
+    assert EVIDENCE_PACK_MISSING_UNIT_RAW_TEXT in result.warnings
+    assert result.debug["selected_evidence_count"] == 0
+
+
+def test_evidence_pack_uses_explicit_raw_text_when_present():
+    unit_payload = {
+        **citable_metadata("ro.codul_muncii.art_raw"),
+        "raw_text": "Text legal exact",
+        "normalized_text": "text normalizat",
+    }
+
+    result = EvidencePackCompiler(target_evidence_units=1).compile(
+        ranked_candidates=[ranked_with_unit(unit_payload["id"], unit_payload)],
+        debug=True,
+    )
+
+    assert len(result.evidence_units) == 1
+    evidence = result.evidence_units[0]
+    assert evidence.raw_text == "Text legal exact"
+    assert evidence.excerpt == "Text legal exact"
+    assert evidence.normalized_text == "text normalizat"
 
 
 def test_mmr_penalizes_redundant_text_and_diversifies_selection():

--- a/tests/test_handoff03_fixture_integration.py
+++ b/tests/test_handoff03_fixture_integration.py
@@ -202,6 +202,7 @@ async def test_query_orchestrator_returns_real_evidence_units_for_demo_fixture()
     assert response.verifier.groundedness_score > 0.0
     assert "mock" not in " ".join(response.verifier.warnings).lower()
     assert response.debug.retrieval["candidate_count"] >= 4
+    assert response.debug.retrieval_mode == "raw_retriever_client:FixtureRawRetriever"
     assert response.debug.evidence_pack["selected_evidence_count"] == 4
     assert response.debug.evidence_units_count == 4
     assert response.debug.citations_count == len(response.citations)

--- a/tests/test_query_orchestrator.py
+++ b/tests/test_query_orchestrator.py
@@ -1,7 +1,10 @@
 import pytest
 
-from apps.api.app.schemas import QueryRequest
-from apps.api.app.services.evidence_pack_compiler import EvidencePackCompiler
+from apps.api.app.schemas import QueryRequest, RawRetrievalResponse, RetrievalCandidate
+from apps.api.app.services.evidence_pack_compiler import (
+    EvidencePackCompiler,
+    EVIDENCE_PACK_MISSING_UNIT_RAW_TEXT,
+)
 from apps.api.app.services.graph_expansion_policy import GraphExpansionPolicy
 from apps.api.app.services.query_orchestrator import QueryOrchestrator
 from tests.helpers.fixture_handoff03 import (
@@ -24,6 +27,46 @@ def demo_orchestrator() -> QueryOrchestrator:
     )
 
 
+class NoRawTextRetriever:
+    async def retrieve(self, plan, *, top_k: int = 50, debug: bool = False):
+        return RawRetrievalResponse(
+            candidates=[
+                RetrievalCandidate(
+                    unit_id="ro.codul_muncii.art_no_raw",
+                    rank=1,
+                    retrieval_score=0.9,
+                    score_breakdown={"bm25": 0.9, "dense": 0.8},
+                    why_retrieved="unit_without_raw_text",
+                    unit={
+                        "id": "ro.codul_muncii.art_no_raw",
+                        "law_id": "ro.codul_muncii",
+                        "law_title": "Codul muncii",
+                        "status": "active",
+                        "hierarchy_path": ["Codul muncii", "art. no raw"],
+                        "article_number": "41",
+                        "normalized_text": "NU TREBUIE CITAT",
+                        "text": "NU TREBUIE CITAT",
+                        "legal_domain": "munca",
+                        "type": "articol",
+                    },
+                )
+            ],
+            retrieval_methods=["fixture_missing_raw_text"],
+            warnings=[],
+            debug={
+                "fallback_used": False,
+                "candidate_count": 1,
+                "request_payload": {
+                    "question": plan.question,
+                    "top_k": top_k,
+                    "debug": debug,
+                },
+            }
+            if debug
+            else None,
+        )
+
+
 @pytest.mark.anyio
 async def test_query_orchestrator_generates_grounded_draft_with_debug():
     response = await demo_orchestrator().run(
@@ -41,6 +84,7 @@ async def test_query_orchestrator_generates_grounded_draft_with_debug():
     assert response.answer.short_answer
     assert response.answer.confidence == 0.0
     assert response.answer.refusal_reason is None
+    assert response.debug.retrieval_mode == "raw_retriever_client:FixtureRawRetriever"
     assert response.evidence_units
     assert response.citations
     assert citation_ids <= evidence_ids
@@ -72,6 +116,34 @@ async def test_query_orchestrator_generates_grounded_draft_with_debug():
     assert response.debug.verifier["claim_extraction"]["claims_total"] > 0
     assert response.debug.answer_repair["repair_action"] == "none"
     assert response.debug.answer_repair["warnings_added"] == []
+
+
+@pytest.mark.anyio
+async def test_query_orchestrator_refuses_when_retriever_returns_unit_without_raw_text():
+    response = await QueryOrchestrator(
+        raw_retriever_client=NoRawTextRetriever(),
+    ).run(
+        QueryRequest(
+            question=DEMO_QUERY_WITH_DIACRITICS,
+            jurisdiction="RO",
+            date="current",
+            mode="strict_citations",
+            debug=True,
+        )
+    )
+
+    assert response.evidence_units == []
+    assert response.citations == []
+    assert response.answer.refusal_reason == "insufficient_evidence"
+    assert response.verifier.verifier_passed is False
+    assert response.verifier.repair_applied is True
+    assert EVIDENCE_PACK_MISSING_UNIT_RAW_TEXT in response.warnings
+    assert "generation_insufficient_evidence" in response.warnings
+    assert "NU TREBUIE CITAT" not in response.answer.short_answer
+    assert response.debug.retrieval_mode == "raw_retriever_client:NoRawTextRetriever"
+    assert response.debug.evidence_pack["selected_evidence_count"] == 0
+    assert response.debug.generation["generation_mode"] == "deterministic_extractive_v1_insufficient_evidence"
+    assert response.debug.answer_repair["repair_action"] == "refused_insufficient_evidence"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
This pull request strengthens the requirements for evidence units used in legal citations by enforcing that only units containing explicit `raw_text` are eligible for inclusion. It updates the evidence pack compilation logic, improves debug reporting for retrieval modes, and adds comprehensive tests to ensure units without `raw_text` are excluded and properly flagged. The changes also enhance the transparency of retrieval and evidence selection in debug output.

**Evidence Unit Requirements and Compilation:**
- Evidence units must now have a non-empty `raw_text` field to be considered for citation; units with only `normalized_text` or `text` are excluded. A new warning code, `EVIDENCE_PACK_MISSING_UNIT_RAW_TEXT`, is issued when such units are encountered. (`apps/api/app/services/evidence_pack_compiler.py` [[1]](diffhunk://#diff-0efe9114b7002ccddc52d4ca020e7e8edbd56e38eb0eba999a839acf38d0e3aaR22) [[2]](diffhunk://#diff-0efe9114b7002ccddc52d4ca020e7e8edbd56e38eb0eba999a839acf38d0e3aaL202-R209) [[3]](diffhunk://#diff-0efe9114b7002ccddc52d4ca020e7e8edbd56e38eb0eba999a839acf38d0e3aaL222-R224) [[4]](diffhunk://#diff-0efe9114b7002ccddc52d4ca020e7e8edbd56e38eb0eba999a839acf38d0e3aaL542-R544)
- The `_candidate_text` method is simplified to only consider `raw_text`, removing fallback to `normalized_text` or `text`. (`apps/api/app/services/evidence_pack_compiler.py` [apps/api/app/services/evidence_pack_compiler.pyL542-R544](diffhunk://#diff-0efe9114b7002ccddc52d4ca020e7e8edbd56e38eb0eba999a839acf38d0e3aaL542-R544))

**Debugging and Retrieval Reporting:**
- The orchestrator's debug output now includes a `retrieval_mode` field that indicates the retrieval backend and whether a fallback was used. This is determined based on warnings and the retriever client in use. (`apps/api/app/services/query_orchestrator.py` [[1]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3L29-R29) [[2]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3L137-R137) [[3]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R326-R330)
- Tests are updated to assert the correct `retrieval_mode` is reported in debug output for various scenarios. (`tests/api/test_query.py` [[1]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R65) [[2]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R237) `tests/test_handoff03_fixture_integration.py` [[3]](diffhunk://#diff-57006dacd1db3c106f85c556524c4f65f0d0baaa9c2ad82e10bf751e4f5784c1R205) `tests/test_query_orchestrator.py` [[4]](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330R87)

**Testing and Validation:**
- Extensive new tests verify that evidence units without `raw_text` are excluded, appropriate warnings are issued, and no accidental promotion of `normalized_text` or `text` occurs. These tests cover both the compiler and the orchestrator. (`tests/test_evidence_pack_compiler.py` [[1]](diffhunk://#diff-bc179239c9fa4a1dac16a9f10cdad18a9dba7ddbd6f482a63fa15fda801b5df6R7) [[2]](diffhunk://#diff-bc179239c9fa4a1dac16a9f10cdad18a9dba7ddbd6f482a63fa15fda801b5df6R57-R87) [[3]](diffhunk://#diff-bc179239c9fa4a1dac16a9f10cdad18a9dba7ddbd6f482a63fa15fda801b5df6R103-R155) `tests/test_query_orchestrator.py` [[4]](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330L3-R7) [[5]](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330R30-R69) [[6]](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330R121-R148)
- A mock retriever is added to simulate retrieval of units lacking `raw_text` for orchestrator tests. (`tests/test_query_orchestrator.py` [tests/test_query_orchestrator.pyR30-R69](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330R30-R69))

These changes ensure that only legally citable, original text is used for evidence, improve traceability in debugging, and provide robust test coverage for these requirements.