### PR TITLE
fix: normalize evidence roles for labor contract modification

### DIFF
--- a/apps/api/app/services/evidence_pack_compiler.py
+++ b/apps/api/app/services/evidence_pack_compiler.py
@@ -119,6 +119,27 @@ SALARY_CONTEXT_TERMS = (
 
 DIRECT_BASIS_KINDS = ("agreement_rule", "modification_scope")
 
+SUPPORT_ROLE_PRIORITY_SCORE = {
+    "direct_basis": 1.0,
+    "condition": 0.85,
+    "exception": 0.65,
+    "definition": 0.55,
+    "procedure": 0.50,
+    "sanction": 0.45,
+    "context": 0.35,
+}
+
+CONTRACT_MODIFICATION_GENERIC_CONTEXT_TERMS = (
+    "anterior incheierii contractului individual de munca",
+    "persoana selectata",
+    "informarea persoanei selectate",
+    "elementele din contract",
+    "locul muncii",
+    "felul muncii",
+    "durata contractului",
+    "drepturile si obligatiile partilor",
+)
+
 
 @dataclass
 class _EvidenceCandidate:
@@ -177,10 +198,22 @@ class EvidencePackCompiler:
             )
 
         selected = self._select_with_mmr(candidate_pool, plan=plan)
-        self._ensure_role_candidate(selected, candidate_pool, "exception")
-        self._ensure_role_candidate(selected, candidate_pool, "definition")
-        self._ensure_role_candidate(selected, candidate_pool, "sanction")
+        if self._is_contract_modification_query(plan):
+            self._ensure_role_candidate(selected, candidate_pool, "exception")
+        else:
+            self._ensure_role_candidate(selected, candidate_pool, "exception")
+            self._ensure_role_candidate(selected, candidate_pool, "definition")
+            self._ensure_role_candidate(selected, candidate_pool, "sanction")
         self._include_parent_context(selected, candidate_pool)
+        selected = self._compact_contract_modification_selection(
+            selected,
+            candidate_pool,
+            plan=plan,
+        )
+        selected = self._normalize_contract_modification_roles(
+            selected,
+            plan=plan,
+        )
 
         if len(selected) < min(self.target_evidence_units, 8):
             warnings.append(EVIDENCE_PACK_PARTIAL)
@@ -207,6 +240,8 @@ class EvidencePackCompiler:
                 input_ranked_candidate_count=len(ranked_candidates),
                 candidate_pool_size=len(candidate_pool),
                 selected=selected,
+                plan=plan,
+                query_frame=query_frame,
                 warnings=result.warnings,
             )
         return result
@@ -332,8 +367,20 @@ class EvidencePackCompiler:
         *,
         plan: QueryPlan | None,
     ) -> list[_EvidenceCandidate]:
