### PR TITLE
feat(h07): add openai-compatible embedding provider

### DIFF
--- a/ingestion/embeddings.py
+++ b/ingestion/embeddings.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, TypeVar
+from typing import Any, Callable, Protocol, TypeVar
 
+import httpx
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from ingestion.chunks import stable_text_hash
@@ -72,6 +74,113 @@ class DeterministicFakeEmbeddingProvider:
             _deterministic_vector(text, model_name=model_name, dimension=self.dimension)
             for text in texts
         ]
+
+
+class OpenAICompatibleEmbeddingProvider:
+    RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+    RETRYABLE_EXCEPTIONS = (httpx.TimeoutException, httpx.NetworkError)
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        timeout_seconds: float = 60.0,
+        max_retries: int = 2,
+        *,
+        transport: httpx.BaseTransport | None = None,
+        sleep_func: Callable[[float], None] = time.sleep,
+    ):
+        normalized_base_url = str(base_url or "").strip().rstrip("/")
+        if not normalized_base_url:
+            raise ValueError("base URL missing: base_url must be non-empty")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be greater than 0")
+        if max_retries < 0:
+            raise ValueError("max_retries must be greater than or equal to 0")
+
+        self.base_url = normalized_base_url
+        self.api_key = api_key
+        self.timeout_seconds = timeout_seconds
+        self.max_retries = max_retries
+        self.embedding_url = f"{self.base_url}/embeddings"
+        self._transport = transport
+        self._sleep = sleep_func
+
+    def embed_texts(self, texts: list[str], model_name: str) -> list[list[float]]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        payload = {"model": model_name, "input": texts}
+
+        with httpx.Client(
+            timeout=self.timeout_seconds,
+            transport=self._transport,
+        ) as client:
+            response = self._post_with_retries(client, headers=headers, payload=payload)
+        return self._parse_embedding_response(response, expected_count=len(texts))
+
+    def _post_with_retries(
+        self,
+        client: httpx.Client,
+        *,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> httpx.Response:
+        last_retryable_error: Exception | None = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = client.post(self.embedding_url, headers=headers, json=payload)
+            except self.RETRYABLE_EXCEPTIONS as exc:
+                last_retryable_error = exc
+                if attempt < self.max_retries:
+                    self._sleep(_retry_delay_seconds(attempt))
+                    continue
+                raise RuntimeError(
+                    "embedding provider request failed after retries: "
+                    f"{exc.__class__.__name__}"
+                ) from exc
+
+            if response.status_code in self.RETRYABLE_STATUS_CODES and attempt < self.max_retries:
+                self._sleep(_retry_delay_seconds(attempt))
+                continue
+            if response.status_code < 200 or response.status_code >= 300:
+                raise RuntimeError(
+                    "embedding provider HTTP status "
+                    f"{response.status_code}: {_response_reason(response)}"
+                )
+            return response
+
+        if last_retryable_error is not None:
+            raise RuntimeError(
+                "embedding provider request failed after retries: "
+                f"{last_retryable_error.__class__.__name__}"
+            ) from last_retryable_error
+        raise RuntimeError("embedding provider request failed after retries")
+
+    def _parse_embedding_response(
+        self,
+        response: httpx.Response,
+        *,
+        expected_count: int,
+    ) -> list[list[float]]:
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ValueError("malformed response: invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ValueError("malformed response: root must be a JSON object")
+
+        data = payload.get("data")
+        if not isinstance(data, list):
+            raise ValueError("malformed response: data must be a list")
+
+        embeddings = _parse_openai_embedding_data(data)
+        if len(embeddings) != expected_count:
+            raise ValueError(
+                "embedding count mismatch: "
+                f"expected {expected_count}, got {len(embeddings)}"
+            )
+        return embeddings
 
 
 @dataclass(frozen=True)
@@ -346,3 +455,41 @@ def _deterministic_vector(
         integer_value = int.from_bytes(digest[:8], "big")
         values.append(integer_value / float(2**64 - 1))
     return values
+
+
+def _parse_openai_embedding_data(data: list[Any]) -> list[list[float]]:
+    has_any_index = any(isinstance(item, dict) and "index" in item for item in data)
+    has_all_index = all(isinstance(item, dict) and "index" in item for item in data)
+    if has_any_index and not has_all_index:
+        raise ValueError(
+            "malformed response: index must be present for every embedding item or absent for all"
+        )
+
+    items = list(data)
+    if has_all_index:
+        for item in items:
+            if isinstance(item.get("index"), bool) or not isinstance(item.get("index"), int):
+                raise ValueError("malformed response: index must be an integer")
+        items = sorted(items, key=lambda item: item["index"])
+
+    embeddings: list[list[float]] = []
+    for item_index, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise ValueError("malformed response: data items must be JSON objects")
+        if "embedding" not in item:
+            raise ValueError("malformed response: data item missing embedding")
+        try:
+            embeddings.append(validate_embedding_vector(item["embedding"]))
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid vector in embedding response at data item {item_index}: {exc}"
+            ) from exc
+    return embeddings
+
+
+def _retry_delay_seconds(attempt: int) -> float:
+    return 0.5 * (2**attempt)
+
+
+def _response_reason(response: httpx.Response) -> str:
+    return response.reason_phrase or "HTTP error"

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -11,6 +12,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from ingestion.embeddings import (  # noqa: E402
     DeterministicFakeEmbeddingProvider,
+    OpenAICompatibleEmbeddingProvider,
     generate_embeddings,
 )
 
@@ -30,6 +32,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--model", required=True, help="Embedding model name")
     parser.add_argument("--batch-size", type=int, default=100)
     parser.add_argument("--expected-dim", type=int, default=None)
+    parser.add_argument("--base-url", default=None, help="OpenAI-compatible base URL")
+    parser.add_argument("--api-key-env", default=None, help="Environment variable holding the API key")
+    parser.add_argument("--timeout-seconds", type=float, default=60.0)
+    parser.add_argument("--max-retries", type=int, default=2)
     parser.add_argument("--resume", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--limit", type=int, default=None)
@@ -39,15 +45,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 def main() -> None:
     parser = _build_arg_parser()
     args = parser.parse_args()
-
-    if args.provider == "openai-compatible":
-        parser.error(
-            "openai-compatible provider is not implemented in Phase 1; use next H07 phase"
-        )
-
-    provider = DeterministicFakeEmbeddingProvider(
-        dimension=args.expected_dim if args.expected_dim is not None else 1024
-    )
+    provider = _build_provider(args, parser)
     try:
         summary = generate_embeddings(
             input_path=Path(args.input),
@@ -65,6 +63,37 @@ def main() -> None:
         sys.exit(1)
 
     print(json.dumps(summary.model_dump(), ensure_ascii=False, indent=2))
+
+
+def _build_provider(args: argparse.Namespace, parser: argparse.ArgumentParser):
+    if args.provider == "fake":
+        return DeterministicFakeEmbeddingProvider(
+            dimension=args.expected_dim if args.expected_dim is not None else 1024
+        )
+
+    if args.provider != "openai-compatible":
+        parser.error(f"unsupported provider: {args.provider}")
+
+    if not args.base_url or not str(args.base_url).strip():
+        parser.error("base URL missing: --base-url is required for openai-compatible provider")
+
+    api_key = None
+    if args.api_key_env:
+        api_key = os.environ.get(args.api_key_env, "").strip()
+        if not api_key:
+            parser.error(f"env var missing or empty: {args.api_key_env}")
+
+    if args.dry_run:
+        return DeterministicFakeEmbeddingProvider(
+            dimension=args.expected_dim if args.expected_dim is not None else 1024
+        )
+
+    return OpenAICompatibleEmbeddingProvider(
+        base_url=args.base_url,
+        api_key=api_key,
+        timeout_seconds=args.timeout_seconds,
+        max_retries=args.max_retries,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ingestion/test_embeddings_job.py
+++ b/tests/ingestion/test_embeddings_job.py
@@ -1,10 +1,14 @@
 import json
+import sys
 
+import httpx
 import pytest
 
+import scripts.generate_embeddings as generate_embeddings_cli
 from ingestion.chunks import stable_text_hash
 from ingestion.embeddings import (
     DeterministicFakeEmbeddingProvider,
+    OpenAICompatibleEmbeddingProvider,
     generate_embeddings,
 )
 
@@ -267,6 +271,327 @@ def test_invalid_vector_values_fail_validation(tmp_path, vector):
     assert not output_path.exists()
 
 
+def test_openai_compatible_provider_posts_to_embeddings_with_body():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _embedding_response([[0.1, 0.2]])
+
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:11434/v1/",
+        transport=httpx.MockTransport(handler),
+        sleep_func=lambda delay: None,
+    )
+
+    embeddings = provider.embed_texts(["retrieval text"], "Qwen/Qwen3-Embedding-0.6B")
+
+    assert embeddings == [[0.1, 0.2]]
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.method == "POST"
+    assert str(request.url) == "http://localhost:11434/v1/embeddings"
+    assert request.headers["content-type"] == "application/json"
+    body = json.loads(request.content.decode("utf-8"))
+    assert body == {
+        "model": "Qwen/Qwen3-Embedding-0.6B",
+        "input": ["retrieval text"],
+    }
+
+
+def test_openai_compatible_provider_sends_authorization_when_api_key_exists():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _embedding_response([[0.1]])
+
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="https://provider.example.com/v1",
+        api_key="secret-key",
+        transport=httpx.MockTransport(handler),
+        sleep_func=lambda delay: None,
+    )
+
+    provider.embed_texts(["retrieval text"], "model")
+
+    assert requests[0].headers["authorization"] == "Bearer secret-key"
+
+
+def test_openai_compatible_provider_omits_authorization_without_api_key():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _embedding_response([[0.1]])
+
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:8000/v1",
+        api_key=None,
+        transport=httpx.MockTransport(handler),
+        sleep_func=lambda delay: None,
+    )
+
+    provider.embed_texts(["retrieval text"], "model")
+
+    assert "authorization" not in requests[0].headers
+
+
+def test_openai_compatible_provider_parses_standard_response_without_index():
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:11434/v1",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"embedding": [0.1, 0.2]},
+                        {"embedding": [0.3, 0.4]},
+                    ],
+                    "model": "model",
+                },
+            )
+        ),
+        sleep_func=lambda delay: None,
+    )
+
+    assert provider.embed_texts(["text 1", "text 2"], "model") == [
+        [0.1, 0.2],
+        [0.3, 0.4],
+    ]
+
+
+def test_openai_compatible_provider_sorts_embeddings_by_index():
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:11434/v1",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {"embedding": [1.0], "index": 1},
+                        {"embedding": [0.0], "index": 0},
+                    ]
+                },
+            )
+        ),
+        sleep_func=lambda delay: None,
+    )
+
+    assert provider.embed_texts(["text 0", "text 1"], "model") == [[0.0], [1.0]]
+
+
+def test_openai_compatible_provider_fails_on_embedding_count_mismatch():
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:11434/v1",
+        transport=httpx.MockTransport(lambda request: _embedding_response([[0.1]])),
+        sleep_func=lambda delay: None,
+    )
+
+    with pytest.raises(ValueError, match="embedding count mismatch"):
+        provider.embed_texts(["text 1", "text 2"], "model")
+
+
+def test_openai_compatible_provider_fails_on_http_400_without_retry():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(400, json={"error": "bad request"})
+
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:11434/v1",
+        max_retries=3,
+        transport=httpx.MockTransport(handler),
+        sleep_func=lambda delay: None,
+    )
+
+    with pytest.raises(RuntimeError, match="HTTP status 400"):
+        provider.embed_texts(["retrieval text"], "model")
+
+    assert len(requests) == 1
+
+
+def test_openai_compatible_provider_retries_http_429_then_succeeds():
+    requests = []
+    sleeps = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(429, json={"error": "rate limited"})
+        return _embedding_response([[0.1]])
+
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:11434/v1",
+        max_retries=2,
+        transport=httpx.MockTransport(handler),
+        sleep_func=sleeps.append,
+    )
+
+    assert provider.embed_texts(["retrieval text"], "model") == [[0.1]]
+    assert len(requests) == 2
+    assert sleeps == [0.5]
+
+
+def test_openai_compatible_provider_retries_timeout_then_succeeds():
+    requests = []
+    sleeps = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            raise httpx.ReadTimeout("timeout", request=request)
+        return _embedding_response([[0.1]])
+
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:11434/v1",
+        max_retries=2,
+        transport=httpx.MockTransport(handler),
+        sleep_func=sleeps.append,
+    )
+
+    assert provider.embed_texts(["retrieval text"], "model") == [[0.1]]
+    assert len(requests) == 2
+    assert sleeps == [0.5]
+
+
+def test_cli_openai_compatible_requires_base_url(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_embeddings.py",
+            "--input",
+            "missing.jsonl",
+            "--output",
+            "out.jsonl",
+            "--provider",
+            "openai-compatible",
+            "--model",
+            "model",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        generate_embeddings_cli.main()
+
+    assert exc.value.code == 2
+    assert "base URL missing" in capsys.readouterr().err
+
+
+def test_cli_api_key_env_missing_fails_explicitly(monkeypatch, capsys):
+    monkeypatch.delenv("EMBEDDING_API_KEY", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_embeddings.py",
+            "--input",
+            "missing.jsonl",
+            "--output",
+            "out.jsonl",
+            "--provider",
+            "openai-compatible",
+            "--base-url",
+            "https://provider.example.com/v1",
+            "--api-key-env",
+            "EMBEDDING_API_KEY",
+            "--model",
+            "model",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        generate_embeddings_cli.main()
+
+    assert exc.value.code == 2
+    assert "env var missing or empty: EMBEDDING_API_KEY" in capsys.readouterr().err
+
+
+def test_cli_dry_run_openai_compatible_does_not_create_http_provider(
+    tmp_path,
+    monkeypatch,
+):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [_input_record("1", embedding_text="Retrieval text")])
+
+    def fail_if_created(*args, **kwargs):
+        raise AssertionError("HTTP provider must not be created during dry-run")
+
+    monkeypatch.setattr(
+        generate_embeddings_cli,
+        "OpenAICompatibleEmbeddingProvider",
+        fail_if_created,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_embeddings.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--provider",
+            "openai-compatible",
+            "--base-url",
+            "http://localhost:11434/v1",
+            "--model",
+            "model",
+            "--dry-run",
+        ],
+    )
+
+    generate_embeddings_cli.main()
+
+    assert not output_path.exists()
+
+
+def test_http_provider_end_to_end_writes_chunk_output_and_uses_embedding_text(tmp_path):
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    input_record = _input_record(
+        "1",
+        text="LegalUnit.raw_text must not be embedded",
+        embedding_text="LegalChunk.embedding_text retrieval only",
+    )
+    _write_jsonl(input_path, [input_record])
+    request_bodies = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        request_bodies.append(json.loads(request.content.decode("utf-8")))
+        return _embedding_response([[0.7, 0.8]])
+
+    provider = OpenAICompatibleEmbeddingProvider(
+        base_url="http://localhost:11434/v1",
+        transport=httpx.MockTransport(handler),
+        sleep_func=lambda delay: None,
+    )
+
+    summary = generate_embeddings(
+        input_path=input_path,
+        output_path=output_path,
+        provider=provider,
+        model_name="Qwen/Qwen3-Embedding-0.6B",
+        expected_dim=2,
+    )
+
+    output_record = _read_jsonl(output_path)[0]
+    assert summary.written_count == 1
+    assert request_bodies[0]["input"] == ["LegalChunk.embedding_text retrieval only"]
+    assert output_record["record_id"] == input_record["record_id"]
+    assert output_record["chunk_id"] == input_record["chunk_id"]
+    assert output_record["legal_unit_id"] == input_record["legal_unit_id"]
+    assert output_record["law_id"] == input_record["law_id"]
+    assert output_record["text_hash"] == input_record["text_hash"]
+    assert output_record["model_name"] == "Qwen/Qwen3-Embedding-0.6B"
+    assert output_record["embedding_dim"] == 2
+    assert output_record["embedding"] == [0.7, 0.8]
+    assert "unit_id" not in output_record
+
+
 def _input_record(
     suffix: str,
     *,
@@ -303,3 +628,16 @@ def _read_jsonl(path) -> list[dict]:
         for line in path.read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
+
+
+def _embedding_response(vectors: list[list[float]]) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "data": [
+                {"embedding": vector, "index": index}
+                for index, vector in enumerate(vectors)
+            ],
+            "model": "model",
+        },
+    )


