### PR TITLE
feat(h07): add embeddings input-output pair validation

### DIFF
--- a/ingestion/embeddings.py
+++ b/ingestion/embeddings.py
@@ -91,6 +91,26 @@ class EmbeddingOutputValidationSummary(BaseModel):
     errors: list[str] = Field(default_factory=list)
 
 
+class EmbeddingInputOutputValidationSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input_read_count: int = 0
+    output_read_count: int = 0
+    embeddable_input_count: int = 0
+    matched_output_count: int = 0
+    missing_output_count: int = 0
+    orphan_output_count: int = 0
+    identity_mismatch_count: int = 0
+    duplicate_input_record_id_count: int = 0
+    duplicate_output_resume_key_count: int = 0
+    unexpected_output_for_empty_input_count: int = 0
+    model_names: list[str] = Field(default_factory=list)
+    embedding_dims: list[int] = Field(default_factory=list)
+    law_ids: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    errors: list[str] = Field(default_factory=list)
+
+
 class EmbeddingProvider(Protocol):
     def embed_texts(self, texts: list[str], model_name: str) -> list[list[float]]:
         ...
@@ -420,6 +440,127 @@ def validate_embeddings_output(
             "embedding output validation failed: "
             f"invalid_count={invalid_count}, error_count={len(errors)}; "
             f"{preview}{suffix}"
+        )
+    return summary
+
+
+def validate_embeddings_pair(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    expected_model: str | None = None,
+    expected_dim: int | None = None,
+    require_all_inputs: bool = True,
+    strict: bool = True,
+) -> EmbeddingInputOutputValidationSummary:
+    if expected_model is not None and not expected_model.strip():
+        raise ValueError("expected_model must be non-empty when provided")
+    if expected_dim is not None and expected_dim <= 0:
+        raise ValueError("expected_dim must be greater than 0")
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    output_summary = validate_embeddings_output(
+        output_path,
+        expected_model=expected_model,
+        expected_dim=expected_dim,
+        require_unique_resume_keys=True,
+        strict=False,
+    )
+    errors.extend(f"output: {message}" for message in output_summary.errors)
+    warnings.extend(f"output: {message}" for message in output_summary.warnings)
+
+    input_records = load_embedding_input_jsonl(input_path)
+    input_by_record_id: dict[str, EmbeddingInputRecord] = {}
+    embeddable_record_ids: set[str] = set()
+    non_embeddable_record_ids: set[str] = set()
+    duplicate_input_record_id_count = 0
+    for record in input_records:
+        if record.record_id in input_by_record_id:
+            duplicate_input_record_id_count += 1
+            errors.append(f"input record_id={record.record_id}: duplicate input record_id")
+            continue
+        input_by_record_id[record.record_id] = record
+        if record.embedding_text.strip():
+            embeddable_record_ids.add(record.record_id)
+        else:
+            non_embeddable_record_ids.add(record.record_id)
+
+    matched_output_count = 0
+    orphan_output_count = 0
+    identity_mismatch_count = 0
+    unexpected_output_for_empty_input_count = 0
+    matched_by_record_id: dict[str, set[str]] = {}
+    output_records: list[EmbeddingOutputRecord] = []
+    if not output_summary.errors:
+        output_records = load_embedding_output_jsonl(output_path)
+
+    for output in output_records:
+        input_record = input_by_record_id.get(output.record_id)
+        output_label = (
+            f"output record_id={output.record_id} "
+            f"model_name={output.model_name} text_hash={output.text_hash}"
+        )
+        if input_record is None:
+            orphan_output_count += 1
+            errors.append(f"{output_label}: orphan output record_id")
+            continue
+        if output.record_id in non_embeddable_record_ids:
+            unexpected_output_for_empty_input_count += 1
+            errors.append(f"{output_label}: unexpected output for non-embeddable input")
+            continue
+
+        mismatched_fields = [
+            field
+            for field in ("chunk_id", "legal_unit_id", "law_id", "text_hash")
+            if getattr(output, field) != getattr(input_record, field)
+        ]
+        if mismatched_fields:
+            identity_mismatch_count += 1
+            errors.append(
+                f"{output_label}: identity mismatch fields={','.join(mismatched_fields)}"
+            )
+            continue
+
+        matched_output_count += 1
+        matched_by_record_id.setdefault(output.record_id, set()).add(output.model_name)
+
+    missing_output_count = 0
+    for record_id in sorted(embeddable_record_ids):
+        matched_models = matched_by_record_id.get(record_id, set())
+        is_missing = expected_model not in matched_models if expected_model else not matched_models
+        if is_missing:
+            missing_output_count += 1
+            message = f"input record_id={record_id}: missing embedding output"
+            if require_all_inputs:
+                errors.append(message)
+            else:
+                warnings.append(message)
+
+    summary = EmbeddingInputOutputValidationSummary(
+        input_read_count=len(input_records),
+        output_read_count=output_summary.read_count,
+        embeddable_input_count=len(embeddable_record_ids),
+        matched_output_count=matched_output_count,
+        missing_output_count=missing_output_count,
+        orphan_output_count=orphan_output_count,
+        identity_mismatch_count=identity_mismatch_count,
+        duplicate_input_record_id_count=duplicate_input_record_id_count,
+        duplicate_output_resume_key_count=output_summary.duplicate_resume_key_count,
+        unexpected_output_for_empty_input_count=unexpected_output_for_empty_input_count,
+        model_names=output_summary.model_names,
+        embedding_dims=output_summary.embedding_dims,
+        law_ids=output_summary.law_ids,
+        warnings=warnings,
+        errors=errors,
+    )
+    if strict and summary.errors:
+        preview = "; ".join(summary.errors[:5])
+        remaining = len(summary.errors) - min(len(summary.errors), 5)
+        suffix = f"; ... {remaining} more" if remaining else ""
+        raise ValueError(
+            "embedding pair validation failed: "
+            f"error_count={len(summary.errors)}; {preview}{suffix}"
         )
     return summary
 