-        target = min(self.target_evidence_units, len(candidate_pool))
+        target = self._selection_target(candidate_pool, plan=plan)
         selected = self._priority_direct_basis_candidates(
+            candidate_pool,
+            plan=plan,
+            target=target,
+        )
+        self._include_contract_modification_salary_scope(
+            selected,
+            candidate_pool,
+            plan=plan,
+            target=target,
+        )
+        self._include_contract_modification_salary_target(
+            selected,
             candidate_pool,
             plan=plan,
             target=target,
@@ -360,6 +407,33 @@ class EvidencePackCompiler:
             selected.append(best)
             remaining.remove(best)
         return selected
+
+    def _selection_target(
+        self,
+        candidate_pool: list[_EvidenceCandidate],
+        *,
+        plan: QueryPlan | None,
+    ) -> int:
+        target = min(self.target_evidence_units, len(candidate_pool))
+        if not self._is_contract_modification_query(plan):
+            return target
+        required_covered = sum(
+            1
+            for requirement_id in (
+                "contract_modification_agreement_rule",
+                "contract_modification_salary_scope",
+            )
+            if any(
+                self._candidate_covers_requirement(candidate, requirement_id)
+                for candidate in candidate_pool
+            )
+        )
+        target = min(target, 8)
+        if len(candidate_pool) >= 6:
+            target = max(target, 6)
+        if required_covered:
+            target = max(target, required_covered)
+        return min(target, self.max_evidence_units, len(candidate_pool))
 
     def _include_contract_modification_condition(
         self,
@@ -399,6 +473,126 @@ class EvidencePackCompiler:
         self._append_reason(best, "contract_modification_condition")
         self._append_reason(best, "priority_condition:act_additional")
         selected.append(best)
+
+    def _include_contract_modification_salary_scope(
+        self,
+        selected: list[_EvidenceCandidate],
+        candidate_pool: list[_EvidenceCandidate],
+        *,
+        plan: QueryPlan | None,
+        target: int,
+    ) -> None:
+        if (
+            len(selected) >= target
+            or not self._is_contract_modification_query(plan)
+            or any(
+                self._candidate_covers_requirement(
+                    candidate,
+                    "contract_modification_salary_scope",
+                )
+                for candidate in selected
+            )
+        ):
+            return
+        selected_ids = {candidate.ranked.unit_id for candidate in selected}
+        candidates = [
+            candidate
+            for candidate in candidate_pool
+            if candidate.ranked.unit_id not in selected_ids
+            and self._candidate_covers_requirement(
+                candidate,
+                "contract_modification_salary_scope",
+            )
+        ]
+        if not candidates:
+            return
+        best = max(
+            candidates,
+            key=lambda candidate: (
+                candidate.support_role == "direct_basis",
+                candidate.ranked.rerank_score,
+                candidate.ranked.retrieval_score or 0.0,
+                self._unit_specificity(candidate.unit),
+                -candidate.ranked.rank,
+                candidate.ranked.unit_id,
+            ),
+        )
+        if best.support_role == "context":
+            best.support_role = "condition"
+        best.mmr_score = self._mmr_score(best, selected)
+        self._append_reason(best, "contract_modification_salary_scope")
+        self._append_reason(best, "priority_requirement:contract_modification_salary_scope")
+        selected.append(best)
+
+    def _include_contract_modification_salary_target(
+        self,
+        selected: list[_EvidenceCandidate],
+        candidate_pool: list[_EvidenceCandidate],
+        *,
+        plan: QueryPlan | None,
+        target: int,
+    ) -> None:
+        if (
+            len(selected) >= target
+            or not self._is_contract_modification_query(plan)
+        ):
+            return
+        selected_ids = {candidate.ranked.unit_id for candidate in selected}
+        scope_parent_ids = {
+            candidate.ranked.unit_id
+            for candidate in selected
+            if self._is_contract_modification_scope_parent(
+                self._haystack(candidate.ranked, candidate.unit)
+            )
+        }
+        if not scope_parent_ids:
+            return
+        candidates = [
+            candidate
+            for candidate in candidate_pool
+            if candidate.ranked.unit_id not in selected_ids
+            and self._is_salary_target_child(candidate, parent_ids=scope_parent_ids)
+        ]
+        if not candidates:
+            return
+        best = max(
+            candidates,
+            key=lambda candidate: (
+                candidate.ranked.rerank_score,
+                candidate.ranked.retrieval_score or 0.0,
+                -candidate.ranked.rank,
+                candidate.ranked.unit_id,
+            ),
+        )
+        best.support_role = "condition"
+        best.mmr_score = self._mmr_score(best, selected)
+        self._append_reason(best, "contract_modification_salary_target_child")
+        self._append_reason(best, "priority_condition:salary_target_element")
+        selected.append(best)
+
+    def _candidate_covers_requirement(
+        self,
+        candidate: _EvidenceCandidate,
+        requirement_id: str,
+    ) -> bool:
+        if candidate.role_decision is not None and (
+            requirement_id in candidate.role_decision.matched_requirement_ids
+        ):
+            return True
+        haystack = self._haystack(candidate.ranked, candidate.unit)
+        if requirement_id == "contract_modification_agreement_rule":
+            return self._is_contract_modification_agreement_rule(haystack)
+        if requirement_id == "contract_modification_salary_scope":
+            return (
+                self._is_contract_modification_salary_scope(haystack)
+                or self._is_contract_modification_scope_parent(haystack)
+                and (
+                    candidate.ranked.score_breakdown.intent_governing_rule_parent > 0
+                    or "intent_governing_rule_parent_context:labor_contract_modification"
+                    in candidate.ranked.why_ranked
+                )
+            )
+        return False
 
     def _priority_direct_basis_candidates(
         self,
@@ -457,8 +651,13 @@ class EvidencePackCompiler:
         self,
         candidate: _EvidenceCandidate,
         selected: list[_EvidenceCandidate],
-    ) -> tuple[float, float, int, str]:
+    ) -> tuple[float, float, float, int, str]:
+        final_score, _ = self._evidence_final_score(
+            candidate,
+            selected=selected,
+        )
         return (
+            final_score,
             self._mmr_score(candidate, selected),
             candidate.ranked.rerank_score,
             -candidate.ranked.rank,
@@ -481,6 +680,401 @@ class EvidencePackCompiler:
             - (1.0 - self.mmr_lambda) * max_similarity,
             6,
         )
+
+    def _compact_contract_modification_selection(
+        self,
+        selected: list[_EvidenceCandidate],
+        candidate_pool: list[_EvidenceCandidate],
+        *,
+        plan: QueryPlan | None,
+    ) -> list[_EvidenceCandidate]:
+        if not self._is_contract_modification_query(plan):
+            return selected
+
+        target = self._selection_target(candidate_pool, plan=plan)
+        required_ids = {
+            "contract_modification_agreement_rule",
+            "contract_modification_salary_scope",
+        }
+        required: list[_EvidenceCandidate] = []
+        optional: list[_EvidenceCandidate] = []
+        for candidate in selected:
+            if any(
+                self._candidate_covers_requirement(candidate, requirement_id)
+                for requirement_id in required_ids
+            ):
+                required.append(candidate)
+            else:
+                optional.append(candidate)
+
+        required = self._dedupe_candidates(required)
+        optional = self._dedupe_candidates(optional)
+        kept: list[_EvidenceCandidate] = []
+        for candidate in sorted(
+            required,
+            key=lambda item: self._evidence_final_sort_key(item, kept),
+            reverse=True,
+        ):
+            if candidate.ranked.unit_id not in {item.ranked.unit_id for item in kept}:
+                self._append_reason(candidate, "contract_modification_required_coverage")
+                kept.append(candidate)
+
+        salary_parent_ids = {
+            candidate.ranked.unit_id
+            for candidate in kept
+            if self._candidate_covers_requirement(
+                candidate,
+                "contract_modification_salary_scope",
+            )
+        }
+        salary_children = [
+            candidate
+            for candidate in optional
+            if self._is_salary_target_child(candidate, parent_ids=salary_parent_ids)
+        ]
+        for candidate in sorted(
+            salary_children,
+            key=lambda item: self._evidence_final_sort_key(item, kept),
+            reverse=True,
+        ):
+            if len(kept) >= target:
+                break
+            if candidate.ranked.unit_id not in {item.ranked.unit_id for item in kept}:
+                self._append_reason(candidate, "contract_modification_optional_salary_target")
+                kept.append(candidate)
+
+        remaining = [
+            candidate
+            for candidate in optional
+            if candidate.ranked.unit_id not in {item.ranked.unit_id for item in kept}
+        ]
+        remaining.sort(
+            key=lambda item: self._evidence_final_sort_key(item, kept),
+            reverse=True,
+        )
+        for candidate in remaining:
+            if len(kept) >= target:
+                break
+            score, breakdown = self._evidence_final_score(candidate, selected=kept)
+            if (
+                candidate.support_role == "context"
+                and breakdown["generic_context_penalty"] >= 0.7
+                and len(kept) >= max(2, len(required))
+            ):
+                continue
+            self._append_reason(candidate, "contract_modification_compact_selection")
+            kept.append(candidate)
+
+        if len(kept) < len(selected):
+            for candidate in kept:
+                self._append_reason(candidate, "contract_modification_pruned_generic_context")
+        return kept
+
+    def _normalize_contract_modification_roles(
+        self,
+        selected: list[_EvidenceCandidate],
+        *,
+        plan: QueryPlan | None,
+    ) -> list[_EvidenceCandidate]:
+        if not self._is_contract_modification_query(plan):
+            return selected
+
+        scope_parent_ids = {
+            candidate.ranked.unit_id
+            for candidate in selected
+            if self._candidate_covers_requirement(
+                candidate,
+                "contract_modification_salary_scope",
+            )
+        }
+        for candidate in selected:
+            original_role = candidate.support_role
+            normalized_role = self._normalized_contract_modification_role(
+                candidate,
+                selected=selected,
+                scope_parent_ids=scope_parent_ids,
+            )
+            if normalized_role == original_role:
+                continue
+            candidate.support_role = normalized_role
+            self._append_reason(
+                candidate,
+                f"role_normalized:{original_role}->{normalized_role}",
+            )
+        return selected
+
+    def _normalized_contract_modification_role(
+        self,
+        candidate: _EvidenceCandidate,
+        *,
+        selected: list[_EvidenceCandidate],
+        scope_parent_ids: set[str],
+    ) -> str:
+        if self._candidate_covers_requirement(
+            candidate,
+            "contract_modification_agreement_rule",
+        ):
+            if self._has_more_specific_requirement_candidate(
+                candidate,
+                selected=selected,
+                requirement_id="contract_modification_agreement_rule",
+            ):
+                return "context"
+            return "direct_basis"
+        if self._candidate_covers_requirement(
+            candidate,
+            "contract_modification_salary_scope",
+        ):
+            return "condition"
+        if self._is_salary_target_child(candidate, parent_ids=scope_parent_ids):
+            return "condition"
+
+        haystack = self._haystack(candidate.ranked, candidate.unit)
+        if self._is_sanction_support(candidate, haystack):
+            return "sanction"
+        if self._is_exception_support(candidate, haystack):
+            return "exception"
+        if candidate.support_role in {"definition", "procedure"}:
+            return candidate.support_role
+        return "context"
+
+    def _has_more_specific_requirement_candidate(
+        self,
+        candidate: _EvidenceCandidate,
+        *,
+        selected: list[_EvidenceCandidate],
+        requirement_id: str,
+    ) -> bool:
+        candidate_specificity = self._unit_specificity(candidate.unit)
+        candidate_law = str(candidate.unit.get("law_id") or "")
+        candidate_article = self._optional_str(candidate.unit.get("article_number"))
+        for other in selected:
+            if other.ranked.unit_id == candidate.ranked.unit_id:
+                continue
+            if not self._candidate_covers_requirement(other, requirement_id):
+                continue
+            if self._unit_specificity(other.unit) <= candidate_specificity:
+                continue
+            other_law = str(other.unit.get("law_id") or "")
+            other_article = self._optional_str(other.unit.get("article_number"))
+            if candidate_law and candidate_article and (
+                candidate_law == other_law and candidate_article == other_article
+            ):
+                return True
+            if self._optional_str(other.unit.get("parent_id")) == candidate.ranked.unit_id:
+                return True
+        return False
+
+    def _is_sanction_support(
+        self,
+        candidate: _EvidenceCandidate,
+        haystack: str,
+    ) -> bool:
+        score = candidate.ranked.score_breakdown
+        if score.is_sanction > 0.0:
+            return True
+        return self._contains_any(
+            haystack,
+            (
+                "amenda",
+                "amenzii",
+                "contraventie",
+                "contraventionala",
+                "sanctiune",
+                "sanction",
+                "constituie contraventie",
+            ),
+        )
+
+    def _is_exception_support(
+        self,
+        candidate: _EvidenceCandidate,
+        haystack: str,
+    ) -> bool:
+        score = candidate.ranked.score_breakdown
+        if score.is_exception > 0.0:
+            return True
+        return self._contains_any(
+            haystack,
+            (
+                "exceptie",
+                "exceptii",
+                "cu titlu de exceptie",
+                "locul muncii poate fi modificat unilateral",
+                "poate fi modificat unilateral",
+                "delegarea",
+                "detasarea",
+                "derogare",
+            ),
+        )
+
+    def _dedupe_candidates(
+        self,
+        candidates: list[_EvidenceCandidate],
+    ) -> list[_EvidenceCandidate]:
+        seen: set[str] = set()
+        deduped: list[_EvidenceCandidate] = []
+        for candidate in candidates:
+            if candidate.ranked.unit_id in seen:
+                continue
+            seen.add(candidate.ranked.unit_id)
+            deduped.append(candidate)
+        return deduped
+
+    def _evidence_final_sort_key(
+        self,
+        candidate: _EvidenceCandidate,
+        selected: list[_EvidenceCandidate],
+    ) -> tuple[float, float, float, int, str]:
+        score, _ = self._evidence_final_score(candidate, selected=selected)
+        return (
+            score,
+            candidate.ranked.rerank_score,
+            candidate.ranked.retrieval_score or 0.0,
+            -candidate.ranked.rank,
+            candidate.ranked.unit_id,
+        )
+
+    def _evidence_final_score(
+        self,
+        candidate: _EvidenceCandidate,
+        *,
+        selected: list[_EvidenceCandidate],
+    ) -> tuple[float, dict[str, float]]:
+        mmr = self._mmr_score(candidate, selected)
+        required_requirement_coverage = self._required_requirement_coverage_score(candidate)
+        same_article_as_core = self._same_article_as_core_score(candidate, selected)
+        support_role_priority = SUPPORT_ROLE_PRIORITY_SCORE.get(
+            candidate.support_role,
+            0.35,
+        )
+        generic_context_penalty = self._generic_context_penalty(candidate, selected)
+        distractor_penalty = self._evidence_distractor_penalty(candidate)
+        final_score = self._clamp(
+            mmr
+            + 0.20 * required_requirement_coverage
+            + 0.10 * same_article_as_core
+            + 0.08 * support_role_priority
+            - 0.15 * generic_context_penalty
+            - 0.20 * distractor_penalty
+        )
+        return (
+            round(final_score, 6),
+            {
+                "mmr": round(mmr, 6),
+                "required_requirement_coverage": round(required_requirement_coverage, 6),
+                "same_article_as_core": round(same_article_as_core, 6),
+                "support_role_priority": round(support_role_priority, 6),
+                "generic_context_penalty": round(generic_context_penalty, 6),
+                "distractor_penalty": round(distractor_penalty, 6),
+            },
+        )
+
+    def _required_requirement_coverage_score(
+        self,
+        candidate: _EvidenceCandidate,
+    ) -> float:
+        if self._candidate_covers_requirement(
+            candidate,
+            "contract_modification_agreement_rule",
+        ):
+            return 1.0
+        if self._candidate_covers_requirement(
+            candidate,
+            "contract_modification_salary_scope",
+        ):
+            return 1.0
+        if candidate.role_decision is not None and (
+            "salary_target_element" in candidate.role_decision.matched_requirement_ids
+        ):
+            return 0.35
+        return 0.0
+
+    def _same_article_as_core_score(
+        self,
+        candidate: _EvidenceCandidate,
+        selected: list[_EvidenceCandidate],
+    ) -> float:
+        core_units = [
+            item
+            for item in selected
+            if self._candidate_covers_requirement(
+                item,
+                "contract_modification_agreement_rule",
+            )
+            or self._candidate_covers_requirement(
+                item,
+                "contract_modification_salary_scope",
+            )
+        ]
+        if not core_units:
+            return 1.0 if self._required_requirement_coverage_score(candidate) else 0.0
+
+        candidate_law = str(candidate.unit.get("law_id") or "")
+        candidate_article = self._optional_str(candidate.unit.get("article_number"))
+        candidate_parent = self._optional_str(candidate.unit.get("parent_id"))
+        for core in core_units:
+            core_law = str(core.unit.get("law_id") or "")
+            core_article = self._optional_str(core.unit.get("article_number"))
+            if (
+                candidate_law
+                and candidate_article
+                and candidate_law == core_law
+                and candidate_article == core_article
+            ):
+                return 1.0
+            if candidate_parent and candidate_parent == core.ranked.unit_id:
+                return 0.5
+            core_parent = self._optional_str(core.unit.get("parent_id"))
+            if core_parent and core_parent == candidate.ranked.unit_id:
+                return 0.5
+        return 0.0
+
+    def _generic_context_penalty(
+        self,
+        candidate: _EvidenceCandidate,
+        selected: list[_EvidenceCandidate],
+    ) -> float:
+        if self._required_requirement_coverage_score(candidate) > 0:
+            return 0.0
+        haystack = self._haystack(candidate.ranked, candidate.unit)
+        same_article = self._same_article_as_core_score(candidate, selected)
+        has_core = (
+            self._is_contract_modification_agreement_rule(haystack)
+            or self._is_contract_modification_salary_scope(haystack)
+            or self._is_contract_modification_scope_parent(haystack)
+        )
+        if has_core:
+            return 0.0
+        if candidate.support_role == "context" and same_article == 0.0:
+            return 1.0
+        if self._contains_any(haystack, CONTRACT_MODIFICATION_GENERIC_CONTEXT_TERMS):
+            return 0.8 if same_article == 0.0 else 0.4
+        if (
+            self._contains_any(haystack, CONTRACT_MODIFICATION_TARGET_TERMS)
+            and same_article == 0.0
+        ):
+            return 0.7
+        if candidate.support_role == "context":
+            return 0.5
+        return 0.0
+
+    def _evidence_distractor_penalty(
+        self,
+        candidate: _EvidenceCandidate,
+    ) -> float:
+        haystack = self._haystack(candidate.ranked, candidate.unit)
+        score = candidate.ranked.score_breakdown
+        if score.distractor_penalty >= 0.7:
+            return 1.0
+        if self._is_salary_context(haystack):
+            return 0.0 if self._required_requirement_coverage_score(candidate) else 1.0
+        if (
+            self._contains_any(haystack, CONTRACT_MODIFICATION_TARGET_TERMS)
+            and not self._required_requirement_coverage_score(candidate)
+        ):
+            return 0.5
+        return 0.0
 
     def _ensure_role_candidate(
         self,
@@ -534,7 +1128,18 @@ class EvidencePackCompiler:
             parent = pool_by_unit_id.get(parent_id)
             if parent is None:
                 continue
-            parent.support_role = "context"
+            if self._candidate_covers_requirement(
+                parent,
+                "contract_modification_salary_scope",
+            ):
+                if parent.support_role == "context":
+                    parent.support_role = "condition"
+                self._append_reason(
+                    parent,
+                    "parent_context_requirement:contract_modification_salary_scope",
+                )
+            else:
+                parent.support_role = "context"
             parent.mmr_score = self._mmr_score(parent, selected)
             self._append_reason(parent, "parent_context_candidate")
             self._append_reason(parent, "selected_parent_context")
@@ -755,6 +1360,8 @@ class EvidencePackCompiler:
             return "context"
         if self._graph_node_type(unit) in {"root", "domain", "legal_act", "title", "chapter", "section"}:
             return "context"
+        if contract_modification_query:
+            return "context"
         return "direct_basis"
 
     def _is_contract_modification_query(self, plan: QueryPlan | None) -> bool:
@@ -783,10 +1390,7 @@ class EvidencePackCompiler:
         return has_reduction and has_target
 
     def _is_contract_modification_direct_basis(self, haystack: str) -> bool:
-        agreement = any(
-            self._normalize_text(term) in haystack
-            for term in AGREEMENT_RULE_TERMS
-        )
+        agreement = self._is_contract_modification_agreement_rule(haystack)
         scope = any(
             self._normalize_text(term) in haystack
             for term in MODIFICATION_SCOPE_TERMS
@@ -797,6 +1401,51 @@ class EvidencePackCompiler:
             haystack,
             ("modificarea", "modificare", "poate privi", "salariul", "elementele"),
         )
+
+    def _is_contract_modification_agreement_rule(self, haystack: str) -> bool:
+        return any(
+            self._normalize_text(term) in haystack
+            for term in AGREEMENT_RULE_TERMS
+        )
+
+    def _is_contract_modification_scope_parent(self, haystack: str) -> bool:
+        scope = any(
+            self._normalize_text(term) in haystack
+            for term in MODIFICATION_SCOPE_TERMS
+        )
+        return scope and self._contains_any(
+            haystack,
+            (
+                "modificarea",
+                "modificare",
+                "se refera",
+                "poate privi",
+                "elemente",
+                "elementele",
+                "urmatoarele elemente",
+            ),
+        )
+
+    def _is_contract_modification_salary_scope(self, haystack: str) -> bool:
+        return self._is_contract_modification_scope_parent(
+            haystack
+        ) and self._contains_any(haystack, CONTRACT_MODIFICATION_TARGET_TERMS)
+
+    def _is_salary_target_child(
+        self,
+        candidate: _EvidenceCandidate,
+        *,
+        parent_ids: set[str],
+    ) -> bool:
+        parent_id = str(candidate.unit.get("parent_id") or "")
+        if not parent_id or parent_id not in parent_ids:
+            return False
+        if not (candidate.unit.get("letter_number") or candidate.unit.get("point_number")):
+            return False
+        haystack = self._haystack(candidate.ranked, candidate.unit)
+        if not self._contains_any(haystack, CONTRACT_MODIFICATION_TARGET_TERMS):
+            return False
+        return not self._is_salary_context(haystack)
 
     def _is_contract_modification_condition(self, haystack: str) -> bool:
         return (
@@ -931,6 +1580,8 @@ class EvidencePackCompiler:
         input_ranked_candidate_count: int,
         candidate_pool_size: int,
         selected: list[_EvidenceCandidate],
+        plan: QueryPlan | None,
+        query_frame: QueryFrame | None,
         warnings: list[str],
     ) -> dict[str, Any]:
         return {
@@ -946,16 +1597,132 @@ class EvidencePackCompiler:
                     "unit_id": candidate.ranked.unit_id,
                     "rerank_score": candidate.ranked.rerank_score,
                     "mmr_score": candidate.mmr_score,
+                    "evidence_final_score": self._evidence_final_score(
+                        candidate,
+                        selected=selected,
+                    )[0],
+                    "evidence_final_score_breakdown": self._evidence_final_score(
+                        candidate,
+                        selected=selected,
+                    )[1],
                     "support_role": candidate.support_role,
                     "why_selected": self._dedupe(candidate.why_selected),
+                    "matched_requirement_ids": (
+                        candidate.role_decision.matched_requirement_ids
+                        if candidate.role_decision is not None
+                        else []
+                    ),
                     "role_decision": candidate.role_decision.model_dump(mode="json")
                     if candidate.role_decision is not None
                     else None,
                 }
                 for candidate in selected
             ],
+            "requirement_coverage": self._requirement_coverage(
+                selected,
+                plan=plan,
+                query_frame=query_frame,
+            ),
             "warnings": warnings,
         }
