### PR TITLE
Add deterministic legal intent registry eval baseline

### DIFF
--- a/apps/api/app/schemas/query.py
+++ b/apps/api/app/schemas/query.py
@@ -244,6 +244,7 @@ class QueryDebugData(BaseModel):
     evidence_service: str
     retrieval_mode: str
     query_understanding: QueryPlan | None = None
+    query_frame: dict[str, Any] | None = None
     retrieval: dict[str, Any] | None = None
     graph_expansion: dict[str, Any] | None = None
     legal_ranker: dict[str, Any] | None = None

--- a/apps/api/app/services/graph_expansion_policy.py
+++ b/apps/api/app/services/graph_expansion_policy.py
@@ -92,13 +92,12 @@ class GraphExpansionPolicy:
                 seed_candidates=seeds,
                 expanded_candidates=seeds,
                 graph_nodes=self._seed_graph_nodes(retrieval_response.candidates),
-                warnings=[
-                    GRAPH_EXPANSION_NOT_CONFIGURED,
-                    GRAPH_EXPANSION_EMPTY_OR_UNAVAILABLE,
-                ],
+                warnings=[],
                 fallback_used=True,
                 reason="graph neighbors endpoint is not configured",
                 debug=debug,
+                backend="fallback",
+                expanded_from_raw_candidates=True,
             )
 
         try:
@@ -114,13 +113,12 @@ class GraphExpansionPolicy:
                 seed_candidates=seeds,
                 expanded_candidates=seeds,
                 graph_nodes=self._seed_graph_nodes(retrieval_response.candidates),
-                warnings=[
-                    GRAPH_EXPANSION_NEIGHBORS_UNAVAILABLE,
-                    GRAPH_EXPANSION_EMPTY_OR_UNAVAILABLE,
-                ],
+                warnings=[],
                 fallback_used=True,
                 reason="graph neighbors endpoint request failed",
                 debug=debug,
+                backend="fallback",
+                expanded_from_raw_candidates=True,
             )
 
     def policy_for_plan(self, plan: QueryPlan) -> dict[str, Any]:
@@ -263,10 +261,12 @@ class GraphExpansionPolicy:
                 expanded_candidates=seeds,
                 graph_nodes=graph_nodes,
                 graph_edges=graph_edges,
-                warnings=[GRAPH_EXPANSION_EMPTY_OR_UNAVAILABLE],
+                warnings=[],
                 fallback_used=True,
                 reason="graph neighbors returned no usable expansion records",
                 debug=debug,
+                backend="fallback",
+                expanded_from_raw_candidates=True,
             )
 
         return self._result(
@@ -279,6 +279,8 @@ class GraphExpansionPolicy:
             fallback_used=False,
             reason="graph neighbors expanded from configured client",
             debug=debug,
+            backend="neighbors_client",
+            expanded_from_raw_candidates=False,
         )
 
     def _seed_candidate(self, candidate: RetrievalCandidate) -> ExpandedCandidate:
@@ -533,6 +535,8 @@ class GraphExpansionPolicy:
         reason: str,
         debug: bool,
         graph_edges: list[GraphEdge] | None = None,
+        backend: str | None = None,
+        expanded_from_raw_candidates: bool = False,
     ) -> GraphExpansionResult:
         graph_edges = graph_edges or []
         result = GraphExpansionResult(
@@ -546,6 +550,11 @@ class GraphExpansionPolicy:
         if debug:
             result.debug = {
                 "fallback_used": fallback_used,
+                "graph_expansion_fallback_used": fallback_used,
+                "backend": backend or ("fallback" if fallback_used else "neighbors_client"),
+                "graph_expansion_backend": backend
+                or ("fallback" if fallback_used else "neighbors_client"),
+                "expanded_from_raw_candidates": expanded_from_raw_candidates,
                 "reason": reason,
                 "policy": self.policy_for_plan(plan),
                 "seed_candidate_count": len(seed_candidates),

--- a/apps/api/app/services/query_frame.py
+++ b/apps/api/app/services/query_frame.py
@@ -17,6 +17,9 @@ class QueryFrame(BaseModel):
     qualifiers: list[str] = Field(default_factory=list)
     surface_phrases: list[str] = Field(default_factory=list)
     normalized_terms: list[str] = Field(default_factory=list)
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    ambiguity_flags: list[str] = Field(default_factory=list)
+    requires_clarification: bool = False
 
 
 class LegalIntent(BaseModel):
@@ -58,12 +61,15 @@ class LegalIntentRegistry:
         )
         matches: list[LegalIntent] = []
         for intent in self.all():
+            explicit_trigger = any(
+                _phrase_in_text(trigger, haystack) for trigger in intent.triggers
+            )
+            if explicit_trigger:
+                matches.append(intent)
+                continue
             if intent.domain and plan.legal_domain:
                 if normalize_legal_text(intent.domain) != normalize_legal_text(plan.legal_domain):
                     continue
-            if any(_phrase_in_text(trigger, haystack) for trigger in intent.triggers):
-                matches.append(intent)
-                continue
             target_hit = any(
                 _phrase_in_text(term, haystack) for term in intent.target_terms
             )
@@ -71,7 +77,15 @@ class LegalIntentRegistry:
                 _phrase_in_text(term, haystack) for term in intent.qualifier_terms
             )
             actor_hit = any(_phrase_in_text(term, haystack) for term in intent.actor_terms)
-            if target_hit and (qualifier_hit or actor_hit):
+            issue_hit = any(
+                _phrase_in_text(term, haystack)
+                for term in [
+                    *intent.core_phrases,
+                    *intent.qualifier_terms,
+                    *intent.triggers,
+                ]
+            )
+            if target_hit and (qualifier_hit or actor_hit) and issue_hit:
                 matches.append(intent)
         return matches
 
