### PR TITLE
feat(ingestion): add offline embeddings job infrastructure

### DIFF
--- a/ingestion/embeddings.py
+++ b/ingestion/embeddings.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+from ingestion.chunks import stable_text_hash
+from ingestion.contracts import EmbeddingInputRecord
+
+
+ResumeKey = tuple[str, str, str]
+T = TypeVar("T")
+
+
+class EmbeddingOutputRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    record_id: str
+    chunk_id: str
+    legal_unit_id: str
+    law_id: str
+    model_name: str
+    embedding_dim: int = Field(gt=0)
+    text_hash: str
+    embedding: list[float]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("embedding", mode="before")
+    @classmethod
+    def validate_embedding_values(cls, value: Any) -> list[float]:
+        return validate_embedding_vector(value)
+
+    @model_validator(mode="after")
+    def validate_embedding_dim_matches_vector(self) -> "EmbeddingOutputRecord":
+        validate_embedding_vector(self.embedding, expected_dim=self.embedding_dim)
+        return self
+
+
+class EmbeddingJobSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    read_count: int = 0
+    written_count: int = 0
+    skipped_empty_text_count: int = 0
+    skipped_resume_count: int = 0
+    failed_count: int = 0
+    embedding_dim: int | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class EmbeddingProvider(Protocol):
+    def embed_texts(self, texts: list[str], model_name: str) -> list[list[float]]:
+        ...
+
+
+class DeterministicFakeEmbeddingProvider:
+    def __init__(self, dimension: int = 4):
+        if dimension <= 0:
+            raise ValueError("dimension must be greater than 0")
+        self.dimension = dimension
+        self.received_texts: list[str] = []
+
+    def embed_texts(self, texts: list[str], model_name: str) -> list[list[float]]:
+        self.received_texts.extend(texts)
+        return [
+            _deterministic_vector(text, model_name=model_name, dimension=self.dimension)
+            for text in texts
+        ]
+
+
+@dataclass(frozen=True)
+class EmbeddingJobCandidate:
+    record: EmbeddingInputRecord
+    embedding_text_length: int
+
+
+def load_embedding_input_jsonl(path: str | Path) -> list[EmbeddingInputRecord]:
+    resolved_path = Path(path)
+    records: list[EmbeddingInputRecord] = []
+    for line_number, line in enumerate(
+        resolved_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{resolved_path}:{line_number} invalid JSON") from exc
+        if not isinstance(value, dict):
+            raise ValueError(f"{resolved_path}:{line_number} must contain a JSON object")
+        try:
+            records.append(_validate_embedding_input_record(value))
+        except ValidationError as exc:
+            raise ValueError(
+                f"{resolved_path}:{line_number} invalid EmbeddingInputRecord"
+            ) from exc
+    return records
+
+
+def load_embedding_output_jsonl(path: str | Path) -> list[EmbeddingOutputRecord]:
+    resolved_path = Path(path)
+    if not resolved_path.exists():
+        return []
+
+    records: list[EmbeddingOutputRecord] = []
+    for line_number, line in enumerate(
+        resolved_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{resolved_path}:{line_number} invalid JSON") from exc
+        if not isinstance(value, dict):
+            raise ValueError(f"{resolved_path}:{line_number} must contain a JSON object")
+        try:
+            records.append(EmbeddingOutputRecord.model_validate(value))
+        except ValidationError as exc:
+            raise ValueError(
+                f"{resolved_path}:{line_number} invalid EmbeddingOutputRecord"
+            ) from exc
+    return records
+
+
+def write_embedding_output_jsonl(
+    records: list[EmbeddingOutputRecord],
+    path: str | Path,
+    *,
+    append: bool = False,
+) -> None:
+    resolved_path = Path(path)
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    mode = "a" if append else "w"
+    with resolved_path.open(mode, encoding="utf-8", newline="\n") as output_file:
+        for record in records:
+            output_file.write(
+                json.dumps(
+                    record.model_dump(),
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+                + "\n"
+            )
+
+
+def read_existing_resume_keys(path: str | Path) -> set[ResumeKey]:
+    return {
+        output_resume_key(record)
+        for record in load_embedding_output_jsonl(path)
+    }
+
+
+def validate_embedding_vector(
+    vector: Any,
+    *,
+    expected_dim: int | None = None,
+) -> list[float]:
+    if expected_dim is not None and expected_dim <= 0:
+        raise ValueError("expected_dim must be greater than 0")
+    if not isinstance(vector, list):
+        raise ValueError("embedding vector must be a list")
+    if not vector:
+        raise ValueError("embedding vector must be non-empty")
+    if expected_dim is not None and len(vector) != expected_dim:
+        raise ValueError(
+            f"embedding vector dimension mismatch: expected {expected_dim}, got {len(vector)}"
+        )
+
+    values: list[float] = []
+    for index, value in enumerate(vector):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"embedding vector item {index} must be an int or float")
+        float_value = float(value)
+        if not math.isfinite(float_value):
+            raise ValueError(f"embedding vector item {index} must be finite")
+        values.append(float_value)
+    return values
+
+
+def iter_batches(items: list[T], batch_size: int) -> Iterator[list[T]]:
+    if batch_size <= 0:
+        raise ValueError("batch_size must be greater than 0")
+    for index in range(0, len(items), batch_size):
+        yield items[index : index + batch_size]
+
+
+def input_resume_key(record: EmbeddingInputRecord, model_name: str) -> ResumeKey:
+    return (record.record_id, record.text_hash, model_name)
+
+
+def output_resume_key(record: EmbeddingOutputRecord) -> ResumeKey:
+    return (record.record_id, record.text_hash, record.model_name)
+
+
+def generate_embeddings(
+    *,
+    input_path: str | Path,
+    output_path: str | Path,
+    provider: EmbeddingProvider,
+    model_name: str,
+    batch_size: int = 100,
+    expected_dim: int | None = None,
+    resume: bool = False,
+    dry_run: bool = False,
+    limit: int | None = None,
+) -> EmbeddingJobSummary:
+    if batch_size <= 0:
+        raise ValueError("batch_size must be greater than 0")
+    if expected_dim is not None and expected_dim <= 0:
+        raise ValueError("expected_dim must be greater than 0")
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be greater than or equal to 0")
+    if not model_name.strip():
+        raise ValueError("model_name must be non-empty")
+
+    input_records = load_embedding_input_jsonl(input_path)
+    warnings: list[str] = []
+    existing_keys = read_existing_resume_keys(output_path) if resume else set()
+
+    candidates: list[EmbeddingJobCandidate] = []
+    skipped_empty_text_count = 0
+    skipped_resume_count = 0
+    for record in input_records:
+        embedding_text_length = len(record.embedding_text)
+        log_context = _record_log_context(record, embedding_text_length)
+
+        if not record.embedding_text.strip():
+            skipped_empty_text_count += 1
+            warnings.append(f"skipped empty embedding_text {log_context}")
+            continue
+
+        if stable_text_hash(record.embedding_text) != record.text_hash:
+            warnings.append(f"text_hash mismatch {log_context}")
+
+        if resume and input_resume_key(record, model_name) in existing_keys:
+            skipped_resume_count += 1
+            continue
+
+        candidates.append(
+            EmbeddingJobCandidate(
+                record=record,
+                embedding_text_length=embedding_text_length,
+            )
+        )
+
+    if limit is not None:
+        candidates = candidates[:limit]
+
+    summary = EmbeddingJobSummary(
+        read_count=len(input_records),
+        written_count=0,
+        skipped_empty_text_count=skipped_empty_text_count,
+        skipped_resume_count=skipped_resume_count,
+        failed_count=0,
+        embedding_dim=expected_dim,
+        warnings=warnings,
+    )
+    if dry_run:
+        return summary
+
+    output_records: list[EmbeddingOutputRecord] = []
+    resolved_dim = expected_dim
+    for batch in iter_batches(candidates, batch_size):
+        texts = [candidate.record.embedding_text for candidate in batch]
+        vectors = provider.embed_texts(texts, model_name)
+        if len(vectors) != len(batch):
+            raise RuntimeError(
+                "embedding provider returned a different number of vectors "
+                f"than requested: expected {len(batch)}, got {len(vectors)}"
+            )
+
+        for candidate, vector in zip(batch, vectors):
+            if resolved_dim is None:
+                validated_vector = validate_embedding_vector(vector)
+                resolved_dim = len(validated_vector)
+            else:
+                validated_vector = validate_embedding_vector(
+                    vector,
+                    expected_dim=resolved_dim,
+                )
+            record = candidate.record
+            output_records.append(
+                EmbeddingOutputRecord(
+                    record_id=record.record_id,
+                    chunk_id=record.chunk_id,
+                    legal_unit_id=record.legal_unit_id,
+                    law_id=record.law_id,
+                    model_name=model_name,
+                    embedding_dim=resolved_dim,
+                    text_hash=record.text_hash,
+                    embedding=validated_vector,
+                    metadata=dict(record.metadata),
+                )
+            )
+
+    append = resume and Path(output_path).exists()
+    write_embedding_output_jsonl(output_records, output_path, append=append)
+
+    return summary.model_copy(
+        update={
+            "written_count": len(output_records),
+            "embedding_dim": resolved_dim,
+        }
+    )
+
+
+def _validate_embedding_input_record(value: dict[str, Any]) -> EmbeddingInputRecord:
+    embedding_text = value.get("embedding_text")
+    if embedding_text == "":
+        validation_value = dict(value)
+        validation_value["embedding_text"] = " "
+        record = EmbeddingInputRecord.model_validate(validation_value)
+        return record.model_copy(update={"embedding_text": ""})
+    return EmbeddingInputRecord.model_validate(value)
+
+
+def _record_log_context(record: EmbeddingInputRecord, embedding_text_length: int) -> str:
+    return (
+        f"record_id={record.record_id} "
+        f"chunk_id={record.chunk_id} "
+        f"legal_unit_id={record.legal_unit_id} "
+        f"text_hash={record.text_hash} "
+        f"embedding_text_length={embedding_text_length}"
+    )
+
+
+def _deterministic_vector(
+    text: str,
+    *,
+    model_name: str,
+    dimension: int,
+) -> list[float]:
+    seed = f"{model_name}\0{text}".encode("utf-8")
+    values: list[float] = []
+    for index in range(dimension):
+        digest = hashlib.sha256(seed + index.to_bytes(4, "big")).digest()
+        integer_value = int.from_bytes(digest[:8], "big")
+        values.append(integer_value / float(2**64 - 1))
+    return values

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -1,70 +1,71 @@
+from __future__ import annotations
+
 import argparse
 import json
-import hashlib
-from pathlib import Path
 import sys
+from pathlib import Path
 
-# Allow running as `python scripts/generate_embeddings.py` from the repo root
+# Allow running as `python scripts/generate_embeddings.py` from the repo root.
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from ingestion.embedding_service import MockEmbeddingProvider, build_embedding_text
+from ingestion.embeddings import (  # noqa: E402
+    DeterministicFakeEmbeddingProvider,
+    generate_embeddings,
+)
 
-def get_text_hash(text: str) -> str:
-    return hashlib.sha256(text.encode('utf-8')).hexdigest()
 
-def main():
-    parser = argparse.ArgumentParser(description="Generate embeddings for legal units")
-    parser.add_argument("--input", required=True, help="Path to legal_units.json")
-    parser.add_argument("--out", required=True, help="Path to output embeddings.import.jsonl")
-    parser.add_argument("--model", required=True, help="Model name")
-    
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate chunk-based embedding output JSONL from embeddings_input.jsonl"
+    )
+    parser.add_argument("--input", required=True, help="Path to embeddings_input.jsonl")
+    parser.add_argument("--output", required=True, help="Path to embeddings_output.jsonl")
+    parser.add_argument(
+        "--provider",
+        default="fake",
+        choices=["fake", "openai-compatible"],
+        help="Embedding provider to use",
+    )
+    parser.add_argument("--model", required=True, help="Embedding model name")
+    parser.add_argument("--batch-size", type=int, default=100)
+    parser.add_argument("--expected-dim", type=int, default=None)
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--limit", type=int, default=None)
+    return parser
+
+
+def main() -> None:
+    parser = _build_arg_parser()
     args = parser.parse_args()
-    
-    input_path = Path(args.input)
-    out_path = Path(args.out)
-    
-    # Try to load manifest for metadata
-    manifest_path = input_path.parent / "corpus_manifest.json"
-    corpus_metadata = {}
-    if manifest_path.exists():
-        with open(manifest_path, "r", encoding="utf-8") as f:
-            manifest = json.load(f)
-            for source in manifest.get("sources", []):
-                corpus_metadata[source["law_id"]] = {
-                    "law_title": source.get("law_title", ""),
-                    "legal_domain": source.get("legal_domain", "")
-                }
-    else:
-        print(f"Warning: Manifest not found at {manifest_path}. Metadata will be missing.")
-    
-    with open(input_path, "r", encoding="utf-8") as f:
-        units = json.load(f)
-        
-    provider = MockEmbeddingProvider(dimension=1024)
-    
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    
-    batch_size = 100
-    
-    with open(out_path, "w", encoding="utf-8") as out_f:
-        for i in range(0, len(units), batch_size):
-            batch_units = units[i:i+batch_size]
-            texts = [build_embedding_text(u, corpus_metadata) for u in batch_units]
-            embeddings = provider.embed_texts(texts)
-            
-            for j, unit in enumerate(batch_units):
-                text_hash = get_text_hash(texts[j])
-                record = {
-                    "unit_id": unit["id"],
-                    "model_name": args.model,
-                    "embedding_dim": 1024,
-                    "text_hash": text_hash,
-                    "embedding": embeddings[j]
-                }
-                out_f.write(json.dumps(record, ensure_ascii=False) + "\n")
-                
-    print(f"Generated {len(units)} embeddings to {out_path}")
+
+    if args.provider == "openai-compatible":
+        parser.error(
+            "openai-compatible provider is not implemented in Phase 1; use next H07 phase"
+        )
+
+    provider = DeterministicFakeEmbeddingProvider(
+        dimension=args.expected_dim if args.expected_dim is not None else 1024
+    )
+    try:
+        summary = generate_embeddings(
+            input_path=Path(args.input),
+            output_path=Path(args.output),
+            provider=provider,
+            model_name=args.model,
+            batch_size=args.batch_size,
+            expected_dim=args.expected_dim,
+            resume=args.resume,
+            dry_run=args.dry_run,
+            limit=args.limit,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(f"[generate-embeddings] {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps(summary.model_dump(), ensure_ascii=False, indent=2))
+
 
 if __name__ == "__main__":
     main()

--- a/tests/ingestion/test_embeddings_job.py
+++ b/tests/ingestion/test_embeddings_job.py
@@ -1,0 +1,305 @@
+import json
+
+import pytest
+
+from ingestion.chunks import stable_text_hash
+from ingestion.embeddings import (
+    DeterministicFakeEmbeddingProvider,
+    generate_embeddings,
+)
+
+
+class StaticEmbeddingProvider:
+    def __init__(self, vectors):
+        self.vectors = vectors
+        self.received_texts = []
+
+    def embed_texts(self, texts: list[str], model_name: str) -> list[list[float]]:
+        self.received_texts.extend(texts)
+        return self.vectors
+
+
+def test_valid_jsonl_writes_chunk_based_embedding_output(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    records = [
+        _input_record("1", embedding_text="Retrieval text 1"),
+        _input_record("2", embedding_text="Retrieval text 2"),
+    ]
+    _write_jsonl(input_path, records)
+
+    provider = DeterministicFakeEmbeddingProvider(dimension=4)
+    summary = generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=provider,
+        model_name="fake-model",
+        batch_size=2,
+        expected_dim=4,
+    )
+
+    output_records = _read_jsonl(output_path)
+    assert summary.read_count == 2
+    assert summary.written_count == 2
+    assert summary.embedding_dim == 4
+    assert len(output_records) == 2
+    assert output_records[0]["record_id"] == records[0]["record_id"]
+    assert output_records[0]["chunk_id"] == records[0]["chunk_id"]
+    assert output_records[0]["legal_unit_id"] == records[0]["legal_unit_id"]
+    assert output_records[0]["law_id"] == records[0]["law_id"]
+    assert output_records[0]["model_name"] == "fake-model"
+    assert output_records[0]["embedding_dim"] == 4
+    assert output_records[0]["text_hash"] == records[0]["text_hash"]
+    assert "unit_id" not in output_records[0]
+    assert len(output_records[0]["embedding"]) == 4
+    assert all(isinstance(value, float) for value in output_records[0]["embedding"])
+
+
+def test_provider_receives_embedding_text_not_citable_text(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    record = _input_record(
+        "1",
+        text="LegalUnit.raw_text citable source",
+        embedding_text="LegalChunk.embedding_text retrieval only",
+    )
+    _write_jsonl(input_path, [record])
+
+    provider = DeterministicFakeEmbeddingProvider(dimension=4)
+    generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=provider,
+        model_name="fake-model",
+        expected_dim=4,
+    )
+
+    assert provider.received_texts == ["LegalChunk.embedding_text retrieval only"]
+
+
+def test_empty_embedding_text_is_skipped_with_warning(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    record = _input_record("1", embedding_text="", text_hash=stable_text_hash(""))
+    _write_jsonl(input_path, [record])
+
+    provider = DeterministicFakeEmbeddingProvider(dimension=4)
+    summary = generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=provider,
+        model_name="fake-model",
+        expected_dim=4,
+    )
+
+    assert summary.read_count == 1
+    assert summary.written_count == 0
+    assert summary.skipped_empty_text_count == 1
+    assert provider.received_texts == []
+    assert "skipped empty embedding_text" in summary.warnings[0]
+    assert "record_id=embedding.chunk.ro.test.1.0" in summary.warnings[0]
+    assert "embedding_text_length=0" in summary.warnings[0]
+    assert output_path.read_text(encoding="utf-8") == ""
+
+
+def test_expected_dim_mismatch_fails_explicitly(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [_input_record("1", embedding_text="Retrieval text")])
+
+    provider = DeterministicFakeEmbeddingProvider(dimension=3)
+    with pytest.raises(ValueError, match="dimension mismatch"):
+        generate_embeddings(
+            input_path=input_path,
+            output_path=output_path,
+            provider=provider,
+            model_name="fake-model",
+            expected_dim=4,
+        )
+
+    assert not output_path.exists()
+
+
+def test_expected_dim_absent_is_deduced_from_first_valid_vector(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            _input_record("1", embedding_text="Retrieval text 1"),
+            _input_record("2", embedding_text="Retrieval text 2"),
+        ],
+    )
+
+    provider = DeterministicFakeEmbeddingProvider(dimension=5)
+    summary = generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=provider,
+        model_name="fake-model",
+        expected_dim=None,
+    )
+
+    output_records = _read_jsonl(output_path)
+    assert summary.embedding_dim == 5
+    assert [record["embedding_dim"] for record in output_records] == [5, 5]
+    assert [len(record["embedding"]) for record in output_records] == [5, 5]
+
+
+def test_resume_does_not_duplicate_existing_output(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [_input_record("1", embedding_text="Retrieval text")])
+
+    first_provider = DeterministicFakeEmbeddingProvider(dimension=4)
+    generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=first_provider,
+        model_name="fake-model",
+        expected_dim=4,
+    )
+
+    second_provider = DeterministicFakeEmbeddingProvider(dimension=4)
+    summary = generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=second_provider,
+        model_name="fake-model",
+        expected_dim=4,
+        resume=True,
+    )
+
+    assert summary.read_count == 1
+    assert summary.written_count == 0
+    assert summary.skipped_resume_count == 1
+    assert second_provider.received_texts == []
+    assert len(_read_jsonl(output_path)) == 1
+
+
+def test_dry_run_does_not_call_provider_or_write_output(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [_input_record("1", embedding_text="Retrieval text")])
+
+    provider = DeterministicFakeEmbeddingProvider(dimension=4)
+    summary = generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=provider,
+        model_name="fake-model",
+        expected_dim=4,
+        dry_run=True,
+    )
+
+    assert summary.read_count == 1
+    assert summary.written_count == 0
+    assert provider.received_texts == []
+    assert not output_path.exists()
+
+
+def test_job_does_not_require_database_url(tmp_path, monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [_input_record("1", embedding_text="Retrieval text")])
+
+    provider = DeterministicFakeEmbeddingProvider(dimension=4)
+    summary = generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=provider,
+        model_name="fake-model",
+        expected_dim=4,
+    )
+
+    assert summary.written_count == 1
+
+
+def test_output_preserves_identity_hash_and_metadata(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    record = _input_record(
+        "1",
+        embedding_text="Retrieval text",
+        metadata={"retrieval_text_is_citable": False, "source": "unit-test"},
+    )
+    _write_jsonl(input_path, [record])
+
+    provider = DeterministicFakeEmbeddingProvider(dimension=4)
+    generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=provider,
+        model_name="fake-model",
+        expected_dim=4,
+    )
+
+    output_record = _read_jsonl(output_path)[0]
+    for key in ("record_id", "chunk_id", "legal_unit_id", "law_id", "text_hash"):
+        assert output_record[key] == record[key]
+    assert output_record["metadata"] == record["metadata"]
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [
+        [float("nan")],
+        [float("inf")],
+        ["not-a-number"],
+        [True],
+    ],
+)
+def test_invalid_vector_values_fail_validation(tmp_path, vector):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [_input_record("1", embedding_text="Retrieval text")])
+
+    provider = StaticEmbeddingProvider([vector])
+    with pytest.raises(ValueError):
+        generate_embeddings(
+            input_path=input_path,
+            output_path=output_path,
+            provider=provider,
+            model_name="fake-model",
+        )
+
+    assert not output_path.exists()
+
+
+def _input_record(
+    suffix: str,
+    *,
+    text: str = "LegalUnit.raw_text",
+    embedding_text: str = "LegalChunk.embedding_text",
+    text_hash: str | None = None,
+    metadata: dict | None = None,
+) -> dict:
+    if text_hash is None:
+        text_hash = stable_text_hash(embedding_text)
+    return {
+        "record_id": f"embedding.chunk.ro.test.{suffix}.0",
+        "chunk_id": f"chunk.ro.test.{suffix}.0",
+        "legal_unit_id": f"ro.test.{suffix}",
+        "law_id": "ro.test",
+        "text": text,
+        "embedding_text": embedding_text,
+        "text_hash": text_hash,
+        "model_hint": None,
+        "metadata": metadata or {},
+    }
+
+
+def _write_jsonl(path, records: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _read_jsonl(path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]


### PR DESCRIPTION
This pull request introduces a new, robust chunk-based embedding pipeline for legal units. The main changes include the implementation of a new `ingestion/embeddings.py` module, a complete rewrite of the embedding generation script to use this new pipeline, and a comprehensive test suite to validate the embedding job's correctness and reliability. The new system emphasizes strong validation, resumable jobs, and clear separation of input/output records.

**Major changes:**

**Embedding pipeline implementation:**

* Added a new `ingestion/embeddings.py` module that defines the core embedding job logic, including:
  - Data models for input/output embedding records and job summaries using Pydantic.
  - Batch processing, strong validation of embedding vectors, resumable job support, and deterministic fake provider for testing.

**Script rewrite:**

* Rewrote `scripts/generate_embeddings.py` to use the new embedding pipeline, providing a CLI interface with options for provider, batch size, resume, dry run, and more. The script now uses the new deterministic fake provider and robust error handling.

**Testing:**

* Added `tests/ingestion/test_embeddings_job.py` with comprehensive tests covering correct output, provider usage, skipping logic, error handling, resuming, dry runs, and validation of vector values.

These changes modernize and standardize the embedding generation workflow, making it easier to maintain, test, and extend for future phases.