--- a/scripts/validate_embeddings_pair.py
+++ b/scripts/validate_embeddings_pair.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from ingestion.embeddings import (  # noqa: E402
+    EmbeddingInputOutputValidationSummary,
+    validate_embeddings_pair,
+)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate embeddings_input.jsonl against embeddings_output.jsonl"
+    )
+    parser.add_argument("--input", required=True, help="Path to embeddings_input.jsonl")
+    parser.add_argument("--output", required=True, help="Path to embeddings_output.jsonl")
+    parser.add_argument("--expected-model", default=None)
+    parser.add_argument("--expected-dim", type=int, default=None)
+    parser.add_argument("--require-all-inputs", action="store_true")
+    parser.add_argument("--strict", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    return parser
+
+
+def main() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    try:
+        summary = validate_embeddings_pair(
+            Path(args.input),
+            Path(args.output),
+            expected_model=args.expected_model,
+            expected_dim=args.expected_dim,
+            require_all_inputs=args.require_all_inputs,
+            strict=False,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"[validate-embeddings-pair] {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.as_json:
+        print(json.dumps(summary.model_dump(), ensure_ascii=False, indent=2))
+    else:
+        print(_format_human_report(summary))
+
+    if args.strict and summary.errors:
+        sys.exit(1)
+
+
+def _format_human_report(summary: EmbeddingInputOutputValidationSummary) -> str:
+    lines = [
+        "Embeddings input/output pair validation",
+        f"input_read_count: {summary.input_read_count}",
+        f"output_read_count: {summary.output_read_count}",
+        f"embeddable_input_count: {summary.embeddable_input_count}",
+        f"matched_output_count: {summary.matched_output_count}",
+        f"missing_output_count: {summary.missing_output_count}",
+        f"orphan_output_count: {summary.orphan_output_count}",
+        f"identity_mismatch_count: {summary.identity_mismatch_count}",
+        f"duplicate_input_record_id_count: {summary.duplicate_input_record_id_count}",
+        f"duplicate_output_resume_key_count: {summary.duplicate_output_resume_key_count}",
+        f"unexpected_output_for_empty_input_count: {summary.unexpected_output_for_empty_input_count}",
+        f"model_names: {_join_or_dash(summary.model_names)}",
+        f"embedding_dims: {_join_or_dash([str(dim) for dim in summary.embedding_dims])}",
+        f"law_ids: {_join_or_dash(summary.law_ids)}",
+    ]
+    _append_messages(lines, "warnings", summary.warnings)
+    _append_messages(lines, "errors", summary.errors)
+    return "\n".join(lines)
+
+
+def _append_messages(lines: list[str], label: str, messages: list[str]) -> None:
+    if not messages:
+        return
+    lines.append(f"{label}:")
+    lines.extend(f"- {_truncate_message(message)}" for message in messages[:5])
+    if len(messages) > 5:
+        lines.append(f"- ... {len(messages) - 5} more")
+
+
+def _join_or_dash(values: list[str]) -> str:
+    return ", ".join(values) if values else "-"
+
+
+def _truncate_message(message: str, limit: int = 240) -> str:
+    if len(message) <= limit:
+        return message
+    return message[: limit - 3] + "..."
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ingestion/test_embeddings_pair_validation.py
+++ b/tests/ingestion/test_embeddings_pair_validation.py
@@ -1,0 +1,391 @@
+import json
+import sys
+
+import pytest
+
+import scripts.validate_embeddings_pair as pair_cli
+from ingestion.embeddings import validate_embeddings_pair
+
+
+MODEL = "Qwen/Qwen3-Embedding-4B"
+
+
+def test_valid_input_and_output_returns_summary(tmp_path):
+    input_path, output_path = _write_pair(tmp_path, ["1", "2"], ["1", "2"])
+
+    summary = validate_embeddings_pair(
+        input_path,
+        output_path,
+        expected_model=MODEL,
+        expected_dim=3,
+    )
+
+    assert summary.input_read_count == 2
+    assert summary.output_read_count == 2
+    assert summary.embeddable_input_count == 2
+    assert summary.matched_output_count == 2
+    assert summary.missing_output_count == 0
+    assert summary.orphan_output_count == 0
+    assert summary.identity_mismatch_count == 0
+    assert summary.model_names == [MODEL]
+    assert summary.embedding_dims == [3]
+    assert summary.law_ids == ["ro.test"]
+    assert summary.errors == []
+
+
+def test_orphan_output_record_id_is_error(tmp_path):
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["2"])
+
+    summary = validate_embeddings_pair(input_path, output_path, strict=False)
+
+    assert summary.orphan_output_count == 1
+    assert any("orphan output record_id" in error for error in summary.errors)
+
+
+@pytest.mark.parametrize("field", ["chunk_id", "legal_unit_id", "law_id", "text_hash"])
+def test_identity_mismatch_fields_are_errors(tmp_path, field):
+    input_record = _input_record("1")
+    output_record = _output_record_from_input(input_record)
+    output_record[field] = f"changed-{field}"
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [output_record])
+
+    summary = validate_embeddings_pair(input_path, output_path, strict=False)
+
+    assert summary.identity_mismatch_count == 1
+    assert any(f"identity mismatch fields={field}" in error for error in summary.errors)
+
+
+def test_missing_output_for_embeddable_input_is_error_when_required(tmp_path):
+    input_path, output_path = _write_pair(tmp_path, ["1", "2"], ["1"])
+
+    summary = validate_embeddings_pair(
+        input_path,
+        output_path,
+        require_all_inputs=True,
+        strict=False,
+    )
+
+    assert summary.missing_output_count == 1
+    assert any("missing embedding output" in error for error in summary.errors)
+
+
+def test_missing_output_for_embeddable_input_can_be_warning(tmp_path):
+    input_path, output_path = _write_pair(tmp_path, ["1", "2"], ["1"])
+
+    summary = validate_embeddings_pair(
+        input_path,
+        output_path,
+        require_all_inputs=False,
+        strict=False,
+    )
+
+    assert summary.missing_output_count == 1
+    assert summary.errors == []
+    assert any("missing embedding output" in warning for warning in summary.warnings)
+
+
+def test_empty_embedding_input_does_not_require_output(tmp_path):
+    input_record = _input_record("1", embedding_text="")
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [])
+
+    summary = validate_embeddings_pair(input_path, output_path)
+
+    assert summary.embeddable_input_count == 0
+    assert summary.missing_output_count == 0
+    assert summary.errors == []
+
+
+def test_output_for_empty_embedding_input_is_error(tmp_path):
+    input_record = _input_record("1", embedding_text="")
+    output_record = _output_record_from_input(input_record)
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [output_record])
+
+    summary = validate_embeddings_pair(input_path, output_path, strict=False)
+
+    assert summary.unexpected_output_for_empty_input_count == 1
+    assert any("unexpected output for non-embeddable input" in error for error in summary.errors)
+
+
+def test_duplicate_input_record_id_is_error(tmp_path):
+    records = [_input_record("1"), _input_record("1", text_hash="hash-b")]
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, records)
+    _write_jsonl(output_path, [_output_record_from_input(records[0])])
+
+    summary = validate_embeddings_pair(input_path, output_path, strict=False)
+
+    assert summary.duplicate_input_record_id_count == 1
+    assert any("duplicate input record_id" in error for error in summary.errors)
+
+
+def test_duplicate_output_resume_key_is_error(tmp_path):
+    input_record = _input_record("1")
+    output_record = _output_record_from_input(input_record)
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [output_record, dict(output_record)])
+
+    summary = validate_embeddings_pair(input_path, output_path, strict=False)
+
+    assert summary.duplicate_output_resume_key_count == 1
+    assert any("duplicate resume key" in error for error in summary.errors)
+
+
+def test_expected_model_mismatch_is_error(tmp_path):
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["1"])
+
+    summary = validate_embeddings_pair(
+        input_path,
+        output_path,
+        expected_model="other-model",
+        strict=False,
+    )
+
+    assert any("expected_model mismatch" in error for error in summary.errors)
+
+
+def test_expected_dim_mismatch_is_error(tmp_path):
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["1"])
+
+    summary = validate_embeddings_pair(
+        input_path,
+        output_path,
+        expected_dim=2560,
+        strict=False,
+    )
+
+    assert any("expected_dim mismatch" in error for error in summary.errors)
+
+
+def test_strict_false_returns_errors_without_exception(tmp_path):
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["2"])
+
+    summary = validate_embeddings_pair(input_path, output_path, strict=False)
+
+    assert summary.errors
+
+
+def test_strict_true_raises_value_error(tmp_path):
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["2"])
+
+    with pytest.raises(ValueError, match="embedding pair validation failed"):
+        validate_embeddings_pair(input_path, output_path, strict=True)
+
+
+def test_cli_human_readable_passes_on_valid_pair(tmp_path, monkeypatch, capsys):
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["1"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_embeddings_pair.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--expected-model",
+            MODEL,
+            "--expected-dim",
+            "3",
+            "--require-all-inputs",
+            "--strict",
+        ],
+    )
+
+    pair_cli.main()
+
+    stdout = capsys.readouterr().out
+    assert "Embeddings input/output pair validation" in stdout
+    assert "matched_output_count: 1" in stdout
+    assert "missing_output_count: 0" in stdout
+
+
+def test_cli_json_outputs_valid_json(tmp_path, monkeypatch, capsys):
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["1"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_embeddings_pair.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--json",
+        ],
+    )
+
+    pair_cli.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["input_read_count"] == 1
+    assert payload["matched_output_count"] == 1
+    assert payload["model_names"] == [MODEL]
+
+
+def test_cli_strict_returns_nonzero_on_invalid_pair(tmp_path, monkeypatch):
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["2"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_embeddings_pair.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--strict",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        pair_cli.main()
+
+    assert exc.value.code == 1
+
+
+def test_validator_does_not_require_database_url(tmp_path, monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    input_path, output_path = _write_pair(tmp_path, ["1"], ["1"])
+
+    summary = validate_embeddings_pair(input_path, output_path)
+
+    assert summary.matched_output_count == 1
+
+
+def test_cli_output_does_not_include_text_fields_or_full_vector(tmp_path, monkeypatch, capsys):
+    secret_text = "SECRET_FULL_LEGAL_TEXT"
+    input_record = _input_record("1", text=secret_text, embedding_text="SECRET_EMBEDDING_TEXT")
+    output_record = _output_record_from_input(input_record, embedding=[0.1, 0.2, 0.3], embedding_dim=2)
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [output_record])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_embeddings_pair.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    pair_cli.main()
+
+    stdout = capsys.readouterr().out
+    assert "SECRET_FULL_LEGAL_TEXT" not in stdout
+    assert "SECRET_EMBEDDING_TEXT" not in stdout
+    assert "[0.1, 0.2, 0.3]" not in stdout
+
+
+def test_strict_exception_does_not_include_text_fields_or_full_vector(tmp_path):
+    input_record = _input_record("1", text="SECRET_FULL_LEGAL_TEXT", embedding_text="SECRET_EMBEDDING_TEXT")
+    output_record = _output_record_from_input(input_record, embedding=[0.1, 0.2, 0.3], embedding_dim=2)
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [output_record])
+
+    with pytest.raises(ValueError) as exc:
+        validate_embeddings_pair(input_path, output_path)
+
+    message = str(exc.value)
+    assert "SECRET_FULL_LEGAL_TEXT" not in message
+    assert "SECRET_EMBEDDING_TEXT" not in message
+    assert "[0.1, 0.2, 0.3]" not in message
+
+
+def _write_pair(tmp_path, input_suffixes: list[str], output_suffixes: list[str]):
+    inputs = [_input_record(suffix) for suffix in input_suffixes]
+    inputs_by_suffix = {
+        record["record_id"].split(".")[-2]: record
+        for record in inputs
+    }
+    outputs = [
+        _output_record_from_input(inputs_by_suffix[suffix])
+        if suffix in inputs_by_suffix
+        else _output_record(suffix)
+        for suffix in output_suffixes
+    ]
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, inputs)
+    _write_jsonl(output_path, outputs)
+    return input_path, output_path
+
+
+def _input_record(
+    suffix: str,
+    *,
+    text: str = "LegalUnit.raw_text",
+    embedding_text: str = "LegalChunk.embedding_text",
+    text_hash: str | None = None,
+) -> dict:
+    if text_hash is None:
+        text_hash = f"hash-{suffix}"
+    return {
+        "record_id": f"embedding.chunk.ro.test.{suffix}.0",
+        "chunk_id": f"chunk.ro.test.{suffix}.0",
+        "legal_unit_id": f"ro.test.{suffix}",
+        "law_id": "ro.test",
+        "text": text,
+        "embedding_text": embedding_text,
+        "text_hash": text_hash,
+        "model_hint": None,
+        "metadata": {"retrieval_text_is_citable": False},
+    }
+
+
+def _output_record_from_input(
+    input_record: dict,
+    *,
+    model_name: str = MODEL,
+    embedding: list | None = None,
+    embedding_dim: int = 3,
+) -> dict:
+    return {
+        "record_id": input_record["record_id"],
+        "chunk_id": input_record["chunk_id"],
+        "legal_unit_id": input_record["legal_unit_id"],
+        "law_id": input_record["law_id"],
+        "model_name": model_name,
+        "embedding_dim": embedding_dim,
+        "text_hash": input_record["text_hash"],
+        "embedding": embedding if embedding is not None else [0.1, 0.2, 0.3],
+        "metadata": {"retrieval_text_is_citable": False},
+    }
+
+
+def _output_record(suffix: str, *, model_name: str = MODEL) -> dict:
+    return {
+        "record_id": f"embedding.chunk.ro.test.{suffix}.0",
+        "chunk_id": f"chunk.ro.test.{suffix}.0",
+        "legal_unit_id": f"ro.test.{suffix}",
+        "law_id": "ro.test",
+        "model_name": model_name,
+        "embedding_dim": 3,
+        "text_hash": f"hash-{suffix}",
+        "embedding": [0.1, 0.2, 0.3],
+        "metadata": {"retrieval_text_is_citable": False},
+    }
+
+
+def _write_jsonl(path, records: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
This pull request introduces a comprehensive validation mechanism for embedding input/output file pairs, including a new validation function, a command-line tool, and a suite of tests to ensure correctness and robustness. These changes make it easier to check the consistency and integrity of embedding data, both programmatically and via the CLI.

**Embedding input/output validation:**

* Added the `EmbeddingInputOutputValidationSummary` model in `ingestion/embeddings.py` to summarize validation results for embedding input/output pairs, including counts of various error types and lists of warnings/errors.
* Implemented the `validate_embeddings_pair` function in `ingestion/embeddings.py` to compare embedding input and output files, detect mismatches, missing or orphaned records, identity mismatches, and other data integrity issues, raising exceptions if strict validation is requested.

**Command-line interface:**

* Added a new script `scripts/validate_embeddings_pair.py` that provides a CLI for validating embedding input/output pairs, supporting both human-readable and JSON output, strict error handling, and various validation options.

**Testing:**

* Introduced `tests/ingestion/test_embeddings_pair_validation.py`, a comprehensive test suite covering the new validation logic and CLI, including edge cases such as orphaned records, identity mismatches, missing outputs, and privacy (ensuring sensitive data is not leaked in error messages or CLI output).