@@ -137,7 +151,352 @@ class LegalIntentRegistry:
                     "confidentialitatea salariului",
                     "registrul general de evidenta",
                 ],
-            )
+            ),
+            LegalIntent(
+                id="labor_salary_payment",
+                domain="munca",
+                meta_intents=["payment", "obligation", "remedy"],
+                triggers=[
+                    "plata salariului",
+                    "intarzie plata salariului",
+                    "intarzierea platii salariului",
+                    "neplata salariului",
+                    "salariu neplatit",
+                    "drepturi salariale restante",
+                ],
+                core_concepts=["salary_payment", "wage_due"],
+                core_phrases=[
+                    "plata salariului",
+                    "drepturi salariale",
+                    "salariul se plateste",
+                    "salariu neplatit",
+                ],
+                target_concepts=["salary"],
+                target_terms=["salariu", "salariul", "salariului", "drepturi salariale", "remuneratie"],
+                actor_concepts=["employer", "employee"],
+                actor_terms=["angajator", "angajatorul", "salariat", "salariatul"],
+                qualifier_concepts=["delayed_payment", "unpaid_salary"],
+                qualifier_terms=["intarzie", "intarziere", "neplata", "restant", "restante"],
+                distractor_terms=[
+                    "act aditional",
+                    "modificare contract",
+                    "confidentialitatea salariului",
+                    "salariul minim",
+                ],
+            ),
+            LegalIntent(
+                id="labor_dismissal",
+                domain="munca",
+                meta_intents=["termination", "procedure", "obligation"],
+                triggers=[
+                    "concediere",
+                    "preaviz",
+                    "decizie de concediere",
+                    "incetarea contractului de munca",
+                    "dat afara",
+                ],
+                core_concepts=["dismissal", "notice"],
+                core_phrases=[
+                    "concediere",
+                    "preaviz",
+                    "decizie de concediere",
+                    "incetarea contractului individual de munca",
+                ],
+                target_concepts=["dismissal", "notice"],
+                target_terms=["concediere", "preaviz", "incetare", "demitere"],
+                actor_concepts=["employer", "employee"],
+                actor_terms=["angajator", "angajatorul", "salariat", "salariatul"],
+                qualifier_concepts=["before_dismissal", "without_notice"],
+                qualifier_terms=["inainte", "fara preaviz", "disciplinar", "colectiva"],
+                distractor_terms=["demisie", "pensie", "salariu minim"],
+            ),
+            LegalIntent(
+                id="labor_working_time",
+                domain="munca",
+                meta_intents=["working_time", "obligation", "limit"],
+                triggers=[
+                    "ore suplimentare",
+                    "program de lucru",
+                    "timp de munca",
+                    "pontaj",
+                    "repaus saptamanal",
+                    "munca de noapte",
+                ],
+                core_concepts=["working_time", "overtime", "rest_period"],
+                core_phrases=[
+                    "timp de munca",
+                    "ore suplimentare",
+                    "program de lucru",
+                    "repaus",
+                    "munca de noapte",
+                ],
+                target_concepts=["working_time", "overtime"],
+                target_terms=["ore", "program", "pontaj", "timp de munca", "repaus"],
+                actor_concepts=["employer", "employee"],
+                actor_terms=["angajator", "angajatorul", "salariat", "salariatul"],
+                qualifier_concepts=["overtime", "night_work", "weekly_rest"],
+                qualifier_terms=["suplimentare", "noapte", "saptamanal", "maxim"],
+                distractor_terms=["concediu", "concediere", "salariu restant"],
+            ),
+            LegalIntent(
+                id="labor_leave",
+                domain="munca",
+                meta_intents=["leave", "entitlement", "procedure"],
+                triggers=[
+                    "concediu de odihna",
+                    "concediul de odihna",
+                    "concediu medical",
+                    "zile libere",
+                    "indemnizatie de concediu",
+                    "cerere de concediu",
+                ],
+                core_concepts=["leave", "paid_leave"],
+                core_phrases=[
+                    "concediu de odihna",
+                    "concediu medical",
+                    "zile libere",
+                    "indemnizatie de concediu",
+                ],
+                target_concepts=["leave"],
+                target_terms=["concediu", "concediul", "zile libere", "indemnizatie"],
+                actor_concepts=["employer", "employee"],
+                actor_terms=["angajator", "angajatorul", "salariat", "salariatul"],
+                qualifier_concepts=["annual_leave", "medical_leave"],
+                qualifier_terms=["odihna", "medical", "neefectuat", "aprobare"],
+                distractor_terms=["concediere", "preaviz", "ore suplimentare"],
+            ),
+            LegalIntent(
+                id="contravention_sanction",
+                domain="contraventional",
+                meta_intents=["sanction", "liability"],
+                triggers=[
+                    "sanctiune contraventionala",
+                    "amenda pentru contraventie",
+                    "ce amenda",
+                    "proces verbal de contraventie",
+                ],
+                core_concepts=["contravention", "fine", "sanction"],
+                core_phrases=["contraventie", "sanctiune contraventionala", "amenda"],
+                target_concepts=["fine", "sanction"],
+                target_terms=["amenda", "sanctiune", "contraventie"],
+                actor_concepts=["offender", "public_authority"],
+                actor_terms=["contravenient", "agent constatator", "autoritate"],
+                qualifier_concepts=["contravention"],
+                qualifier_terms=["contraventional", "proces verbal"],
+                distractor_terms=["impozit", "salariu", "contract civil"],
+            ),
+            LegalIntent(
+                id="contravention_challenge",
+                domain="contraventional",
+                meta_intents=["procedure", "challenge", "remedy"],
+                triggers=[
+                    "contest amenda",
+                    "contesta amenda",
+                    "cum contest",
+                    "plangere contraventionala",
+                    "anulare proces verbal",
+                    "contest procesul verbal",
+                ],
+                core_concepts=["contravention_challenge", "complaint"],
+                core_phrases=[
+                    "plangere contraventionala",
+                    "contestare amenda",
+                    "anulare proces verbal",
+                    "proces verbal contraventional",
+                ],
+                target_concepts=["fine", "report"],
+                target_terms=["amenda", "proces verbal", "sanctiune"],
+                actor_concepts=["offender", "public_authority"],
+                actor_terms=["contravenient", "agent constatator", "autoritate"],
+                qualifier_concepts=["challenge", "deadline"],
+                qualifier_terms=["contest", "contesta", "plangere", "termen"],
+                distractor_terms=["plata impozit", "salariu", "concediere"],
+            ),
+            LegalIntent(
+                id="contravention_payment_deadline",
+                domain="contraventional",
+                meta_intents=["payment", "deadline", "procedure"],
+                triggers=[
+                    "termen plata amenda",
+                    "termenul de plata a amenzii",
+                    "platesc amenda",
+                    "achit amenda",
+                    "plata amenzii",
+                    "jumatate din minim",
+                    "plata amenzii contraventionale",
+                ],
+                core_concepts=["fine_payment", "deadline"],
+                core_phrases=[
+                    "plata amenzii",
+                    "termen de plata",
+                    "achitarea amenzii",
+                    "jumatate din minim",
+                ],
+                target_concepts=["fine", "payment_deadline"],
+                target_terms=["amenda", "amenzii", "plata", "termen", "achitare"],
+                actor_concepts=["offender", "public_authority"],
+                actor_terms=["contravenient", "autoritate", "trezorerie"],
+                qualifier_concepts=["payment_deadline", "reduced_payment"],
+                qualifier_terms=["termen", "jumatate", "minim", "rapid"],
+                distractor_terms=["contest", "plangere", "salariu"],
+            ),
+            LegalIntent(
+                id="civil_contract_validity",
+                domain="civil",
+                meta_intents=["validity", "condition"],
+                triggers=[
+                    "contract valabil",
+                    "validitatea contractului",
+                    "nulitate contract",
+                    "consimtamant",
+                    "capacitate de a contracta",
+                ],
+                core_concepts=["contract_validity", "consent", "capacity"],
+                core_phrases=[
+                    "validitatea contractului",
+                    "contract valabil",
+                    "nulitate",
+                    "consimtamant",
+                    "capacitate",
+                ],
+                target_concepts=["contract"],
+                target_terms=["contract", "act juridic", "clauza"],
+                actor_concepts=["party", "creditor", "debtor"],
+                actor_terms=["parte", "parti", "creditor", "debitor"],
+                qualifier_concepts=["validity", "nullity"],
+                qualifier_terms=["valabil", "nulitate", "anulare", "consimtamant"],
+                distractor_terms=["concediere", "amenda contraventionala", "anaf"],
+            ),
+            LegalIntent(
+                id="civil_liability",
+                domain="civil",
+                meta_intents=["liability", "remedy", "damages"],
+                triggers=[
+                    "raspundere civila",
+                    "daune",
+                    "prejudiciu",
+                    "despagubiri",
+                    "vina",
+                ],
+                core_concepts=["civil_liability", "damage", "fault"],
+                core_phrases=[
+                    "raspundere civila",
+                    "prejudiciu",
+                    "despagubiri",
+                    "repararea prejudiciului",
+                ],
+                target_concepts=["damages", "liability"],
+                target_terms=["daune", "prejudiciu", "despagubiri", "raspundere"],
+                actor_concepts=["injured_party", "liable_party"],
+                actor_terms=["persoana vatamata", "autor", "debitor", "creditor"],
+                qualifier_concepts=["fault", "causation"],
+                qualifier_terms=["vina", "culpa", "cauzalitate", "fapta"],
+                distractor_terms=["salariu", "amenda", "impozit"],
+            ),
+            LegalIntent(
+                id="civil_prescription",
+                domain="civil",
+                meta_intents=["limitation_period", "deadline"],
+                triggers=[
+                    "se prescrie",
+                    "prescriptie",
+                    "dreptul la actiune",
+                    "termen de prescriptie",
+                    "datorie civila",
+                ],
+                core_concepts=["prescription", "limitation_period"],
+                core_phrases=[
+                    "prescriptie",
+                    "dreptul la actiune",
+                    "termen de prescriptie",
+                    "datorie civila",
+                ],
+                target_concepts=["claim", "debt"],
+                target_terms=["actiune", "drept", "datorie", "creanta"],
+                actor_concepts=["creditor", "debtor"],
+                actor_terms=["creditor", "debitor", "parte"],
+                qualifier_concepts=["limitation_period"],
+                qualifier_terms=["termen", "cat timp", "in cat timp", "prescrie"],
+                distractor_terms=["concediere", "amenda", "declaratie fiscala"],
+            ),
+            LegalIntent(
+                id="tax_payment_obligation",
+                domain="fiscal",
+                meta_intents=["payment", "obligation"],
+                triggers=[
+                    "plata impozit",
+                    "plata taxei",
+                    "cand platesc impozitul",
+                    "obligatie de plata fiscala",
+                    "taxe si impozite",
+                ],
+                core_concepts=["tax_payment", "tax_obligation"],
+                core_phrases=[
+                    "plata impozitului",
+                    "obligatie fiscala",
+                    "obligatie de plata",
+                    "taxe si impozite",
+                ],
+                target_concepts=["tax", "payment"],
+                target_terms=["impozit", "taxa", "tva", "contributii"],
+                actor_concepts=["taxpayer", "tax_authority"],
+                actor_terms=["contribuabil", "anaf", "organ fiscal"],
+                qualifier_concepts=["due_date", "tax_obligation"],
+                qualifier_terms=["scadenta", "termen", "datorat", "de plata"],
+                distractor_terms=["salariu", "concediere", "amenda contraventionala"],
+            ),
+            LegalIntent(
+                id="tax_declaration_obligation",
+                domain="fiscal",
+                meta_intents=["procedure", "obligation"],
+                triggers=[
+                    "declaratie fiscala",
+                    "declaratia fiscala",
+                    "depusa declaratia",
+                    "depun declaratia",
+                    "formular fiscal",
+                ],
+                core_concepts=["tax_declaration", "filing_obligation"],
+                core_phrases=[
+                    "declaratie fiscala",
+                    "depunerea declaratiei",
+                    "formular fiscal",
+                    "anaf",
+                ],
+                target_concepts=["tax_declaration"],
+                target_terms=["declaratie", "formular", "anaf", "fiscal"],
+                actor_concepts=["taxpayer", "tax_authority"],
+                actor_terms=["contribuabil", "anaf", "organ fiscal"],
+                qualifier_concepts=["filing_deadline"],
+                qualifier_terms=["cand", "termen", "depusa", "depunere"],
+                distractor_terms=["plata salariului", "concediu", "contraventie"],
+            ),
+            LegalIntent(
+                id="tax_penalty_interest",
+                domain="fiscal",
+                meta_intents=["sanction", "interest", "late_payment"],
+                triggers=[
+                    "dobanzi penalitati",
+                    "penalitati fiscale",
+                    "dobanda fiscala",
+                    "majorari intarziere",
+                    "intarziere plata impozit",
+                ],
+                core_concepts=["tax_penalty", "interest", "late_payment"],
+                core_phrases=[
+                    "penalitati fiscale",
+                    "dobanzi",
+                    "majorari de intarziere",
+                    "intarziere la plata",
+                ],
+                target_concepts=["penalty", "interest"],
+                target_terms=["penalitati", "dobanzi", "majorari", "intarziere"],
+                actor_concepts=["taxpayer", "tax_authority"],
+                actor_terms=["contribuabil", "anaf", "organ fiscal"],
+                qualifier_concepts=["late_payment"],
+                qualifier_terms=["intarziere", "neplata", "scadenta"],
+                distractor_terms=["preaviz", "concediere", "amenda contraventionala"],
+            ),
         ]
 
 