+
+    def _requirement_coverage(
+        self,
+        selected: list[_EvidenceCandidate],
+        *,
+        plan: QueryPlan | None,
+        query_frame: QueryFrame | None,
+    ) -> dict[str, Any]:
+        required_ids: list[str] = []
+        if self._should_use_role_classifier(query_frame):
+            required_ids = [
+                "contract_modification_agreement_rule",
+                "contract_modification_salary_scope",
+            ]
+        elif self._is_contract_modification_query(plan):
+            required_ids = [
+                "contract_modification_agreement_rule",
+                "contract_modification_salary_scope",
+            ]
+        if not required_ids:
+            return {
+                "enabled": False,
+                "intent_id": None,
+                "required_requirement_ids": [],
+                "required_requirements_total": 0,
+                "required_requirements_covered": 0,
+                "covered_requirement_ids": [],
+                "missing_required_requirements": [],
+                "missing_required_requirement_ids": [],
+                "coverage_passed": True,
+            }
+
+        covered: list[str] = []
+        if self._contract_modification_agreement_covered(selected):
+            covered.append("contract_modification_agreement_rule")
+        if self._contract_modification_salary_scope_covered(selected):
+            covered.append("contract_modification_salary_scope")
+        missing = [
+            requirement_id
+            for requirement_id in required_ids
+            if requirement_id not in covered
+        ]
+        return {
+            "enabled": True,
+            "intent_id": "labor_contract_modification",
+            "required_requirement_ids": required_ids,
+            "required_requirements_total": len(required_ids),
+            "required_requirements_covered": len(covered),
+            "covered_requirement_ids": covered,
+            "missing_required_requirements": missing,
+            "missing_required_requirement_ids": missing,
+            "coverage_passed": not missing,
+        }
+
+    def _contract_modification_agreement_covered(
+        self,
+        selected: list[_EvidenceCandidate],
+    ) -> bool:
+        for candidate in selected:
+            if candidate.role_decision is not None and (
+                "contract_modification_agreement_rule"
+                in candidate.role_decision.matched_requirement_ids
+            ):
+                return True
+            if self._is_contract_modification_agreement_rule(
+                self._haystack(candidate.ranked, candidate.unit)
+            ):
+                return True
+        return False
+
+    def _contract_modification_salary_scope_covered(
+        self,
+        selected: list[_EvidenceCandidate],
+    ) -> bool:
+        for candidate in selected:
+            if candidate.role_decision is not None and (
+                "contract_modification_salary_scope"
+                in candidate.role_decision.matched_requirement_ids
+            ):
+                return True
+            if self._is_contract_modification_salary_scope(
+                self._haystack(candidate.ranked, candidate.unit)
+            ):
+                return True
+
+        scope_parent_ids = {
+            candidate.ranked.unit_id
+            for candidate in selected
+            if self._is_contract_modification_scope_parent(
+                self._haystack(candidate.ranked, candidate.unit)
+            )
+        }
+        if not scope_parent_ids:
+            return False
+        return any(
+            self._is_salary_target_child(candidate, parent_ids=scope_parent_ids)
+            for candidate in selected
+        )
 
     def _candidate_text(self, unit: dict[str, Any]) -> str:
         value = unit.get("raw_text")