### PR DESCRIPTION
This pull request adds support for an OpenAI-compatible embedding provider to the embeddings ingestion pipeline, allowing embeddings to be generated via HTTP requests to external services. The implementation includes robust error handling and retry logic, command-line interface integration, and comprehensive tests for the new provider.

**OpenAI-Compatible Embedding Provider Implementation:**

* Introduced the `OpenAICompatibleEmbeddingProvider` class in `ingestion/embeddings.py`, which sends HTTP POST requests to a configurable base URL, handles authentication, parses responses, and implements retry logic for transient errors.
* Added helper functions for parsing embedding responses, sorting by index, calculating retry delays, and extracting HTTP response reasons.

**Command-Line Interface Enhancements:**

* Updated `scripts/generate_embeddings.py` to accept new arguments for provider selection, base URL, API key environment variable, timeout, and retries. Integrated the new provider into the CLI workflow, including validation and dry-run handling. [[1]](diffhunk://#diff-5b30f92143848cde1180aa72a1b5b1587f70dc334d2b4981b1f3f01048cdcb13R35-R38) [[2]](diffhunk://#diff-5b30f92143848cde1180aa72a1b5b1587f70dc334d2b4981b1f3f01048cdcb13L42-R48) [[3]](diffhunk://#diff-5b30f92143848cde1180aa72a1b5b1587f70dc334d2b4981b1f3f01048cdcb13R68-R98)

**Testing Improvements:**

* Added extensive tests for the OpenAI-compatible provider in `tests/ingestion/test_embeddings_job.py`, covering request formation, authentication, response parsing, error handling, retry behavior, CLI integration, and end-to-end scenarios.
* Introduced a helper for generating mock embedding responses in tests.

**Dependency and Import Updates:**

* Imported `httpx` and related modules where needed, and updated imports to include the new provider in both the main and test code. [[1]](diffhunk://#diff-fed9ed5ba3a241ab68dc4b7195934ae602d5fe91bbeda6ef981bf63546263daeR6-R12) [[2]](diffhunk://#diff-5b30f92143848cde1180aa72a1b5b1587f70dc334d2b4981b1f3f01048cdcb13R15) [[3]](diffhunk://#diff-359a0242518de7453a547a7ee2a585b9e8b9679d0ffcd1cdd97185037beefb4cR2-R11)

**Minor Utility Changes:**

* Added `os` import in `scripts/generate_embeddings.py` for environment variable support.