@@ -147,9 +506,10 @@ class QueryFrameBuilder:
 
     def build(self, *, question: str, plan: QueryPlan) -> QueryFrame:
         matched_intents = self.registry.matching_intents(question=question, plan=plan)
+        domain = self._resolved_domain(plan, matched_intents)
         generic_labor = (
             not matched_intents
-            and normalize_legal_text(str(plan.legal_domain or "")) == "munca"
+            and normalize_legal_text(str(domain or "")) == "munca"
         )
         intents = [intent.id for intent in matched_intents]
         if generic_labor:
@@ -168,9 +528,25 @@ class QueryFrameBuilder:
             actors=actors,
             qualifiers=qualifiers,
         )
+        ambiguity_flags = self._ambiguity_flags(
+            question=question,
+            plan=plan,
+            intents=matched_intents,
+            domain=domain,
+        )
+        confidence = self._confidence(
+            question=question,
+            plan=plan,
+            intents=matched_intents,
+            domain=domain,
+            targets=targets,
+            actors=actors,
+            qualifiers=qualifiers,
+            generic_labor=generic_labor,
+        )
 
         return QueryFrame(
-            domain=plan.legal_domain,
+            domain=domain,
             intents=self._dedupe(intents),
             meta_intents=self._dedupe(meta_intents),
             targets=self._dedupe(targets),
@@ -178,7 +554,107 @@ class QueryFrameBuilder:
             qualifiers=self._dedupe(qualifiers),
             surface_phrases=self._dedupe(surface_phrases),
             normalized_terms=self._dedupe(normalized_terms),
+            confidence=confidence,
+            ambiguity_flags=ambiguity_flags,
+            requires_clarification=self._requires_clarification(
+                confidence=confidence,
+                ambiguity_flags=ambiguity_flags,
+            ),
         )