--- a/tests/api/test_query.py
+++ b/tests/api/test_query.py
@@ -3,10 +3,21 @@ from fastapi.testclient import TestClient
 
 import apps.api.app.routes.query as query_route
 from apps.api.app.main import app
-from apps.api.app.schemas import EvidenceUnit, QueryRequest, RawRetrievalResponse, RetrievalCandidate
+from apps.api.app.schemas import (
+    EvidenceUnit,
+    ExpandedCandidate,
+    GraphExpansionResult,
+    LegalRankerResult,
+    QueryRequest,
+    RawRetrievalResponse,
+    RankedCandidate,
+    RankerFeatureBreakdown,
+    RetrievalCandidate,
+)
 from apps.api.app.services.query_orchestrator import QueryOrchestrator
 from apps.api.app.services.generation_adapter import GenerationAdapter
 from apps.api.app.services.raw_retriever_client import RawRetrieverClient
+from apps.api.app.services.evidence_pack_compiler import EvidencePackCompiler
 
 
 VALID_QUERY = {
@@ -216,9 +227,30 @@ def test_post_api_query_demo_uses_raw_retriever_client_internal_candidates():
         "ro.codul_muncii.art_41.alin_1",
         "ro.codul_muncii.art_41.alin_3",
     }.issubset(evidence_ids)
+    assert len(payload["evidence_units"]) <= 8
     evidence_by_id = {unit["id"]: unit for unit in payload["evidence_units"]}
     assert evidence_by_id["ro.codul_muncii.art_41.alin_1"]["support_role"] == "direct_basis"
-    assert evidence_by_id["ro.codul_muncii.art_41.alin_3"]["support_role"] == "direct_basis"
+    assert evidence_by_id["ro.codul_muncii.art_41.alin_3"]["support_role"] in {
+        "condition",
+        "direct_basis",
+    }
+    direct_basis_ids = {
+        unit_id
+        for unit_id, unit in evidence_by_id.items()
+        if unit["support_role"] == "direct_basis"
+    }
+    assert direct_basis_ids <= {
+        "ro.codul_muncii.art_41.alin_1",
+        "ro.codul_muncii.art_41.alin_3",
+    }
+    for forbidden_direct_basis_id in {
+        "ro.codul_muncii.art_17.alin_3.lit_b",
+        "ro.codul_muncii.art_35.alin_1",
+        "ro.codul_muncii.art_166",
+        "ro.codul_muncii.art_260.alin_1.lit_a",
+    }:
+        if forbidden_direct_basis_id in evidence_by_id:
+            assert evidence_by_id[forbidden_direct_basis_id]["support_role"] != "direct_basis"
     assert payload["evidence_units"]
     first = payload["evidence_units"][0]
     assert first["raw_text"]
@@ -242,7 +274,13 @@ def test_post_api_query_demo_uses_raw_retriever_client_internal_candidates():
     assert "art. 41" in payload["answer"]["short_answer"]
     assert "art. 264" not in payload["answer"]["short_answer"]
     normalized_answer = payload["answer"]["short_answer"].casefold()
-    assert "acordul partilor" in normalized_answer
+    assert "muncă" in normalized_answer
+    assert "regulă" in normalized_answer
+    assert "părților" in normalized_answer
+    assert "excepțiile" in normalized_answer
+    assert "munca " not in normalized_answer
+    assert "partilor" not in normalized_answer
+    assert "exceptiile" not in normalized_answer
     assert "remuneratie restanta" not in normalized_answer
     assert "persoane angajate ilegal" not in normalized_answer
     citation_unit_ids = {
@@ -253,9 +291,43 @@ def test_post_api_query_demo_uses_raw_retriever_client_internal_candidates():
         "ro.codul_muncii.art_41.alin_1",
         "ro.codul_muncii.art_41.alin_3",
     }.issubset(citation_unit_ids)
+    assert all(citation["verified"] is True for citation in payload["citations"])
     assert all(unit_id.startswith("ro.codul_muncii.art_41") for unit_id in citation_unit_ids)
-    assert "ro.codul_muncii.art_264.lit_a" in evidence_ids
+    if "ro.codul_muncii.art_264.lit_a" in evidence_by_id:
+        assert evidence_by_id["ro.codul_muncii.art_264.lit_a"]["support_role"] != "direct_basis"
     assert "ro.codul_muncii.art_264.lit_a" not in citation_unit_ids
+    assert "ro.codul_muncii.art_17.alin_3.lit_b" not in citation_unit_ids
+    assert "ro.codul_muncii.art_35.alin_1" not in citation_unit_ids
+    assert "ro.codul_muncii.art_166" not in citation_unit_ids
+    assert "ro.codul_muncii.art_260.alin_1.lit_a" not in citation_unit_ids
+    assert "muncă" in evidence_by_id["ro.codul_muncii.art_41.alin_1"]["raw_text"]
+    assert "părților" in evidence_by_id["ro.codul_muncii.art_41.alin_1"]["raw_text"]
+    for unit_id in (
+        "ro.codul_muncii.art_41.alin_1",
+        "ro.codul_muncii.art_41.alin_3",
+    ):
+        raw_text = evidence_by_id[unit_id]["raw_text"]
+        assert "muncÄ" not in raw_text
+        assert "pÄ" not in raw_text
+        assert "È" not in raw_text
+    coverage = payload["debug"]["evidence_pack"]["requirement_coverage"]
+    assert coverage["intent_id"] == "labor_contract_modification"
+    assert coverage["required_requirements_total"] == 2
+    assert coverage["required_requirements_covered"] == 2
+    assert coverage["coverage_passed"] is True
+    assert coverage["missing_required_requirements"] == []
+    with TestClient(app) as client:
+        graph_response = client.get(f"/api/query/{payload['query_id']}/graph")
+    assert graph_response.status_code == 200
+    graph_payload = graph_response.json()
+    assert graph_payload["highlighted_edge_ids"]
+    assert {
+        "ro.codul_muncii.art_41.alin_1",
+        "ro.codul_muncii.art_41.alin_3",
+    }.issubset(set(graph_payload["cited_unit_ids"]))
+    assert "cited_in_answer" in {
+        edge["type"] for edge in graph_payload["graph"]["edges"]
+    }
     retrieval_debug = payload["debug"]["retrieval"]
     assert retrieval_debug["backend"] == "internal"
     assert retrieval_debug["response_summary"]["candidate_count"] >= 6
@@ -291,7 +363,7 @@ class FakeRawRetrieverClient:
                         "status": "active",
                         "hierarchy_path": ["Codul muncii", "art. 41"],
                         "article_number": "41",
-                        "raw_text": "Contractul individual de munca poate fi modificat prin acordul partilor.",
+                        "raw_text": "Contractul individual de muncă poate fi modificat prin acordul părților.",
                         "legal_domain": "munca",
                         "legal_concepts": ["contract", "salariu"],
                         "source_url": "https://legislatie.just.ro/test",
@@ -388,6 +460,67 @@ def _art41_units():
         },
         {
             **base,
+            "id": "ro.codul_muncii.art_17.alin_3.lit_b",
+            "hierarchy_path": ["Codul muncii", "Art. 17", "Alin. (3)", "Lit. b)"],
+            "article_number": "17",
+            "paragraph_number": "3",
+            "letter_number": "b",
+            "point_number": None,
+            "parent_id": "ro.codul_muncii.art_17.alin_3",
+            "raw_text": (
+                "b) locul muncii sau, in lipsa unui loc de munca fix, "
+                "posibilitatea ca salariatul sa munceasca in diverse locuri;"
+            ),
+            "normalized_text": "locul muncii loc munca fix salariat munceasca diverse locuri",
+            "type": "litera",
+        },
+        {
+            **base,
+            "id": "ro.codul_muncii.art_35.alin_1",
+            "hierarchy_path": ["Codul muncii", "Art. 35", "Alin. (1)"],
+            "article_number": "35",
+            "paragraph_number": "1",
+            "letter_number": None,
+            "point_number": None,
+            "parent_id": "ro.codul_muncii.art_35",
+            "raw_text": (
+                "Orice salariat are dreptul de a munci la angajatori diferiti "
+                "sau la acelasi angajator, in baza unor contracte individuale de munca."
+            ),
+            "normalized_text": "salariat dreptul munci angajatori diferiti contracte individuale munca",
+            "type": "alineat",
+        },
+        {
+            **base,
+            "id": "ro.codul_muncii.art_166",
+            "hierarchy_path": ["Codul muncii", "Art. 166"],
+            "article_number": "166",
+            "paragraph_number": None,
+            "letter_number": None,
+            "point_number": None,
+            "parent_id": None,
+            "raw_text": "Salariul se plateste in bani cel putin o data pe luna.",
+            "normalized_text": "salariul plateste bani luna",
+            "type": "articol",
+        },
+        {
+            **base,
+            "id": "ro.codul_muncii.art_260.alin_1.lit_a",
+            "hierarchy_path": ["Codul muncii", "Art. 260", "Alin. (1)", "Lit. a)"],
+            "article_number": "260",
+            "paragraph_number": "1",
+            "letter_number": "a",
+            "point_number": None,
+            "parent_id": "ro.codul_muncii.art_260.alin_1",
+            "raw_text": (
+                "a) primirea la munca a uneia sau a mai multor persoane fara "
+                "incheierea unui contract individual de munca constituie contraventie."
+            ),
+            "normalized_text": "primirea munca persoane fara incheiere contract individual munca constituie contraventie",
+            "type": "litera",
+        },
+        {
+            **base,
             "id": "ro.codul_muncii.art_41.alin_1",
             "hierarchy_path": ["Codul muncii", "Art. 41", "Alin. (1)"],
             "article_number": "41",
@@ -395,7 +528,7 @@ def _art41_units():
             "letter_number": None,
             "point_number": None,
             "parent_id": "ro.codul_muncii.art_41",
-            "raw_text": "(1) Contractul individual de munca poate fi modificat numai prin acordul partilor.",
+            "raw_text": "(1) Contractul individual de muncă poate fi modificat numai prin acordul părților.",
             "normalized_text": "contract individual munca modificat acord parti act aditional salariu",
             "type": "alineat",
         },
