### PR TITLE
Railway Deployment #fd2e17 fix: add repair_romanian_mojibake

### DIFF
--- a/ingestion/normalizer.py
+++ b/ingestion/normalizer.py
@@ -3,6 +3,36 @@ from __future__ import annotations
 import re
 import unicodedata
 
+# Common Romanian mojibake mappings (UTF-8 bytes misread as Windows-1252/Latin-1)
+_ROMANIAN_MOJIBAKE_MAP: dict[str, str] = {
+    "Ä\u0083": "ă",
+    "Ã¢": "â",
+    "Ã®": "î",
+    "È™": "ș",
+    "È›": "ț",
+    "Ä‚": "Ă",
+    "Ã‚": "Â",
+    "ÃŽ": "Î",
+    "È˜": "Ș",
+    "Èš": "Ț",
+    "Å£": "ț",
+    "Å¢": "Ț",
+    "ÅŸ": "ș",
+    "Åž": "Ș",
+    "ãƒ": "ă",
+    "Äƒ": "ă",
+}
+
+_MOJIBAKE_RE = re.compile("|".join(re.escape(k) for k in sorted(_ROMANIAN_MOJIBAKE_MAP, key=len, reverse=True)))
+
+
+def repair_romanian_mojibake(text: str | None) -> str | None:
+    """Replace common Romanian mojibake sequences with correct diacritics."""
+    if text is None:
+        return None
+    repaired = _MOJIBAKE_RE.sub(lambda m: _ROMANIAN_MOJIBAKE_MAP[m.group()], text)
+    return unicodedata.normalize("NFC", repaired) or None
+
 
 def normalize_legal_text(raw_text: str | None) -> str | None:
     """Derive retrieval-friendly text without replacing the source raw_text."""


### PR DESCRIPTION
## Problem

The app crashes on startup with `ImportError: cannot import name 'repair_romanian_mojibake' from 'ingestion.normalizer'`. The function is imported in `apps/api/app/services/raw_retriever.py` but was never defined in `ingestion/normalizer.py`, causing the HEALTHCHECK to fail on every deploy.

## Solution

Added `repair_romanian_mojibake` to `ingestion/normalizer.py` along with a mojibake mapping table and compiled regex for common Romanian diacritics corruption patterns (UTF-8 bytes misread as Windows-1252/Latin-1). This satisfies the import and allows the app to start successfully.

### Changes
- **Modified** `ingestion/normalizer.py`

### Context
- **Deployment**: [#fd2e17](https://railway.com/project/a50703a8-f940-4c96-825d-c50da7d73dd4/environment/8f9e9869-e248-4fac-b0b3-1f8763752ef7/deployment/fd2e17a7-f20f-445c-9568-a4cc7896084f)
- **Failed commit**: `dacfb21`

---
*Generated by [Railway](https://railway.com)*