+
+    def _resolved_domain(
+        self,
+        plan: QueryPlan,
+        intents: list[LegalIntent],
+    ) -> str | None:
+        if plan.legal_domain:
+            return plan.legal_domain
+        intent_domains = {
+            intent.domain for intent in intents if intent.domain
+        }
+        if len(intent_domains) == 1:
+            return next(iter(intent_domains))
+        return None
+
+    def _ambiguity_flags(
+        self,
+        *,
+        question: str,
+        plan: QueryPlan,
+        intents: list[LegalIntent],
+        domain: str | None,
+    ) -> list[str]:
+        flags = list(plan.ambiguity_flags)
+        tokens = self._tokens(question)
+        intent_domains = {
+            intent.domain for intent in intents if intent.domain
+        }
+        if len(tokens) < 3:
+            flags.append("too_short")
+        if not domain and not intents:
+            flags.append("unknown_legal_domain")
+        if len(intent_domains) > 1:
+            flags.append("multiple_possible_domains")
+        if len(intents) > 1:
+            flags.append("multiple_possible_intents")
+        return self._dedupe(flags)
+
+    def _confidence(
+        self,
+        *,
+        question: str,
+        plan: QueryPlan,
+        intents: list[LegalIntent],
+        domain: str | None,
+        targets: list[str],
+        actors: list[str],
+        qualifiers: list[str],
+        generic_labor: bool,
+    ) -> float:
+        if not intents:
+            if generic_labor or domain:
+                return 0.40
+            return 0.20 if len(self._tokens(question)) >= 3 else 0.10
+
+        explicit_trigger = any(
+            self._intent_has_trigger(intent, question, plan) for intent in intents
+        )
+        domain_match = bool(
+            domain
+            and any(intent.domain == domain for intent in intents if intent.domain)
+        )
+        if explicit_trigger and domain_match:
+            return 0.90
+        if (targets and (actors or qualifiers)) and domain_match:
+            return 0.75
+        if explicit_trigger:
+            return 0.60
+        if domain_match:
+            return 0.55
+        return 0.30
+
+    def _requires_clarification(
+        self,
+        *,
+        confidence: float,
+        ambiguity_flags: list[str],
+    ) -> bool:
+        if "too_short" in ambiguity_flags:
+            return True
+        if confidence < 0.35:
+            return True
+        return "unknown_legal_domain" in ambiguity_flags
+
+    def _intent_has_trigger(
+        self,
+        intent: LegalIntent,
+        question: str,
+        plan: QueryPlan,
+    ) -> bool:
+        haystack = normalize_legal_text(
+            " ".join([question, plan.normalized_question])
+        )
+        return any(_phrase_in_text(trigger, haystack) for trigger in intent.triggers)
 
     def _meta_intents(
         self,
@@ -207,7 +683,8 @@ class QueryFrameBuilder:
             concept_values = getattr(intent, f"{kind}_concepts")
             term_values = getattr(intent, f"{kind}_terms")
             for concept in concept_values:
-                if any(_phrase_in_text(term, haystack) for term in term_values):
+                terms = [*term_values, *self._concept_terms(concept)]
+                if any(_phrase_in_text(term, haystack) for term in terms):
                     concepts.append(concept)
         if "without_addendum" in concepts and "without_agreement" not in concepts:
             concepts.append("without_agreement")
@@ -251,13 +728,76 @@ class QueryFrameBuilder:
 
     def _concept_terms(self, concept: str) -> list[str]:
         aliases = {
-            "salary": ["salariu", "salariul", "salarizare"],
+            "salary": ["salariu", "salariul", "salariului", "salarizare"],
             "employer": ["angajator", "angajatorul"],
             "employee": ["salariat", "salariatul"],
             "without_addendum": ["act", "aditional"],
             "without_agreement": ["acord", "parti"],
             "contract_modification": ["modificare", "modificat", "contract"],
             "agreement_of_parties": ["acord", "partilor"],
+            "delayed_payment": ["intarzie", "intarziere", "restant"],
+            "unpaid_salary": ["neplata", "neplatit", "restant"],
+            "dismissal": ["concediere", "concediat", "demitere"],
+            "notice": ["preaviz"],
+            "before_dismissal": ["inainte", "preaviz"],
+            "without_notice": ["fara", "preaviz"],
+            "working_time": ["program", "timp", "munca", "pontaj"],
+            "overtime": ["ore", "suplimentare"],
+            "rest_period": ["repaus"],
+            "night_work": ["noapte"],
+            "weekly_rest": ["saptamanal", "repaus"],
+            "leave": ["concediu", "concediul", "zile", "libere"],
+            "paid_leave": ["concediu", "concediul", "indemnizatie"],
+            "annual_leave": ["odihna"],
+            "medical_leave": ["medical"],
+            "contravention": ["contraventie", "contraventional"],
+            "contravention_challenge": ["contest", "contesta", "plangere"],
+            "fine": ["amenda"],
+            "sanction": ["sanctiune"],
+            "offender": ["contravenient"],
+            "public_authority": ["autoritate", "agent", "constatator"],
+            "report": ["proces", "verbal"],
+            "complaint": ["plangere"],
+            "challenge": ["contest", "contesta"],
+            "deadline": ["termen"],
+            "fine_payment": ["plata", "amenda"],
+            "payment_deadline": ["termen", "plata"],
+            "reduced_payment": ["jumatate", "minim"],
+            "contract_validity": ["contract", "valabil", "validitate"],
+            "consent": ["consimtamant"],
+            "capacity": ["capacitate"],
+            "contract": ["contract"],
+            "party": ["parte", "parti"],
+            "creditor": ["creditor"],
+            "debtor": ["debitor"],
+            "validity": ["valabil", "validitate"],
+            "nullity": ["nulitate", "anulare"],
+            "civil_liability": ["raspundere", "civila"],
+            "damage": ["prejudiciu", "daune"],
+            "fault": ["vina", "culpa"],
+            "damages": ["daune", "despagubiri"],
+            "liability": ["raspundere"],
+            "injured_party": ["persoana", "vatamata"],
+            "liable_party": ["autor", "debitor"],
+            "causation": ["cauzalitate"],
+            "prescription": ["prescriptie", "prescrie"],
+            "limitation_period": ["termen", "prescriptie"],
+            "claim": ["actiune", "drept"],
+            "debt": ["datorie", "creanta"],
+            "tax_payment": ["plata", "impozit", "taxa"],
+            "tax_obligation": ["obligatie", "fiscala"],
+            "tax": ["impozit", "taxa", "tva"],
+            "payment": ["plata"],
+            "taxpayer": ["contribuabil"],
+            "tax_authority": ["anaf", "organ", "fiscal"],
+            "due_date": ["scadenta", "termen"],
+            "tax_declaration": ["declaratie", "fiscala"],
+            "filing_obligation": ["depunere", "declaratie"],
+            "filing_deadline": ["termen", "depunere", "cand"],
+            "tax_penalty": ["penalitati", "fiscale"],
+            "interest": ["dobanzi", "majorari"],
+            "penalty": ["penalitati"],
+            "late_payment": ["intarziere", "neplata"],
         }
         return aliases.get(concept, [normalize_legal_text(concept)])
 

--- a/apps/api/app/services/query_orchestrator.py
+++ b/apps/api/app/services/query_orchestrator.py
@@ -25,6 +25,7 @@ from .generation_adapter import (
 from .graph_expansion_policy import GraphExpansionPolicy
 from .legal_ranker import LegalRanker
 from .mock_evidence import MockEvidenceService
+from .query_frame import QueryFrameBuilder
 from .query_understanding import QueryUnderstanding
 from .raw_retriever_client import RAW_RETRIEVAL_NOT_CONFIGURED, RawRetrieverClient
 
@@ -41,6 +42,7 @@ class QueryOrchestrator:
         generation_adapter: GenerationAdapter | None = None,
         citation_verifier: CitationVerifier | None = None,
         answer_repair: AnswerRepair | None = None,
+        query_frame_builder: QueryFrameBuilder | None = None,
     ) -> None:
         self.evidence_service = evidence_service or MockEvidenceService()
         self.query_understanding = query_understanding or QueryUnderstanding()
@@ -55,10 +57,15 @@ class QueryOrchestrator:
         self.generation_adapter = generation_adapter or GenerationAdapter()
         self.citation_verifier = citation_verifier or CitationVerifier()
         self.answer_repair = answer_repair or AnswerRepair()
+        self.query_frame_builder = query_frame_builder or QueryFrameBuilder()
 
     async def run(self, request: QueryRequest) -> QueryResponse:
         query_id = self._query_id(request)
         query_plan = self.query_understanding.build_plan(request)
+        query_frame = self.query_frame_builder.build(
+            question=request.question,
+            plan=query_plan,
+        )
         raw_retrieval = await self.raw_retriever_client.retrieve(
             query_plan,
             top_k=50,
@@ -136,6 +143,7 @@ class QueryOrchestrator:
                 evidence_service=self.evidence_service.__class__.__name__,
                 retrieval_mode=self._retrieval_mode(raw_retrieval),
                 query_understanding=query_plan,
+                query_frame=query_frame.model_dump(mode="json"),
                 retrieval=raw_retrieval.debug,
                 graph_expansion=graph_expansion.debug,
                 legal_ranker=legal_ranker.debug,

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -84,6 +84,14 @@ def test_post_api_query_debug_true_includes_debug_payload():
     assert "obligation" in debug["query_understanding"]["query_types"]
     assert debug["query_understanding"]["exact_citations"] == []
     assert debug["query_understanding"]["retrieval_filters"]["status"] == "active"
+    assert debug["query_frame"]["domain"] == "munca"
+    assert "labor_contract_modification" in debug["query_frame"]["intents"]
+    assert "salary" in debug["query_frame"]["targets"]
+    assert {
+        "without_addendum",
+        "without_agreement",
+    }.intersection(debug["query_frame"]["qualifiers"])
+    assert debug["query_frame"]["requires_clarification"] is False
     retrieval = debug["retrieval"]
     assert retrieval["fallback_used"] is True
     assert retrieval["request_payload"]["filters"]["legal_domain"] == "munca"
@@ -254,6 +262,13 @@ def test_post_api_query_demo_uses_raw_retriever_client_internal_candidates():
         "status": "active",
         "date_context": "current",
     }
+    assert payload["debug"]["query_frame"]["domain"] == "munca"
+    assert "labor_contract_modification" in payload["debug"]["query_frame"]["intents"]
+    assert "salary" in payload["debug"]["query_frame"]["targets"]
+    assert {
+        "without_addendum",
+        "without_agreement",
+    }.intersection(payload["debug"]["query_frame"]["qualifiers"])
     assert payload["debug"]["evidence_pack"]["selected_evidence_count"] > 0
 
 

--- a/tests/fixtures/eval/query_frame_cases.json
+++ b/tests/fixtures/eval/query_frame_cases.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": "labor_salary_reduction_without_addendum",
+    "question": "Poate angajatorul să-mi scadă salariul fără act adițional?",
+    "expected_domain": "munca",
+    "expected_intents_any": ["labor_contract_modification"],
+    "expected_targets_any": ["salary"],
+    "expected_actors_any": ["employer", "employee"],
+    "expected_qualifiers_any": ["without_addendum", "without_agreement"],
+    "expected_requires_clarification": false
+  },
+  {
+    "id": "labor_salary_payment_delay",
+    "question": "Ce pot face dacă angajatorul întârzie plata salariului?",
+    "expected_domain": "munca",
+    "expected_intents_any": ["labor_salary_payment"],
+    "expected_targets_any": ["salary"],
+    "expected_actors_any": ["employer", "employee"]
+  },
+  {
+    "id": "labor_dismissal_notice",
+    "question": "Angajatorul trebuie să îmi dea preaviz înainte de concediere?",
+    "expected_domain": "munca",
+    "expected_intents_any": ["labor_dismissal"],
+    "expected_meta_intents_any": ["procedure", "obligation"]
+  },
+  {
+    "id": "contravention_fine_challenge",
+    "question": "Cum contest o amendă contravențională?",
+    "expected_domain": "contraventional",
+    "expected_intents_any": ["contravention_challenge"],
+    "expected_meta_intents_any": ["procedure"]
+  },
+  {
+    "id": "civil_prescription",
+    "question": "În cât timp se prescrie dreptul la acțiune pentru o datorie civilă?",
+    "expected_domain": "civil",
+    "expected_intents_any": ["civil_prescription"],
+    "expected_meta_intents_any": ["limitation_period"]
+  },
+  {
+    "id": "tax_declaration",
+    "question": "Când trebuie depusă declarația fiscală la ANAF?",
+    "expected_domain": "fiscal",
+    "expected_intents_any": ["tax_declaration_obligation"],
+    "expected_meta_intents_any": ["procedure", "obligation"]
+  },
+  {
+    "id": "unknown_short",
+    "question": "Ce fac?",
+    "expected_requires_clarification": true
+  }
+]