@@ -408,7 +541,7 @@ def _art41_units():
             "letter_number": None,
             "point_number": None,
             "parent_id": None,
-            "raw_text": "Articolul 41\nContractul individual de munca poate fi modificat numai prin acordul partilor.",
+            "raw_text": "Articolul 41\nContractul individual de muncă poate fi modificat numai prin acordul părților.",
             "normalized_text": "contract individual munca modificat acord parti",
             "type": "articol",
         },
@@ -421,7 +554,7 @@ def _art41_units():
             "letter_number": None,
             "point_number": None,
             "parent_id": "ro.codul_muncii.art_41",
-            "raw_text": "(2) Modificarea contractului individual de munca se refera la elementele contractuale.",
+            "raw_text": "(2) Modificarea contractului individual de muncă se referă la elementele contractuale.",
             "normalized_text": "modificare contract individual munca elemente contractuale",
             "type": "alineat",
         },
@@ -434,7 +567,7 @@ def _art41_units():
             "letter_number": None,
             "point_number": None,
             "parent_id": "ro.codul_muncii.art_41",
-            "raw_text": "(3) Modificarea contractului individual de munca poate privi durata, locul muncii, felul muncii, conditiile de munca, salariul si timpul de munca.",
+            "raw_text": "(3) Modificarea contractului individual de muncă poate privi durata, locul muncii, felul muncii, condițiile de muncă, salariul și timpul de muncă.",
             "normalized_text": "modificare contract individual munca durata loc fel conditii salariu timp",
             "type": "alineat",
         },
@@ -452,6 +585,292 @@ def _art41_units():
             "type": "litera",
         },
     ]
