### PR TITLE
feat(h07): add embeddings import-readiness manifest

### DIFF
--- a/ingestion/embeddings.py
+++ b/ingestion/embeddings.py
@@ -6,6 +6,7 @@ import math
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Protocol, TypeVar
 
@@ -18,6 +19,7 @@ from ingestion.contracts import EmbeddingInputRecord
 
 ResumeKey = tuple[str, str, str]
 T = TypeVar("T")
+EMBEDDINGS_IMPORT_READINESS_VALIDATOR_VERSION = "h07.phase5.import_readiness.v1"
 EMBEDDING_OUTPUT_REQUIRED_FIELDS = (
     "record_id",
     "chunk_id",
@@ -109,6 +111,28 @@ class EmbeddingInputOutputValidationSummary(BaseModel):
     law_ids: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
+
+
+class EmbeddingsImportReadinessManifest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input_path: str
+    output_path: str
+    model_name: str
+    embedding_dim: int
+    input_read_count: int
+    output_read_count: int
+    embeddable_input_count: int
+    matched_output_count: int
+    missing_output_count: int
+    orphan_output_count: int
+    law_ids: list[str] = Field(default_factory=list)
+    model_names: list[str] = Field(default_factory=list)
+    embedding_dims: list[int] = Field(default_factory=list)
+    ready_for_pgvector_import: bool
+    validated_at: str
+    validator_version: str
+    warnings: list[str] = Field(default_factory=list)
 
 
 class EmbeddingProvider(Protocol):
@@ -565,6 +589,56 @@ def validate_embeddings_pair(
     return summary
 
 
+def build_embeddings_import_manifest(
+    *,
+    input_path: str | Path,
+    output_path: str | Path,
+    expected_model: str,
+    expected_dim: int,
+    manifest_path: str | Path | None = None,
+) -> EmbeddingsImportReadinessManifest:
+    if not expected_model.strip():
+        raise ValueError("expected_model must be non-empty")
+    if expected_dim <= 0:
+        raise ValueError("expected_dim must be greater than 0")
+
+    summary = validate_embeddings_pair(
+        input_path,
+        output_path,
+        expected_model=expected_model,
+        expected_dim=expected_dim,
+        require_all_inputs=True,
+        strict=True,
+    )
+    manifest = EmbeddingsImportReadinessManifest(
+        input_path=str(Path(input_path)),
+        output_path=str(Path(output_path)),
+        model_name=expected_model,
+        embedding_dim=expected_dim,
+        input_read_count=summary.input_read_count,
+        output_read_count=summary.output_read_count,
+        embeddable_input_count=summary.embeddable_input_count,
+        matched_output_count=summary.matched_output_count,
+        missing_output_count=summary.missing_output_count,
+        orphan_output_count=summary.orphan_output_count,
+        law_ids=summary.law_ids,
+        model_names=summary.model_names,
+        embedding_dims=summary.embedding_dims,
+        ready_for_pgvector_import=True,
+        validated_at=_utc_now_iso_z(),
+        validator_version=EMBEDDINGS_IMPORT_READINESS_VALIDATOR_VERSION,
+        warnings=summary.warnings,
+    )
+    if manifest_path is not None:
+        resolved_manifest_path = Path(manifest_path)
+        resolved_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        resolved_manifest_path.write_text(
+            json.dumps(manifest.model_dump(), ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    return manifest
+
+
 def write_embedding_output_jsonl(
     records: list[EmbeddingOutputRecord],
     path: str | Path,
@@ -779,6 +853,10 @@ def _valid_output_embedding_dim(
         errors.append(f"{record_label}: embedding_dim must be a positive integer")
         return None
     return embedding_dim
+
+
+def _utc_now_iso_z() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _record_log_context(record: EmbeddingInputRecord, embedding_text_length: int) -> str:

--- a/scripts/write_embeddings_manifest.py
+++ b/scripts/write_embeddings_manifest.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from ingestion.embeddings import (  # noqa: E402
+    EmbeddingsImportReadinessManifest,
+    build_embeddings_import_manifest,
+)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Write an offline embeddings import-readiness manifest"
+    )
+    parser.add_argument("--input", required=True, help="Path to embeddings_input.jsonl")
+    parser.add_argument("--output", required=True, help="Path to embeddings_output.jsonl")
+    parser.add_argument("--manifest", required=True, help="Path to manifest JSON")
+    parser.add_argument("--expected-model", required=True)
+    parser.add_argument("--expected-dim", type=int, required=True)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    return parser
+
+
+def main() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    try:
+        manifest = build_embeddings_import_manifest(
+            input_path=Path(args.input),
+            output_path=Path(args.output),
+            expected_model=args.expected_model,
+            expected_dim=args.expected_dim,
+            manifest_path=Path(args.manifest),
+        )
+    except (OSError, ValueError) as exc:
+        print(f"[write-embeddings-manifest] {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.as_json:
+        print(json.dumps(manifest.model_dump(), ensure_ascii=False, indent=2))
+    else:
+        print(_format_human_report(Path(args.manifest), manifest))
+
+
+def _format_human_report(
+    manifest_path: Path,
+    manifest: EmbeddingsImportReadinessManifest,
+) -> str:
+    return "\n".join(
+        [
+            "Embeddings import-readiness manifest",
+            f"manifest_path: {manifest_path}",
+            f"ready_for_pgvector_import: {manifest.ready_for_pgvector_import}",
+            f"model_name: {manifest.model_name}",
+            f"embedding_dim: {manifest.embedding_dim}",
+            f"matched_output_count: {manifest.matched_output_count}",
+            f"law_ids: {', '.join(manifest.law_ids) if manifest.law_ids else '-'}",
+        ]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ingestion/test_embeddings_manifest.py
+++ b/tests/ingestion/test_embeddings_manifest.py
@@ -1,0 +1,300 @@
+import json
+import sys
+
+import pytest
+
+import scripts.write_embeddings_manifest as manifest_cli
+from ingestion.embeddings import (
+    EMBEDDINGS_IMPORT_READINESS_VALIDATOR_VERSION,
+    build_embeddings_import_manifest,
+)
+
+
+MODEL = "Qwen/Qwen3-Embedding-4B"
+
+
+def test_manifest_is_built_from_valid_input_and_output(tmp_path):
+    input_path, output_path = _write_pair(tmp_path)
+
+    manifest = build_embeddings_import_manifest(
+        input_path=input_path,
+        output_path=output_path,
+        expected_model=MODEL,
+        expected_dim=2,
+    )
+
+    assert manifest.input_path == str(input_path)
+    assert manifest.output_path == str(output_path)
+    assert manifest.model_name == MODEL
+    assert manifest.embedding_dim == 2
+    assert manifest.input_read_count == 1
+    assert manifest.output_read_count == 1
+    assert manifest.embeddable_input_count == 1
+    assert manifest.matched_output_count == 1
+    assert manifest.missing_output_count == 0
+    assert manifest.orphan_output_count == 0
+    assert manifest.law_ids == ["ro.test"]
+    assert manifest.model_names == [MODEL]
+    assert manifest.embedding_dims == [2]
+    assert manifest.validator_version == EMBEDDINGS_IMPORT_READINESS_VALIDATOR_VERSION
+    assert manifest.validated_at.endswith("Z")
+
+
+def test_manifest_written_to_disk_is_valid_json(tmp_path):
+    input_path, output_path = _write_pair(tmp_path)
+    manifest_path = tmp_path / "manifests" / "validated_embeddings_manifest.json"
+
+    manifest = build_embeddings_import_manifest(
+        input_path=input_path,
+        output_path=output_path,
+        expected_model=MODEL,
+        expected_dim=2,
+        manifest_path=manifest_path,
+    )
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload == manifest.model_dump()
+    assert payload["ready_for_pgvector_import"] is True
+
+
+def test_ready_for_pgvector_import_is_true_when_validation_passes(tmp_path):
+    input_path, output_path = _write_pair(tmp_path)
+
+    manifest = build_embeddings_import_manifest(
+        input_path=input_path,
+        output_path=output_path,
+        expected_model=MODEL,
+        expected_dim=2,
+    )
+
+    assert manifest.ready_for_pgvector_import is True
+
+
+def test_invalid_pair_does_not_write_manifest(tmp_path):
+    input_record = _input_record("1")
+    output_record = _output_record_from_input(input_record)
+    output_record["chunk_id"] = "changed"
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    manifest_path = tmp_path / "validated_embeddings_manifest.json"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [output_record])
+
+    with pytest.raises(ValueError):
+        build_embeddings_import_manifest(
+            input_path=input_path,
+            output_path=output_path,
+            expected_model=MODEL,
+            expected_dim=2,
+            manifest_path=manifest_path,
+        )
+
+    assert not manifest_path.exists()
+
+
+def test_manifest_does_not_include_text_embedding_text_raw_text_or_embedding(tmp_path):
+    input_path, output_path = _write_pair(
+        tmp_path,
+        text="SECRET_RAW_TEXT",
+        embedding_text="SECRET_EMBEDDING_TEXT",
+    )
+
+    manifest = build_embeddings_import_manifest(
+        input_path=input_path,
+        output_path=output_path,
+        expected_model=MODEL,
+        expected_dim=2,
+    )
+    payload = manifest.model_dump()
+    serialized = json.dumps(payload, ensure_ascii=False)
+
+    assert "text" not in payload
+    assert "embedding_text" not in payload
+    assert "raw_text" not in payload
+    assert "embedding" not in payload
+    assert "SECRET_RAW_TEXT" not in serialized
+    assert "SECRET_EMBEDDING_TEXT" not in serialized
+    assert "[0.1, 0.2]" not in serialized
+
+
+def test_cli_writes_valid_manifest(tmp_path, monkeypatch, capsys):
+    input_path, output_path = _write_pair(tmp_path)
+    manifest_path = tmp_path / "validated_embeddings_manifest.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "write_embeddings_manifest.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--manifest",
+            str(manifest_path),
+            "--expected-model",
+            MODEL,
+            "--expected-dim",
+            "2",
+        ],
+    )
+
+    manifest_cli.main()
+
+    stdout = capsys.readouterr().out
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["ready_for_pgvector_import"] is True
+    assert payload["model_name"] == MODEL
+    assert "ready_for_pgvector_import: True" in stdout
+    assert "matched_output_count: 1" in stdout
+
+
+def test_cli_json_prints_valid_json(tmp_path, monkeypatch, capsys):
+    input_path, output_path = _write_pair(tmp_path)
+    manifest_path = tmp_path / "validated_embeddings_manifest.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "write_embeddings_manifest.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--manifest",
+            str(manifest_path),
+            "--expected-model",
+            MODEL,
+            "--expected-dim",
+            "2",
+            "--json",
+        ],
+    )
+
+    manifest_cli.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["model_name"] == MODEL
+    assert payload["embedding_dim"] == 2
+    assert payload["ready_for_pgvector_import"] is True
+    assert manifest_path.exists()
+
+
+def test_cli_invalid_pair_returns_nonzero(tmp_path, monkeypatch):
+    input_record = _input_record("1")
+    output_record = _output_record_from_input(input_record)
+    output_record["law_id"] = "changed"
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    manifest_path = tmp_path / "validated_embeddings_manifest.json"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [output_record])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "write_embeddings_manifest.py",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--manifest",
+            str(manifest_path),
+            "--expected-model",
+            MODEL,
+            "--expected-dim",
+            "2",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        manifest_cli.main()
+
+    assert exc.value.code == 1
+    assert not manifest_path.exists()
+
+
+def test_manifest_builder_does_not_require_database_url(tmp_path, monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    input_path, output_path = _write_pair(tmp_path)
+
+    manifest = build_embeddings_import_manifest(
+        input_path=input_path,
+        output_path=output_path,
+        expected_model=MODEL,
+        expected_dim=2,
+    )
+
+    assert manifest.ready_for_pgvector_import is True
+
+
+def test_manifest_builder_does_not_make_network_calls(tmp_path, monkeypatch):
+    input_path, output_path = _write_pair(tmp_path)
+
+    def fail_http_client(*args, **kwargs):
+        raise AssertionError("network calls are not allowed")
+
+    monkeypatch.setattr("httpx.Client", fail_http_client)
+
+    manifest = build_embeddings_import_manifest(
+        input_path=input_path,
+        output_path=output_path,
+        expected_model=MODEL,
+        expected_dim=2,
+    )
+
+    assert manifest.matched_output_count == 1
+
+
+def _write_pair(
+    tmp_path,
+    *,
+    text: str = "LegalUnit.raw_text",
+    embedding_text: str = "LegalChunk.embedding_text",
+):
+    input_record = _input_record("1", text=text, embedding_text=embedding_text)
+    output_record = _output_record_from_input(input_record)
+    input_path = tmp_path / "embeddings_input.jsonl"
+    output_path = tmp_path / "embeddings_output.jsonl"
+    _write_jsonl(input_path, [input_record])
+    _write_jsonl(output_path, [output_record])
+    return input_path, output_path
+
+
+def _input_record(
+    suffix: str,
+    *,
+    text: str = "LegalUnit.raw_text",
+    embedding_text: str = "LegalChunk.embedding_text",
+) -> dict:
+    return {
+        "record_id": f"embedding.chunk.ro.test.{suffix}.0",
+        "chunk_id": f"chunk.ro.test.{suffix}.0",
+        "legal_unit_id": f"ro.test.{suffix}",
+        "law_id": "ro.test",
+        "text": text,
+        "embedding_text": embedding_text,
+        "text_hash": f"hash-{suffix}",
+        "model_hint": None,
+        "metadata": {"retrieval_text_is_citable": False},
+    }
+
+
+def _output_record_from_input(input_record: dict) -> dict:
+    return {
+        "record_id": input_record["record_id"],
+        "chunk_id": input_record["chunk_id"],
+        "legal_unit_id": input_record["legal_unit_id"],
+        "law_id": input_record["law_id"],
+        "model_name": MODEL,
+        "embedding_dim": 2,
+        "text_hash": input_record["text_hash"],
+        "embedding": [0.1, 0.2],
+        "metadata": {"retrieval_text_is_citable": False},
+    }
+
+
+def _write_jsonl(path, records: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
+        encoding="utf-8",
+    )


### PR DESCRIPTION
This pull request introduces a new system for validating and generating import-readiness manifests for embeddings, along with a CLI tool and comprehensive tests. The main goal is to ensure that embeddings are ready for import into a pgvector database by validating input/output pairs and summarizing their readiness in a manifest file. The changes include new data models, manifest generation logic, a CLI for offline validation, and thorough testing.

**Embeddings import-readiness validation and manifest generation:**

* Added the `EmbeddingsImportReadinessManifest` data model to capture validation results and readiness metadata for embeddings input/output pairs, including counts, model info, and validation status.
* Implemented the `build_embeddings_import_manifest` function to validate embeddings input/output files, build a manifest, and optionally write it to disk. This function ensures all required conditions are met and includes a versioned validator. [[1]](diffhunk://#diff-fed9ed5ba3a241ab68dc4b7195934ae602d5fe91bbeda6ef981bf63546263daeR592-R641) [[2]](diffhunk://#diff-fed9ed5ba3a241ab68dc4b7195934ae602d5fe91bbeda6ef981bf63546263daeR22)
* Added a utility function `_utc_now_iso_z` to generate ISO-formatted UTC timestamps for manifest metadata.

**CLI tool for manifest generation:**

* Introduced a new script, `scripts/write_embeddings_manifest.py`, which provides a command-line interface to generate and write embeddings import-readiness manifests. The CLI supports both human-readable and JSON output formats and validates input/output pairs offline.

**Testing and validation:**

* Added a comprehensive test suite in `tests/ingestion/test_embeddings_manifest.py` to verify manifest creation, file output, CLI behavior, error handling, and that sensitive text or embeddings are not leaked in the manifest. Tests also ensure no network or database dependencies are required for validation.

These changes provide a robust, offline, and testable workflow for ensuring embeddings data is validated and ready for import, improving reliability and safety in downstream processes.