--- a/tests/test_graph_expansion_policy.py
+++ b/tests/test_graph_expansion_policy.py
@@ -5,7 +5,6 @@ from apps.api.app.services.graph_expansion_policy import (
     EDGE_TYPE_WEIGHTS,
     GRAPH_EXPANSION_EMPTY_OR_UNAVAILABLE,
     GRAPH_EXPANSION_NO_SEED_CANDIDATES,
-    GRAPH_EXPANSION_NOT_CONFIGURED,
     GraphExpansionPolicy,
 )
 from apps.api.app.services.query_understanding import QueryUnderstanding
@@ -68,10 +67,7 @@ async def test_seed_candidate_without_neighbors_client_returns_seed_only_fallbac
         debug=True,
     )
 
-    assert result.warnings == [
-        GRAPH_EXPANSION_NOT_CONFIGURED,
-        GRAPH_EXPANSION_EMPTY_OR_UNAVAILABLE,
-    ]
+    assert result.warnings == []
     assert len(result.seed_candidates) == 1
     assert len(result.expanded_candidates) == 1
     expanded = result.expanded_candidates[0]
@@ -84,8 +80,49 @@ async def test_seed_candidate_without_neighbors_client_returns_seed_only_fallbac
     assert result.graph_nodes[0].legal_unit_id == "ro.codul_muncii.art_41.alin_1"
     assert result.graph_edges == []
     assert result.debug["fallback_used"] is True