+
+
+class AgreementOnlyRetriever:
+    async def retrieve(self, request):
+        units = {unit["id"]: unit for unit in _art41_units()}
+        agreement = dict(units["ro.codul_muncii.art_41.alin_1"])
+        agreement["normalized_text"] = (
+            "contract individual munca poate fi modificat numai prin acordul partilor"
+        )
+        ordered = [
+            agreement,
+            units["ro.codul_muncii.art_264.lit_a"],
+        ]
+        candidates = []
+        for index, unit in enumerate(ordered, start=1):
+            candidates.append(
+                RetrievalCandidate(
+                    unit_id=unit["id"],
+                    rank=index,
+                    retrieval_score=round(0.94 - index * 0.05, 6),
+                    score_breakdown={
+                        "bm25": round(0.98 - index * 0.05, 6),
+                        "dense": 0.0,
+                        "domain_match": 1.0,
+                        "metadata_validity": 1.0,
+                    },
+                    matched_terms=["salariu", "contract", "act aditional"],
+                    why_retrieved="agreement_only_fixture",
+                    unit=unit,
+                )
+            )
+        return RawRetrievalResponse(
+            candidates=candidates,
+            retrieval_methods=["agreement_only_fixture"],
+            warnings=[],
+            debug={"candidate_count": len(candidates)},
+        )
+
+
+class BackfillExpandedGraphPolicy:
+    async def expand(self, *, plan, retrieval_response, debug=False):
+        units = {unit["id"]: unit for unit in _art41_units()}
+        scope = dict(units["ro.codul_muncii.art_41.alin_3"])
+        scope["raw_text"] = (
+            "(3) Modificarea contractului individual de munca se refera la "
+            "oricare dintre urmatoarele elemente:"
+        )
+        scope["normalized_text"] = (
+            "modificarea contractului individual de munca se refera la "
+            "oricare dintre urmatoarele elemente"
+        )
+        salary_child = units["ro.codul_muncii.art_41.alin_3.lit_e"]
+        expanded = [
+            ExpandedCandidate(
+                unit_id=scope["id"],
+                source="graph_expansion",
+                graph_distance=1,
+                graph_proximity=0.92,
+                expansion_edge_type="contains_child",
+                expansion_reason="fixture_graph:contains_child",
+                retrieval_candidate=RetrievalCandidate(
+                    unit_id=scope["id"],
+                    rank=3,
+                    retrieval_score=0.52,
+                    score_breakdown={
+                        "bm25": 0.52,
+                        "dense": 0.0,
+                        "domain_match": 1.0,
+                        "graph_proximity": 0.45,
+                    },
+                    matched_terms=["modificare", "contract", "elemente"],
+                    why_retrieved="graph_expansion_scope_fixture",
+                    unit=scope,
+                ),
+                score_breakdown={"graph_proximity": 0.45},
+            ),
+            ExpandedCandidate(
+                unit_id=salary_child["id"],
+                source="graph_expansion",
+                graph_distance=1,
+                graph_proximity=0.62,
+                expansion_edge_type="contains_child",
+                expansion_reason="fixture_graph:contains_child",
+                retrieval_candidate=RetrievalCandidate(
+                    unit_id=salary_child["id"],
+                    rank=4,
+                    retrieval_score=0.48,
+                    score_breakdown={
+                        "bm25": 0.48,
+                        "dense": 0.0,
+                        "domain_match": 1.0,
+                        "graph_proximity": 0.62,
+                    },
+                    matched_terms=["salariu"],
+                    why_retrieved="graph_expansion_salary_child_fixture",
+                    unit=salary_child,
+                ),
+                score_breakdown={"graph_proximity": 0.62},
+            ),
+        ]
+        return GraphExpansionResult(
+            seed_candidates=[],
+            expanded_candidates=expanded,
+            warnings=[],
+            debug={
+                "fallback_used": False,
+                "expanded_candidate_count": len(expanded),
+            }
+            if debug
+            else None,
+        )
+
+
+class MissingRawTextGraphPolicy:
+    async def expand(self, *, plan, retrieval_response, debug=False):
+        units = {unit["id"]: unit for unit in _art41_units()}
+        broken_scope = dict(units["ro.codul_muncii.art_41.alin_3"])
+        broken_scope["raw_text"] = ""
+        broken_scope["normalized_text"] = ""
+        expanded = [
+            ExpandedCandidate(
+                unit_id=broken_scope["id"],
+                source="graph_expansion",
+                graph_distance=1,
+                graph_proximity=0.91,
+                expansion_edge_type="contains_child",
+                expansion_reason="fixture_graph:contains_child",
+                retrieval_candidate=RetrievalCandidate(
+                    unit_id=broken_scope["id"],
+                    rank=3,
+                    retrieval_score=0.72,
+                    score_breakdown={
+                        "bm25": 0.72,
+                        "dense": 0.0,
+                        "domain_match": 1.0,
+                        "graph_proximity": 0.91,
+                    },
+                    matched_terms=["modificare", "contract", "salariu"],
+                    why_retrieved="graph_expansion_broken_scope_fixture",
+                    unit=broken_scope,
+                ),
+                score_breakdown={"graph_proximity": 0.91},
+            )
+        ]
+        return GraphExpansionResult(
+            seed_candidates=[],
+            expanded_candidates=expanded,
+            warnings=[],
+            debug={
+                "fallback_used": False,
+                "expanded_candidate_count": len(expanded),
+            }
+            if debug
+            else None,
+        )
+
+
+def _backfill_ranked_candidate(
+    unit: dict,
+    *,
+    rank: int,
+    rerank_score: float,
+    retrieval_score: float,
+    why_ranked: list[str] | None = None,
+    source: str = "fixture_backfill_ranker",
+) -> RankedCandidate:
+    return RankedCandidate(
+        unit_id=unit["id"],
+        rank=rank,
+        rerank_score=rerank_score,
+        retrieval_score=retrieval_score,
+        unit=unit,
+        score_breakdown=RankerFeatureBreakdown(
+            bm25_score=rerank_score,
+            dense_score=0.0,
+            domain_match=1.0,
+            temporal_validity=1.0,
+        ),
+        why_ranked=why_ranked or [source],
+        source=source,
+    )
+
+
+class BackfillLegalRanker:
+    def rank(
+        self,
+        *,
+        question,
+        plan,
+        retrieval_response,
+        graph_expansion,
+        query_frame=None,
+        debug=False,
+    ):
+        raw_units = {candidate.unit_id: candidate.unit for candidate in retrieval_response.candidates}
+        expanded_units = {
+            candidate.unit_id: candidate.retrieval_candidate.unit
+            for candidate in graph_expansion.expanded_candidates
+            if candidate.retrieval_candidate is not None and candidate.retrieval_candidate.unit
+        }
+        ranked_candidates = [
+            _backfill_ranked_candidate(
+                raw_units["ro.codul_muncii.art_41.alin_1"],
+                rank=1,
+                rerank_score=0.93,
+                retrieval_score=0.93,
+                why_ranked=["agreement_rule_seed"],
+            ),
+            _backfill_ranked_candidate(
+                raw_units["ro.codul_muncii.art_264.lit_a"],
+                rank=2,
+                rerank_score=0.71,
+                retrieval_score=0.71,
+                why_ranked=["salary_distractor"],
+            ),
+            _backfill_ranked_candidate(
+                expanded_units["ro.codul_muncii.art_41.alin_3"],
+                rank=3,
+                rerank_score=0.62,
+                retrieval_score=0.62,
+                why_ranked=["scope_available_in_backfill_pool"],
+            ),
+            _backfill_ranked_candidate(
+                expanded_units["ro.codul_muncii.art_41.alin_3.lit_e"],
+                rank=4,
+                rerank_score=0.54,
+                retrieval_score=0.54,
+                why_ranked=["salary_child_available_in_backfill_pool"],
+            ),
+        ]
+        return LegalRankerResult(
+            ranked_candidates=ranked_candidates,
+            warnings=[],
+            debug={
+                "fallback_used": False,
+                "ranked_candidate_count": len(ranked_candidates),
+                "ranked_candidates": [
+                    candidate.model_dump(mode="json") for candidate in ranked_candidates
+                ],
+            }
+            if debug
+            else None,
+        )
+
+
+class NoScopeBackfillLegalRanker:
+    def rank(
+        self,
+        *,
+        question,
+        plan,
+        retrieval_response,
+        graph_expansion,
+        query_frame=None,
+        debug=False,
+    ):
+        raw_units = {candidate.unit_id: candidate.unit for candidate in retrieval_response.candidates}
+        ranked_candidates = [
+            _backfill_ranked_candidate(
+                raw_units["ro.codul_muncii.art_41.alin_1"],
+                rank=1,
+                rerank_score=0.93,
+                retrieval_score=0.93,
+                why_ranked=["agreement_rule_seed"],
+            ),
+            _backfill_ranked_candidate(
+                raw_units["ro.codul_muncii.art_264.lit_a"],
+                rank=2,
+                rerank_score=0.71,
+                retrieval_score=0.71,
+                why_ranked=["salary_distractor"],
+            ),
+        ]
+        return LegalRankerResult(
+            ranked_candidates=ranked_candidates,
+            warnings=[],
+            debug={
+                "fallback_used": False,
+                "ranked_candidate_count": len(ranked_candidates),
+                "ranked_candidates": [
+                    candidate.model_dump(mode="json") for candidate in ranked_candidates
+                ],
+            }
+            if debug
+            else None,
+        )
 
 
 def _evidence_unit(
@@ -509,8 +928,8 @@ async def test_query_orchestrator_populates_evidence_units_with_fake_candidates(
     evidence = response.evidence_units[0]
     assert evidence.id == "ro.codul_muncii.art_41"
     assert evidence.law_title == "Codul muncii"
-    assert evidence.raw_text == "Contractul individual de munca poate fi modificat prin acordul partilor."
-    assert evidence.excerpt == "Contractul individual de munca poate fi modificat prin acordul partilor."
+    assert evidence.raw_text == "Contractul individual de muncă poate fi modificat prin acordul părților."
+    assert evidence.excerpt == "Contractul individual de muncă poate fi modificat prin acordul părților."
     assert evidence.retrieval_score == 0.78
     assert evidence.rerank_score is not None
     assert evidence.support_role in {"direct_basis", "condition"}
@@ -545,6 +964,82 @@ async def test_query_orchestrator_populates_evidence_units_with_fake_candidates(
     assert response.debug.verifier["claim_extraction"]["claims_total"] > 0
     assert response.debug.answer_repair["repair_action"] == "none"
     assert response.debug.answer_repair["removed_citation_ids"] == []
+
+
+def test_post_api_query_backfills_missing_salary_scope_before_generation():
+    orchestrator = QueryOrchestrator(
+        raw_retriever_client=RawRetrieverClient(
+            base_url=None,
+            internal_retriever_factory=lambda: AgreementOnlyRetriever(),
+        ),
+        graph_expansion_policy=BackfillExpandedGraphPolicy(),
+        legal_ranker=BackfillLegalRanker(),
+        evidence_pack_compiler=EvidencePackCompiler(
+            candidate_pool_size=1,
+            target_evidence_units=1,
+            max_evidence_units=3,
+        ),
+    )
+
+    response = post_query({**VALID_QUERY, "debug": True}, orchestrator=orchestrator)
+
+    assert response.status_code == 200
+    payload = response.json()
+    evidence_ids = {unit["id"] for unit in payload["evidence_units"]}
+    citation_ids = {citation["legal_unit_id"] for citation in payload["citations"]}
+    assert "ro.codul_muncii.art_41.alin_1" in evidence_ids
+    assert "ro.codul_muncii.art_41.alin_3" in evidence_ids
+    assert {
+        "ro.codul_muncii.art_41.alin_1",
+        "ro.codul_muncii.art_41.alin_3",
+    }.issubset(citation_ids)
+    assert "ro.codul_muncii.art_264.lit_a" not in citation_ids
+    assert "art. 264" not in payload["answer"]["short_answer"]
+    backfill = payload["debug"]["requirement_backfill"]
+    assert backfill["enabled"] is True
+    assert backfill["coverage_before"]["coverage_passed"] is False
+    assert backfill["coverage_before"]["missing_required_requirements"] == [
+        "contract_modification_salary_scope"
+    ]
+    assert "ro.codul_muncii.art_41.alin_3" in backfill["added_unit_ids"]
+    assert backfill["coverage_after"]["coverage_passed"] is True
+
+
+def test_post_api_query_keeps_refusal_when_backfill_has_no_real_scope_text():
+    orchestrator = QueryOrchestrator(
+        raw_retriever_client=RawRetrieverClient(
+            base_url=None,
+            internal_retriever_factory=lambda: AgreementOnlyRetriever(),
+        ),
+        graph_expansion_policy=MissingRawTextGraphPolicy(),
+        legal_ranker=NoScopeBackfillLegalRanker(),
+        evidence_pack_compiler=EvidencePackCompiler(
+            candidate_pool_size=1,
+            target_evidence_units=1,
+            max_evidence_units=3,
+        ),
+    )
+
+    response = post_query({**VALID_QUERY, "debug": True}, orchestrator=orchestrator)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["answer"]["refusal_reason"] in {
+        "insufficient_evidence",
+        "no_verifiable_legal_claims",
+    }
+    assert payload["citations"] == []
+    assert "ro.codul_muncii.art_41.alin_3" not in {
+        unit["id"] for unit in payload["evidence_units"]
+    }
+    backfill = payload["debug"]["requirement_backfill"]
+    assert backfill["enabled"] is True
+    assert backfill["coverage_after"]["coverage_passed"] is False
+    assert backfill["coverage_after"]["missing_required_requirements"] == [
+        "contract_modification_salary_scope"
+    ]
+    assert "requirement_backfill_unresolved:contract_modification_salary_scope" in payload["warnings"]
+    assert "requirement_backfill_unresolved:contract_modification_salary_scope" in backfill["warnings"]
 
 
 def test_generation_adapter_scores_focused_contract_modification_over_distractor():

--- a/tests/helpers/live_like_demo.py
+++ b/tests/helpers/live_like_demo.py
@@ -13,10 +13,10 @@ LIVE_LIKE_UNITS = [
         "paragraph_number": "1",
         "letter_number": None,
         "raw_text": (
-            "Contractul individual de munca se incheie in baza "
-            "consimtamantului partilor, in forma scrisa, in limba romana, "
-            "anterior inceperii activitatii. Obligatia de incheiere a "
-            "contractului individual de munca in forma scrisa revine "
+            "Contractul individual de muncă se încheie în baza "
+            "consimțământului părților, în forma scrisă, în limba română, "
+            "anterior începerii activității. Obligația de încheiere a "
+            "contractului individual de muncă în forma scrisă revine "
             "angajatorului."
         ),
     },
@@ -26,10 +26,10 @@ LIVE_LIKE_UNITS = [
         "paragraph_number": "2",
         "letter_number": None,
         "raw_text": (
-            "Modalitatea concreta de formare profesionala, drepturile si "
-            "obligatiile partilor, durata formarii profesionale, precum si "
-            "orice alte aspecte legate de formarea profesionala fac obiectul "
-            "unor acte aditionale la contractele individuale de munca."
+            "Modalitatea concretă de formare profesională, drepturile și "
+            "obligațiile părților, durata formării profesionale, precum și "
+            "orice alte aspecte legate de formarea profesională fac obiectul "
+            "unor acte adiționale la contractele individuale de muncă."
         ),
     },
     {
@@ -38,9 +38,9 @@ LIVE_LIKE_UNITS = [
         "paragraph_number": "1",
         "letter_number": None,
         "raw_text": (
-            "Locul muncii poate fi modificat unilateral de catre angajator "
-            "prin delegarea sau detasarea salariatului intr-un alt loc de "
-            "munca decat cel prevazut in contractul individual de munca."
+            "Locul muncii poate fi modificat unilateral de către angajator "
+            "prin delegarea sau detașarea salariatului într-un alt loc de "
+            "muncă decât cel prevăzut în contractul individual de muncă."
         ),
     },
     {
@@ -49,11 +49,11 @@ LIVE_LIKE_UNITS = [
         "paragraph_number": "3",
         "letter_number": None,
         "raw_text": (
-            "In situatia in care angajatorul constata ca salariatul sau a "
-            "provocat o paguba din vina si in legatura cu munca sa, va putea "
-            "solicita salariatului, printr-o nota de constatare si evaluare "
+            "În situația în care angajatorul constată că salariatul său a "
+            "provocat o pagubă din vina și în legătură cu munca sa, va putea "
+            "solicita salariatului, printr-o notă de constatare și evaluare "
             "a pagubei, recuperarea contravalorii acesteia, prin acordul "
-            "partilor."
+            "părților."
         ),
     },
     {
@@ -62,8 +62,8 @@ LIVE_LIKE_UNITS = [
         "paragraph_number": "1",
         "letter_number": None,
         "raw_text": (
-            "Contractul individual de munca poate fi modificat numai prin "
-            "acordul partilor."
+            "Contractul individual de muncă poate fi modificat numai prin "
+            "acordul părților."
         ),
     },
     {
@@ -72,10 +72,10 @@ LIVE_LIKE_UNITS = [
         "paragraph_number": "3",
         "letter_number": None,
         "raw_text": (
-            "Modificarea contractului individual de munca se refera la "
-            "oricare dintre urmatoarele elemente: durata contractului, locul "
-            "muncii, felul muncii, conditiile de munca, salariul, timpul de "
-            "munca si timpul de odihna."
+            "Modificarea contractului individual de muncă se referă la "
+            "oricare dintre următoarele elemente: durata contractului, locul "
+            "muncii, felul muncii, condițiile de muncă, salariul, timpul de "
+            "muncă și timpul de odihnă."
         ),
     },
     {
@@ -85,6 +85,45 @@ LIVE_LIKE_UNITS = [
         "letter_number": "e",
         "parent_id": "ro.codul_muncii.art_41.alin_3",
         "raw_text": "e) salariul;",
+    },
+    {
+        "id": "ro.codul_muncii.art_17.alin_3.lit_b",
+        "article_number": "17",
+        "paragraph_number": "3",
+        "letter_number": "b",
+        "parent_id": "ro.codul_muncii.art_17.alin_3",
+        "raw_text": (
+            "b) locul muncii sau, in lipsa unui loc de munca fix, "
+            "posibilitatea ca salariatul sa munceasca in diverse locuri;"
+        ),
+    },
+    {
+        "id": "ro.codul_muncii.art_35.alin_1",
+        "article_number": "35",
+        "paragraph_number": "1",
+        "letter_number": None,
+        "raw_text": (
+            "Orice salariat are dreptul de a munci la angajatori diferiti "
+            "sau la acelasi angajator, in baza unor contracte individuale de munca."
+        ),
+    },
+    {
+        "id": "ro.codul_muncii.art_166",
+        "article_number": "166",
+        "paragraph_number": None,
+        "letter_number": None,
+        "raw_text": "Salariul se plateste in bani cel putin o data pe luna.",
+    },
+    {
+        "id": "ro.codul_muncii.art_260.alin_1.lit_a",
+        "article_number": "260",
+        "paragraph_number": "1",
+        "letter_number": "a",
+        "parent_id": "ro.codul_muncii.art_260.alin_1",
+        "raw_text": (
+            "a) primirea la munca a uneia sau a mai multor persoane fara "
+            "incheierea unui contract individual de munca constituie contraventie."
+        ),
     },
 ]
 

--- a/tests/ingestion/test_codul_muncii_demo_path.py
+++ b/tests/ingestion/test_codul_muncii_demo_path.py
@@ -286,7 +286,8 @@ def test_evidence_pack_compiler_consumes_codul_muncii_fixture_units():
     evidence_by_id = {unit.id: unit for unit in result.evidence_units}
     assert "ro.codul_muncii.art_41.alin_4" in evidence_by_id
     assert "ro.codul_muncii.art_41" in evidence_by_id
-    assert "ro.codul_muncii.art_17.alin_3.lit_k" in evidence_by_id
+    if "ro.codul_muncii.art_17.alin_3.lit_k" in evidence_by_id:
+        assert evidence_by_id["ro.codul_muncii.art_17.alin_3.lit_k"].support_role != "direct_basis"
     assert (
         evidence_by_id["ro.codul_muncii.art_41.alin_4"].raw_text
         == units["ro.codul_muncii.art_41.alin_4"]["raw_text"]

--- a/tests/test_live_demo_regression.py
+++ b/tests/test_live_demo_regression.py
@@ -17,9 +17,13 @@ from tests.helpers.live_like_demo import (
 
 FORBIDDEN_LIVE_LIKE_DISTRACTORS = {
     "ro.codul_muncii.art_16.alin_1",
+    "ro.codul_muncii.art_17.alin_3.lit_b",
+    "ro.codul_muncii.art_35.alin_1",
+    "ro.codul_muncii.art_166",
     "ro.codul_muncii.art_196.alin_2",
     "ro.codul_muncii.art_42.alin_1",
     "ro.codul_muncii.art_254.alin_3",
+    "ro.codul_muncii.art_260.alin_1.lit_a",
 }
 
 REQUIRED_ART_41_UNITS = {
@@ -62,15 +66,25 @@ def test_candidate_role_classifier_live_like_demo_roles():
     assert "requirement_match:contract_modification_agreement_rule" in agreement.why_role
 
     salary_scope = decisions["ro.codul_muncii.art_41.alin_3"]
-    assert salary_scope.support_role == "direct_basis"
+    assert salary_scope.support_role in {"condition", "direct_basis"}
     assert "contract_modification_salary_scope" in salary_scope.matched_requirement_ids
+    assert "salary_target_element" not in salary_scope.matched_requirement_ids
+    assert "requirement_match:contract_modification_salary_scope" in salary_scope.why_role
 
     salary_target = decisions["ro.codul_muncii.art_41.alin_3.lit_e"]
     assert salary_target.support_role == "condition"
     assert "salary_target_element" in salary_target.matched_requirement_ids
+    assert "contract_modification_salary_scope" not in salary_target.matched_requirement_ids
 
     assert decisions["ro.codul_muncii.art_196.alin_2"].support_role == "context"
     assert decisions["ro.codul_muncii.art_16.alin_1"].support_role == "context"
+    assert decisions["ro.codul_muncii.art_17.alin_3.lit_b"].support_role == "context"
+    assert decisions["ro.codul_muncii.art_35.alin_1"].support_role == "context"
+    assert decisions["ro.codul_muncii.art_166"].support_role == "context"
+    assert decisions["ro.codul_muncii.art_260.alin_1.lit_a"].support_role in {
+        "sanction",
+        "context",
+    }
     assert decisions["ro.codul_muncii.art_42.alin_1"].support_role in {
         "exception",
         "context",
@@ -78,6 +92,30 @@ def test_candidate_role_classifier_live_like_demo_roles():
     assert decisions["ro.codul_muncii.art_254.alin_3"].support_role == "context"
     for unit_id in FORBIDDEN_LIVE_LIKE_DISTRACTORS:
         assert decisions[unit_id].support_role != "direct_basis"
+
+
+def test_candidate_role_classifier_matches_salary_scope_without_unit_id_heuristics():
+    _, query_frame = _demo_plan_and_frame()
+    decision = CandidateRoleClassifier().classify(
+        query_frame=query_frame,
+        unit_id="fixture.any_contract_scope_unit",
+        unit={
+            "id": "fixture.any_contract_scope_unit",
+            "raw_text": (
+                "Modificarea contractului individual de munca poate privi "
+                "durata contractului, locul muncii, felul muncii si salariul."
+            ),
+            "normalized_text": (
+                "modificarea contractului individual de munca poate privi "
+                "durata contractului locul muncii felul muncii salariul"
+            ),
+        },
+    )
+
+    assert decision.support_role in {"condition", "direct_basis"}
+    assert "contract_modification_salary_scope" in decision.matched_requirement_ids
+    assert "requirement_match:contract_modification_salary_scope" in decision.why_role
+    assert "salary_target_element" not in decision.matched_requirement_ids
 
 
 def test_evidence_pack_live_like_uses_requirements_for_support_roles():
@@ -107,8 +145,20 @@ def test_evidence_pack_live_like_uses_requirements_for_support_roles():
 
     evidence_by_id = {unit.id: unit for unit in compiled.evidence_units}
     assert REQUIRED_ART_41_UNITS.issubset(evidence_by_id)
+    assert len(compiled.evidence_units) <= 8
     assert evidence_by_id["ro.codul_muncii.art_41.alin_1"].support_role == "direct_basis"
-    assert evidence_by_id["ro.codul_muncii.art_41.alin_3"].support_role == "direct_basis"
+    assert evidence_by_id["ro.codul_muncii.art_41.alin_3"].support_role in {
+        "condition",
+        "direct_basis",
+    }
+    for forbidden_direct_basis_id in {
+        "ro.codul_muncii.art_17.alin_3.lit_b",
+        "ro.codul_muncii.art_35.alin_1",
+        "ro.codul_muncii.art_166",
+        "ro.codul_muncii.art_260.alin_1.lit_a",
+    }:
+        if forbidden_direct_basis_id in evidence_by_id:
+            assert evidence_by_id[forbidden_direct_basis_id].support_role != "direct_basis"
 
     direct_basis_ids = {
         unit.id for unit in compiled.evidence_units if unit.support_role == "direct_basis"
@@ -121,7 +171,117 @@ def test_evidence_pack_live_like_uses_requirements_for_support_roles():
     for unit_id in REQUIRED_ART_41_UNITS:
         why_selected = evidence_by_id[unit_id].why_selected
         assert any(reason.startswith("requirement_match:") for reason in why_selected)
-        assert "role_classifier:direct_basis" in why_selected
+    assert "role_classifier:direct_basis" in evidence_by_id[
+        "ro.codul_muncii.art_41.alin_1"
+    ].why_selected
+    debug_by_id = {
+        unit["unit_id"]: unit for unit in compiled.debug["selected_units"]
+    }
+    assert "contract_modification_agreement_rule" in debug_by_id[
+        "ro.codul_muncii.art_41.alin_1"
+    ]["matched_requirement_ids"]
+    assert "contract_modification_salary_scope" in debug_by_id[
+        "ro.codul_muncii.art_41.alin_3"
+    ]["matched_requirement_ids"]
+
+
+def test_evidence_pack_covers_salary_scope_with_parent_and_salary_child():
+    plan, query_frame = _demo_plan_and_frame()
+    candidates = live_like_retrieval_candidates()
+    for candidate in candidates:
+        if candidate.unit_id == "ro.codul_muncii.art_41.alin_3":
+            candidate.unit["raw_text"] = (
+                "Modificarea contractului individual de munca se refera la "
+                "oricare dintre urmatoarele elemente:"
+            )
+            candidate.unit["normalized_text"] = candidate.unit["raw_text"].casefold()
+            candidate.score_breakdown["intent_governing_rule_parent"] = 1.0
+            candidate.why_retrieved = (
+                "intent_governing_rule_parent_context:labor_contract_modification"
+            )
+
+    ranked = LegalRanker().rank(
+        question=LIVE_LIKE_DEMO_QUERY,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=candidates),
+        graph_expansion=GraphExpansionResult(),
+        query_frame=query_frame,
+        debug=True,
+    )
+    compiled = EvidencePackCompiler(
+        target_evidence_units=7,
+        max_evidence_units=7,
+    ).compile(
+        ranked_candidates=ranked.ranked_candidates,
+        graph_expansion=GraphExpansionResult(),
+        plan=plan,
+        query_frame=query_frame,
+        debug=True,
+    )
+
+    evidence_by_id = {unit.id: unit for unit in compiled.evidence_units}
+    assert "ro.codul_muncii.art_41.alin_1" in evidence_by_id
+    assert "ro.codul_muncii.art_41.alin_3" in evidence_by_id
+    assert "ro.codul_muncii.art_41.alin_3.lit_e" in evidence_by_id
+    assert evidence_by_id["ro.codul_muncii.art_41.alin_3"].support_role in {
+        "condition",
+        "direct_basis",
+    }
+    assert (
+        "requirement_match:contract_modification_salary_scope"
+        in evidence_by_id["ro.codul_muncii.art_41.alin_3"].why_selected
+    )
+    coverage = compiled.debug["requirement_coverage"]
+    assert coverage["intent_id"] == "labor_contract_modification"
+    assert coverage["required_requirements_total"] == 2
+    assert coverage["required_requirements_covered"] == 2
+    assert coverage["coverage_passed"] is True
+    assert {
+        "contract_modification_agreement_rule",
+        "contract_modification_salary_scope",
+    }.issubset(set(coverage["covered_requirement_ids"]))
+    assert coverage["missing_required_requirements"] == []
+
+
+def test_evidence_pack_reports_missing_required_salary_scope():
+    plan, query_frame = _demo_plan_and_frame()
+    candidates = [
+        candidate
+        for candidate in live_like_retrieval_candidates()
+        if candidate.unit_id
+        not in {
+            "ro.codul_muncii.art_41.alin_3",
+            "ro.codul_muncii.art_41.alin_3.lit_e",
+        }
+    ]
+
+    ranked = LegalRanker().rank(
+        question=LIVE_LIKE_DEMO_QUERY,
+        plan=plan,
+        retrieval_response=RawRetrievalResponse(candidates=candidates),
+        graph_expansion=GraphExpansionResult(),
+        query_frame=query_frame,
+        debug=True,
+    )
+    compiled = EvidencePackCompiler(
+        target_evidence_units=7,
+        max_evidence_units=7,
+    ).compile(
+        ranked_candidates=ranked.ranked_candidates,
+        graph_expansion=GraphExpansionResult(),
+        plan=plan,
+        query_frame=query_frame,
+        debug=True,
+    )
+
+    coverage = compiled.debug["requirement_coverage"]
+    assert coverage["intent_id"] == "labor_contract_modification"
+    assert coverage["required_requirements_total"] == 2
+    assert coverage["required_requirements_covered"] == 1
+    assert coverage["coverage_passed"] is False
+    assert coverage["missing_required_requirements"] == [
+        "contract_modification_salary_scope"
+    ]
 
 
 @pytest.mark.anyio
@@ -152,12 +312,37 @@ async def test_live_like_demo_flow_cites_art_41_not_topical_distractors():
 
     citation_unit_ids = {citation.legal_unit_id for citation in response.citations}
     assert REQUIRED_ART_41_UNITS.issubset(citation_unit_ids)
+    assert all(citation.verified for citation in response.citations)
+    assert len(response.evidence_units) <= 8
     assert all(unit_id.startswith("ro.codul_muncii.art_41") for unit_id in citation_unit_ids)
     assert not citation_unit_ids.intersection(FORBIDDEN_LIVE_LIKE_DISTRACTORS)
+    evidence_by_id = {unit.id: unit for unit in response.evidence_units}
+    for forbidden_direct_basis_id in {
+        "ro.codul_muncii.art_17.alin_3.lit_b",
+        "ro.codul_muncii.art_35.alin_1",
+        "ro.codul_muncii.art_166",
+        "ro.codul_muncii.art_260.alin_1.lit_a",
+    }:
+        if forbidden_direct_basis_id in evidence_by_id:
+            assert evidence_by_id[forbidden_direct_basis_id].support_role != "direct_basis"
     assert (
         response.debug.generation["generation_mode"]
         == "deterministic_template_v1_labor_contract_modification"
     )
+    coverage = response.debug.evidence_pack["requirement_coverage"]
+    assert coverage["intent_id"] == "labor_contract_modification"
+    assert coverage["required_requirements_total"] == 2
+    assert coverage["required_requirements_covered"] == 2
+    assert {
+        "contract_modification_agreement_rule",
+        "contract_modification_salary_scope",
+    }.issubset(set(coverage["covered_requirement_ids"]))
+    assert coverage["missing_required_requirements"] == []
+    assert coverage["coverage_passed"] is True
+    assert response.graph.edges
+    assert response.verifier.claims_total > 0
+    assert response.verifier.verifier_passed is True
+    assert response.debug.answer_repair["repair_action"] == "none"
     answer = response.answer.short_answer.casefold()
     assert "art. 41" in answer
     assert "art. 196" not in answer

--- a/tests/test_query_orchestrator.py
+++ b/tests/test_query_orchestrator.py
@@ -95,7 +95,8 @@ async def test_query_orchestrator_generates_grounded_draft_with_debug():
     assert "art. 264" not in response.answer.short_answer
     assert all("art_264" not in citation_id for citation_id in citation_ids)
     normalized_answer = response.answer.short_answer.casefold()
-    assert "acordul partilor" in normalized_answer
+    assert "părților" in normalized_answer
+    assert "partilor" not in normalized_answer
     assert "remuneratie restanta" not in normalized_answer
     assert "persoane angajate ilegal" not in normalized_answer
     for citation in response.citations:
@@ -205,7 +206,10 @@ async def test_query_orchestrator_live_like_demo_uses_art_41_not_topical_distrac
 
     evidence_by_id = {unit.id: unit for unit in response.evidence_units}
     assert evidence_by_id["ro.codul_muncii.art_41.alin_1"].support_role == "direct_basis"
-    assert evidence_by_id["ro.codul_muncii.art_41.alin_3"].support_role == "direct_basis"
+    assert evidence_by_id["ro.codul_muncii.art_41.alin_3"].support_role in {
+        "condition",
+        "direct_basis",
+    }
     for unit_id in {
         "ro.codul_muncii.art_16.alin_1",
         "ro.codul_muncii.art_196.alin_2",


### PR DESCRIPTION
This pull request focuses on improving the accuracy and coverage of test cases related to the classification and selection of legal evidence units, especially around labor contract modification scenarios. The main themes are: improved Romanian text normalization, refined test assertions for evidence roles, expanded test coverage for requirement satisfaction, and the addition of new legal units and distractors to test fixtures.

**Test data and normalization improvements:**

* Updated Romanian legal text samples in `live_like_demo.py` to use correct diacritics and more accurate language, improving the realism and reliability of test fixtures. [[1]](diffhunk://#diff-817121fdaa45fffa1abdd3ff1facc2c8cb9c68a48f6e02cb4e91b0105f787812L16-R19) [[2]](diffhunk://#diff-817121fdaa45fffa1abdd3ff1facc2c8cb9c68a48f6e02cb4e91b0105f787812L29-R32) [[3]](diffhunk://#diff-817121fdaa45fffa1abdd3ff1facc2c8cb9c68a48f6e02cb4e91b0105f787812L41-R43) [[4]](diffhunk://#diff-817121fdaa45fffa1abdd3ff1facc2c8cb9c68a48f6e02cb4e91b0105f787812L52-R56) [[5]](diffhunk://#diff-817121fdaa45fffa1abdd3ff1facc2c8cb9c68a48f6e02cb4e91b0105f787812L65-R66) [[6]](diffhunk://#diff-817121fdaa45fffa1abdd3ff1facc2c8cb9c68a48f6e02cb4e91b0105f787812L75-R78) [[7]](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330L98-R99)
* Added new legal units to `live_like_demo.py` for broader coverage, including articles about workplace, salary, and contract requirements.

**Evidence unit and role classification logic:**

* Refined test assertions to accept both "condition" and "direct_basis" as valid support roles for certain evidence units, reflecting updated logic in the role classifier. [[1]](diffhunk://#diff-17f9749bc4fd7e3400a60be6f7f778817c20cb45b1e5a540d8810b4960a9e92cL65-R87) [[2]](diffhunk://#diff-17f9749bc4fd7e3400a60be6f7f778817c20cb45b1e5a540d8810b4960a9e92cR148-R161) [[3]](diffhunk://#diff-17f9749bc4fd7e3400a60be6f7f778817c20cb45b1e5a540d8810b4960a9e92cL124-R284) [[4]](diffhunk://#diff-21026857c2291975357cc0f4a739e7d8ddc4f41800e0bea944720afabc076330L208-R212)
* Strengthened checks to ensure that certain distractor units (recently added) are not incorrectly classified as "direct_basis" in evidence packs. [[1]](diffhunk://#diff-17f9749bc4fd7e3400a60be6f7f778817c20cb45b1e5a540d8810b4960a9e92cR20-R26) [[2]](diffhunk://#diff-17f9749bc4fd7e3400a60be6f7f778817c20cb45b1e5a540d8810b4960a9e92cR148-R161) [[3]](diffhunk://#diff-17f9749bc4fd7e3400a60be6f7f778817c20cb45b1e5a540d8810b4960a9e92cR315-R345)
* Added explicit tests to verify that the evidence pack compiler covers all required requirements and correctly reports missing requirements when necessary.

**Test coverage and regression checks:**

* Expanded regression tests to verify that evidence packs and citations include only the correct legal units, that all citations are verified, and that distractors are excluded.
* Added new tests to confirm that the role classifier and evidence pack compiler behave correctly even when unit ID heuristics are not available.
* Updated test assertions to check for the presence of specific requirement matches and debug information in evidence selection.

**Other minor improvements:**

* Adjusted an assertion in `test_codul_muncii_demo_path.py` to avoid a hard failure if a unit is missing, and to check the support role if present.

These changes collectively strengthen the reliability and precision of the legal evidence selection and classification system, especially in the context of labor contract modification queries.