+    assert result.debug["graph_expansion_backend"] == "fallback"
+    assert result.debug["graph_expansion_fallback_used"] is True
+    assert result.debug["expanded_from_raw_candidates"] is True
     assert result.debug["reason"] == "graph neighbors endpoint is not configured"
     assert result.debug["expanded_candidate_count"] == 1
+
+
+@pytest.mark.anyio
+async def test_empty_neighbors_returns_seed_fallback_without_graph_warning():
+    class EmptyNeighborsClient:
+        is_configured = True
+
+        def neighbors_for(self, unit_id, *, allowed_edge_types, max_depth):
+            return []
+
+    plan = build_plan("Ce spune art. 41 alin. (1) din Codul muncii?")
+    candidate = RetrievalCandidate(
+        unit_id="ro.codul_muncii.art_41.alin_1",
+        rank=1,
+        retrieval_score=0.91,
+        score_breakdown={"bm25": 0.7},
+        unit={
+            "title": "Codul muncii art. 41 alin. 1",
+            "legal_domain": "munca",
+            "status": "active",
+            "importance": 0.9,
+        },
+    )
+
+    result = await GraphExpansionPolicy(
+        neighbors_client=EmptyNeighborsClient()
+    ).expand(
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=[candidate]),
+        debug=True,
+    )
+
+    assert result.warnings == []
+    assert [expanded.unit_id for expanded in result.expanded_candidates] == [
+        "ro.codul_muncii.art_41.alin_1"
+    ]
+    assert result.debug["graph_expansion_backend"] == "fallback"
+    assert result.debug["expanded_from_raw_candidates"] is True
 
 
 def test_policy_config_defaults_and_edge_weights_are_exposed():

--- a/tests/test_query_frame.py
+++ b/tests/test_query_frame.py
@@ -1,0 +1,125 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from apps.api.app.schemas import QueryPlan, QueryRequest
+from apps.api.app.services.query_frame import LegalIntentRegistry, QueryFrameBuilder
+from apps.api.app.services.query_understanding import QueryUnderstanding, normalize_ro_text
+
+
+FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "eval" / "query_frame_cases.json"
+)
+
+
+def build_plan(question: str) -> QueryPlan:
+    if len(question) < 10:
+        return QueryPlan(
+            question=question,
+            normalized_question=normalize_ro_text(question),
+            legal_domain=None,
+            domain_confidence=0.0,
+            domain_scores={},
+            ambiguity_flags=["low_domain_confidence"],
+            retrieval_filters={"status": "active", "date_context": "current"},
+        )
+    return QueryUnderstanding().build_plan(
+        QueryRequest(
+            question=question,
+            jurisdiction="RO",
+            date="current",
+            mode="strict_citations",
+            debug=True,
+        )
+    )
+
+
+def build_frame(question: str):
+    plan = build_plan(question)
+    return QueryFrameBuilder().build(question=question, plan=plan)
+
+
+def assert_any(actual: list[str], expected: list[str] | None) -> None:
+    if not expected:
+        return
+    assert set(actual).intersection(expected)
+
+
+@pytest.mark.parametrize(
+    "case",
+    json.loads(FIXTURE_PATH.read_text(encoding="utf-8")),
+    ids=lambda case: case["id"],
+)
+def test_query_frame_eval_baseline(case):
+    frame = build_frame(case["question"])
+
+    if "expected_domain" in case:
+        assert frame.domain == case["expected_domain"]
+    assert_any(frame.intents, case.get("expected_intents_any"))
+    assert_any(frame.meta_intents, case.get("expected_meta_intents_any"))
+    assert_any(frame.targets, case.get("expected_targets_any"))
+    assert_any(frame.actors, case.get("expected_actors_any"))
+    assert_any(frame.qualifiers, case.get("expected_qualifiers_any"))
+    if "expected_requires_clarification" in case:
+        assert frame.requires_clarification is case["expected_requires_clarification"]
+    if not frame.requires_clarification:
+        assert frame.confidence > 0.70
+
+
+def test_demo_query_frame_keeps_expected_labor_contract_fields():
+    frame = build_frame("Poate angajatorul sa-mi scada salariul fara act aditional?")
+
+    assert frame.domain == "munca"
+    assert "labor_contract_modification" in frame.intents
+    assert "salary" in frame.targets
+    assert "employer" in frame.actors
+    assert "employee" in frame.actors
+    assert {
+        "without_addendum",
+        "without_agreement",
+    }.intersection(frame.qualifiers)
+    assert frame.requires_clarification is False
+
+
+@pytest.mark.parametrize(
+    ("question", "intent_id"),
+    [
+        ("Ce pot face daca angajatorul intarzie plata salariului?", "labor_salary_payment"),
+        ("Angajatorul trebuie sa imi dea preaviz inainte de concediere?", "labor_dismissal"),
+        ("Cate ore suplimentare poate cere angajatorul?", "labor_working_time"),
+        ("Cum se aproba concediul de odihna?", "labor_leave"),
+        ("Ce sanctiune contraventionala se poate aplica?", "contravention_sanction"),
+        ("Cum contest o amenda contraventionala?", "contravention_challenge"),
+        ("Care este termenul de plata a amenzii contraventionale?", "contravention_payment_deadline"),
+        ("Cand este un contract civil valabil?", "civil_contract_validity"),
+        ("Cand pot cere despagubiri pentru prejudiciu?", "civil_liability"),
+        ("In cat timp se prescrie dreptul la actiune pentru o datorie civila?", "civil_prescription"),
+        ("Cand platesc impozitul datorat?", "tax_payment_obligation"),
+        ("Cand trebuie depusa declaratia fiscala la ANAF?", "tax_declaration_obligation"),
+        ("Ce penalitati fiscale se aplica pentru intarziere?", "tax_penalty_interest"),
+    ],
+)
+def test_each_registered_v1_intent_is_detectable(question, intent_id):
+    frame = build_frame(question)
+
+    assert intent_id in frame.intents
+    assert frame.confidence > 0.70
+    assert frame.requires_clarification is False
+
+
+def test_unknown_short_query_does_not_create_confident_artificial_intent():
+    frame = build_frame("Ce fac?")
+
+    assert frame.intents == []
+    assert frame.confidence < 0.35
+    assert frame.requires_clarification is True
+
+
+def test_registry_has_no_article_or_unit_id_specific_rules():
+    forbidden_fragments = ("art.", "article_number", "unit_id", "ro.codul")
+
+    for intent in LegalIntentRegistry().all():
+        payload = intent.model_dump(mode="json")
+        flattened = json.dumps(payload, ensure_ascii=False).casefold()
+        assert not any(fragment in flattened for fragment in forbidden_fragments)


### PR DESCRIPTION
This pull request introduces a new "query frame" extraction and debugging capability to the API, enhancing the system's ability to analyze and explain user questions in greater detail. It also improves the debug information for graph expansion, clarifies handling of fallback scenarios, and adds comprehensive tests and fixtures for the new query frame logic. The most important changes are grouped below:

**Query Frame Extraction and Debugging:**
* Added a new `QueryFrameBuilder` service and integrated it into the `QueryOrchestrator`, so that every query now generates a structured "query frame" (domain, intents, targets, actors, qualifiers, etc.) included in the debug output. The `QueryDebugData` schema and orchestrator logic were updated to support this. [[1]](diffhunk://#diff-f14d76d4a4582f33ea6ddb2e237372a3e64bba18a9eab0c980af1af918190d63R247) [[2]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R28) [[3]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R45) [[4]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R60-R68) [[5]](diffhunk://#diff-6d7b7e100adc6fc0edf777c1c42ebaecfe711f0863f7dc73af2dc0a387bcfeb3R146)

**Graph Expansion Debugging Improvements:**
* Expanded the debug output for graph expansion to include backend type (`fallback` or `neighbors_client`), whether the expansion was from raw candidates, and clarified fallback usage. Warnings for fallback scenarios were removed to avoid confusion, and the debug payload is now more descriptive for both normal and fallback paths. [[1]](diffhunk://#diff-da0e6b8b1f36d7d3bce1c7047698c555ce50caf429ff1ea21d38d003f1424289L95-R100) [[2]](diffhunk://#diff-da0e6b8b1f36d7d3bce1c7047698c555ce50caf429ff1ea21d38d003f1424289L117-R121) [[3]](diffhunk://#diff-da0e6b8b1f36d7d3bce1c7047698c555ce50caf429ff1ea21d38d003f1424289L266-R269) [[4]](diffhunk://#diff-da0e6b8b1f36d7d3bce1c7047698c555ce50caf429ff1ea21d38d003f1424289R282-R283) [[5]](diffhunk://#diff-da0e6b8b1f36d7d3bce1c7047698c555ce50caf429ff1ea21d38d003f1424289R538-R539) [[6]](diffhunk://#diff-da0e6b8b1f36d7d3bce1c7047698c555ce50caf429ff1ea21d38d003f1424289R553-R557)

**Testing and Fixtures for Query Frame:**
* Added a new test suite `test_query_frame.py` with parameterized tests and a fixture file (`query_frame_cases.json`) covering a wide variety of legal queries, ensuring that the query frame extraction logic is robust and accurate. [[1]](diffhunk://#diff-ce2dfe58d062a90c9c64ddd84cbdf2110a7abd2c7d4c4e15fb80f7ca514945f5R1-R125) [[2]](diffhunk://#diff-894eb2dd992736d5da7b5eb036d1cb5b57c223fbebfbce39b7c0e2634ae5b0a8R1-R53)
* Updated existing tests to assert the presence and correctness of the new `query_frame` fields in debug payloads. [[1]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R87-R94) [[2]](diffhunk://#diff-57411a3236d006e1bd46ac7312345e4178ff86e190c89a78853a15ef832a28d3R265-R271)

**Graph Expansion Policy Testing Improvements:**
* Updated graph expansion policy tests to reflect the new debug structure and fallback handling, and added a new test to ensure that empty neighbor results trigger the correct fallback logic without unnecessary warnings. [[1]](diffhunk://#diff-d72299902815fb7d1f0e6d2598c65a7d9e6e59487210ac28b4a764a9efc6bbd9L71-R70) [[2]](diffhunk://#diff-d72299902815fb7d1f0e6d2598c65a7d9e6e59487210ac28b4a764a9efc6bbd9R83-R127)

**Other:**
* Minor cleanup in imports and removal of unused constants from tests.

These changes collectively improve the system's debuggability, clarity of fallback behavior, and provide a foundation for more advanced query understanding features.